### PR TITLE
🧹 [code health] Use importlib.util.find_spec in setup.py

### DIFF
--- a/src/wet_mcp/setup.py
+++ b/src/wet_mcp/setup.py
@@ -8,6 +8,7 @@ This module handles automatic first-run setup:
 Setup runs automatically on first server start.
 """
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -26,8 +27,6 @@ _SEARXNG_INSTALL_URL = (
 def _find_searx_package_dir() -> Path | None:
     """Find SearXNG package directory via importlib."""
     try:
-        import importlib.util
-
         spec = importlib.util.find_spec("searx")
         if spec and spec.submodule_search_locations:
             return Path(spec.submodule_search_locations[0])
@@ -129,13 +128,9 @@ def _install_searxng() -> bool:
     Returns:
         True if installation succeeded or already installed.
     """
-    try:
-        import searx  # noqa: F401
-
+    if importlib.util.find_spec("searx"):
         logger.debug("SearXNG already installed")
         return True
-    except ImportError:
-        pass
 
     logger.info("Installing SearXNG from GitHub...")
     try:


### PR DESCRIPTION
Replaced `import searx` (protected by `noqa: F401`) with `importlib.util.find_spec("searx")` to check for package installation without importing it. This is cleaner and avoids potential side effects of importing the package.
Also cleaned up `_find_searx_package_dir` to remove redundant local import.

Test plan:
- Verified linting with `uv run ruff check src/wet_mcp/setup.py`.
- Verified no regressions with `uv run pytest`.

---
*PR created automatically by Jules for task [693517235037298349](https://jules.google.com/task/693517235037298349) started by @n24q02m*