### PR TITLE
🛡️ Sentinel: Fix path traversal in analyze_media

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -24,6 +24,7 @@ from litellm import acompletion  # noqa: E402
 from loguru import logger  # noqa: E402
 
 from wet_mcp.config import settings  # noqa: E402
+from wet_mcp.security import is_safe_path  # noqa: E402
 
 
 def get_llm_config() -> dict:
@@ -67,6 +68,10 @@ async def analyze_media(
     """Analyze media file using configured LLM with auto-capability detection."""
     if not settings.api_keys:
         return "Error: LLM analysis requires API_KEYS to be configured."
+
+    # Security check: Ensure path is within allowed directories
+    if not is_safe_path(media_path, [settings.download_dir]):
+        return f"Error: Access denied. Path '{media_path}' is not within allowed directories."
 
     path_obj = Path(media_path)
     if not path_obj.exists():

--- a/src/wet_mcp/security.py
+++ b/src/wet_mcp/security.py
@@ -1,8 +1,27 @@
 import ipaddress
 import socket
+from pathlib import Path
 from urllib.parse import urlparse
 
 from loguru import logger
+
+
+def is_safe_path(path: str | Path, allowed_dirs: list[str | Path]) -> bool:
+    """
+    Check if a path is within allowed directories.
+    Prevents path traversal.
+    """
+    try:
+        path = Path(path).resolve()
+        for allowed in allowed_dirs:
+            allowed = Path(allowed).resolve()
+            # If path starts with allowed, it's safe (is_relative_to handles this)
+            if path.is_relative_to(allowed):
+                return True
+        return False
+    except Exception as e:
+        logger.error(f"Error validating path {path}: {e}")
+        return False
 
 
 def is_safe_url(url: str) -> bool:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -45,6 +45,9 @@ def test_get_llm_config_with_temperature(mock_settings):
 @patch("wet_mcp.llm.acompletion")
 def test_analyze_media(mock_completion, mock_settings, tmp_path):
     """Test analyze_media function using real temp file."""
+    # Set download_dir to tmp_path for security check
+    settings.download_dir = str(tmp_path)
+
     # Create valid dummy image file
     img_path = tmp_path / "test.jpg"
     img_path.write_bytes(b"fake-image-data")
@@ -89,15 +92,19 @@ def test_analyze_media_no_keys():
     assert "Error: LLM analysis requires API_KEYS" in result
 
 
-def test_analyze_media_file_not_found(mock_settings):
+def test_analyze_media_file_not_found(mock_settings, tmp_path):
     """Test file not found error."""
-    result = asyncio.run(analyze_media("non_existent_file.jpg"))
+    settings.download_dir = str(tmp_path)
+    result = asyncio.run(analyze_media(str(tmp_path / "non_existent_file.jpg")))
     assert "Error: File not found" in result
 
 
 @patch("wet_mcp.llm.acompletion")
 def test_analyze_media_text_file(mock_completion, mock_settings, tmp_path):
     """Test text file analysis."""
+    # Set download_dir to tmp_path for security check
+    settings.download_dir = str(tmp_path)
+
     txt_path = tmp_path / "test.txt"
     txt_path.write_text("Hello")
 
@@ -117,6 +124,9 @@ def test_analyze_media_text_file(mock_completion, mock_settings, tmp_path):
 
 def test_analyze_media_unsupported_type(mock_settings, tmp_path):
     """Test unsupported file type."""
+    # Set download_dir to tmp_path for security check
+    settings.download_dir = str(tmp_path)
+
     bin_path = tmp_path / "test.bin"
     bin_path.write_bytes(b"\x00\x01")  # unknown binary
 

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal in analyze_media

🚨 Severity: HIGH
💡 Vulnerability: The `analyze_media` tool allowed reading any file on the filesystem via absolute paths or traversal sequences, as it did not validate that the target file was within the allowed download directory.
🎯 Impact: An attacker could potentially read sensitive files (e.g., `/etc/passwd`, ssh keys) by tricking the LLM into analyzing them.
🔧 Fix: Implemented `is_safe_path` in `wet_mcp.security` and applied it in `analyze_media` to enforce that files must be within `settings.download_dir`.
✅ Verification: Verified with a reproduction script `tests/repro_path_traversal.py` which confirmed the vulnerability was blocked. Updated `tests/test_llm.py` to pass with the new restriction.

---
*PR created automatically by Jules for task [9348027600094483320](https://jules.google.com/task/9348027600094483320) started by @n24q02m*