### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in media tools

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
 
     # Media
     download_dir: str = "~/.wet-mcp/downloads"
+    allowed_dirs: list[str] = []
 
     # Media Analysis (LiteLLM)
     api_keys: str | None = None  # provider:key,provider:key

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -24,6 +24,7 @@ from litellm import acompletion  # noqa: E402
 from loguru import logger  # noqa: E402
 
 from wet_mcp.config import settings  # noqa: E402
+from wet_mcp.security import is_safe_path  # noqa: E402
 
 
 def get_llm_config() -> dict:
@@ -73,6 +74,11 @@ async def analyze_media(
     """Analyze media file using configured LLM with auto-capability detection."""
     if not settings.api_keys:
         return "Error: LLM analysis requires API_KEYS to be configured."
+
+    # Validate path security
+    allowed_dirs = [settings.download_dir] + settings.allowed_dirs
+    if not is_safe_path(media_path, allowed_dirs):
+        return f"Error: Access denied to path {media_path}"
 
     path_obj = Path(media_path)
     if not path_obj.exists():

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -2,11 +2,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from wet_mcp.config import settings
 from wet_mcp.sources.crawler import download_media
 
 
+@pytest.fixture
+def allow_tmp_path(tmp_path):
+    original = settings.allowed_dirs
+    settings.allowed_dirs = [str(tmp_path)]
+    yield
+    settings.allowed_dirs = original
+
+
 @pytest.mark.asyncio
-async def test_download_media_path_traversal(tmp_path):
+async def test_download_media_path_traversal(tmp_path, allow_tmp_path):
     """Test that download_media prevents path traversal."""
 
     # Mock httpx response
@@ -50,7 +59,7 @@ async def test_download_media_path_traversal(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_download_media_safe(tmp_path):
+async def test_download_media_safe(tmp_path, allow_tmp_path):
     mock_response = MagicMock()
     mock_response.content = b"safe content"
     mock_response.raise_for_status = MagicMock()


### PR DESCRIPTION
This PR addresses a critical Path Traversal vulnerability in the `download_media` and `analyze_media` tools.

**Vulnerability:**
- `download_media` allowed writing files to arbitrary locations by specifying a malicious `output_dir` or if the server returned a filename with `..` components.
- `analyze_media` allowed reading arbitrary files by specifying a path outside the intended directory.
- `download_media` also lacked SSRF protection (missing `is_safe_url` check).

**Fix:**
- Implemented `is_safe_path` in `src/wet_mcp/security.py` which resolves paths and checks if they are within `settings.download_dir` or explicitly `allowed_dirs`.
- Applied `is_safe_path` validation in `src/wet_mcp/llm.py` (`analyze_media`) and `src/wet_mcp/sources/crawler.py` (`download_media`).
- Added `is_safe_url` validation to `download_media`.
- Updated tests to properly configure `allowed_dirs` when using temporary test directories.

**Verification:**
- Verified with reproduction script `verify_vuln.py` (deleted before submission) which confirmed the exploit was blocked.
- Ran full test suite (`uv run pytest`) to ensure no regressions. All tests passed.


---
*PR created automatically by Jules for task [17308190961238965599](https://jules.google.com/task/17308190961238965599) started by @n24q02m*