### PR TITLE
test(config): add tests for setup_api_keys edge cases and fix crash

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -52,6 +52,9 @@ class Settings(BaseSettings):
 
             env_var, key = pair.split(":", 1)
             env_var = env_var.strip()
+
+            if not env_var:
+                continue
             key = key.strip()
 
             if not key:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,3 +70,23 @@ def test_setup_api_keys_whitespace():
         assert keys == {"ENV": ["key1"], "OTHER": ["key2"]}
         assert os.environ["ENV"] == "key1"
         assert os.environ["OTHER"] == "key2"
+
+
+def test_setup_api_keys_colon_in_value():
+    """Test setup_api_keys where the key value contains colons."""
+    settings = Settings(api_keys="CONNECTION_STRING:driver:postgres:db,OTHER:val")
+    with mock.patch.dict(os.environ, {}, clear=True):
+        keys = settings.setup_api_keys()
+        assert keys == {"CONNECTION_STRING": ["driver:postgres:db"], "OTHER": ["val"]}
+        assert os.environ["CONNECTION_STRING"] == "driver:postgres:db"
+
+
+def test_setup_api_keys_empty_env_var_name():
+    """Test setup_api_keys with empty environment variable name."""
+    settings = Settings(api_keys=":key,VALID:val")
+    with mock.patch.dict(os.environ, {}, clear=True):
+        keys = settings.setup_api_keys()
+        assert keys == {"VALID": ["val"]}
+        assert "VALID" in os.environ
+        # Ensure no empty key was set
+        assert "" not in os.environ

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
- Added `test_setup_api_keys_colon_in_value` to verify that API keys containing colons (e.g., connection strings) are parsed correctly.
- Added `test_setup_api_keys_empty_env_var_name` to verify that entries with empty environment variable names (e.g., `:key`) are ignored.
- Fixed a bug in `src/wet_mcp/config.py` where an empty environment variable name would cause an `OSError` when attempting to set `os.environ[""]`.


---
*PR created automatically by Jules for task [10633961500221474877](https://jules.google.com/task/10633961500221474877) started by @n24q02m*