### PR TITLE
🧹 Refactor encode_image to be async using asyncio.to_thread

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -55,10 +55,14 @@ def get_model_capabilities(model: str) -> dict:
     }
 
 
-def encode_image(image_path: str) -> str:
+async def encode_image(image_path: str) -> str:
     """Encode image to base64."""
-    with open(image_path, "rb") as image_file:
-        return base64.b64encode(image_file.read()).decode("utf-8")
+
+    def _encode_sync(path: str) -> str:
+        with open(path, "rb") as image_file:
+            return base64.b64encode(image_file.read()).decode("utf-8")
+
+    return await asyncio.to_thread(_encode_sync, image_path)
 
 
 async def analyze_media(
@@ -135,7 +139,7 @@ async def analyze_media(
         config = get_llm_config()
         logger.info(f"Analyzing media with model: {config['model']}")
 
-        base64_image = await asyncio.to_thread(encode_image, media_path)
+        base64_image = await encode_image(media_path)
         data_url = f"data:{mime_type};base64,{base64_image}"
 
         messages = [

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from wet_mcp.config import settings
-from wet_mcp.llm import analyze_media, get_llm_config
+from wet_mcp.llm import analyze_media, encode_image, get_llm_config
 
 
 @pytest.fixture
@@ -125,3 +125,14 @@ def test_analyze_media_unsupported_type(mock_settings, tmp_path):
         "Error: Cannot determine file type" in result
         or "Unsupported media type" in result
     )
+
+
+@pytest.mark.asyncio
+async def test_encode_image(tmp_path):
+    """Test async encode_image."""
+    img_path = tmp_path / "test_encode.jpg"
+    img_path.write_bytes(b"test-data")
+
+    result = await encode_image(str(img_path))
+    # base64("test-data") -> "dGVzdC1kYXRh"
+    assert result == "dGVzdC1kYXRh"

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
Refactors `encode_image` in `src/wet_mcp/llm.py` to be an `async` function that wraps the blocking file I/O and base64 encoding in `asyncio.to_thread`. This prevents blocking the event loop in the async MCP server.
Updates `analyze_media` to await the new `encode_image` function directly.
Adds a new test case `test_encode_image` in `tests/test_llm.py` to verify the async functionality of `encode_image`.

🎯 **What:** The code health issue addressed
Refactored `encode_image` to avoid blocking I/O in the async codebase.

💡 **Why:** How this improves maintainability
Ensures that the application remains responsive and follows best practices for async I/O in Python.

✅ **Verification:** How you confirmed the change is safe
Ran `uv run pytest tests/test_llm.py` and verified all tests passed, including the new test case.

✨ **Result:** The improvement achieved
`encode_image` is now async-safe and explicitly awaitable.

---
*PR created automatically by Jules for task [12107896552421490030](https://jules.google.com/task/12107896552421490030) started by @n24q02m*