### PR TITLE
🧹 Move httpx import to top of src/wet_mcp/sources/crawler.py

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from pathlib import Path
 
+import httpx
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 from loguru import logger
 
@@ -296,7 +297,6 @@ async def download_media(
     Returns:
         JSON string with download results
     """
-    import httpx
 
     logger.info(f"Downloading {len(media_urls)} media files")
 


### PR DESCRIPTION
Refactored `src/wet_mcp/sources/crawler.py` to move `import httpx` from inside `download_media` to the top level.

🎯 **What:** Moved `import httpx` from inside the `download_media` function to the top-level imports in `src/wet_mcp/sources/crawler.py`.
💡 **Why:** This improves code readability and follows standard Python conventions by grouping imports at the top of the file. It also makes dependencies more explicit.
✅ **Verification:** Verified the changes by running `pytest tests/test_security_path_traversal.py` to ensure functionality remains correct, and `ruff check src/wet_mcp/sources/crawler.py` to ensure code quality.
✨ **Result:** The code is cleaner and maintains full functionality. Note: environment configuration files (`pyproject.toml`, `.python-version`) were temporarily modified for local testing but have been reverted to their original state.

---
*PR created automatically by Jules for task [11565031212334133101](https://jules.google.com/task/11565031212334133101) started by @n24q02m*