### PR TITLE
🔒 Fix Arbitrary File Read in Media Analysis

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -24,6 +24,7 @@ from litellm import acompletion  # noqa: E402
 from loguru import logger  # noqa: E402
 
 from wet_mcp.config import settings  # noqa: E402
+from wet_mcp.security import is_safe_path  # noqa: E402
 
 
 def get_llm_config() -> dict:
@@ -69,6 +70,12 @@ async def analyze_media(
         return "Error: LLM analysis requires API_KEYS to be configured."
 
     path_obj = Path(media_path)
+
+    # Security check: Ensure file is in allowed directory
+    allowed_dirs = [Path(settings.download_dir)]
+    if not is_safe_path(path_obj, allowed_dirs):
+        return f"Error: Access denied. File must be in {settings.download_dir}"
+
     if not path_obj.exists():
         return f"Error: File not found at {media_path}"
 

--- a/src/wet_mcp/security.py
+++ b/src/wet_mcp/security.py
@@ -1,5 +1,6 @@
 import ipaddress
 import socket
+from pathlib import Path
 from urllib.parse import urlparse
 
 from loguru import logger
@@ -69,3 +70,26 @@ def is_safe_url(url: str) -> bool:
         return False
 
     return True
+
+
+def is_safe_path(path: str | Path, allowed_dirs: list[str | Path]) -> bool:
+    """
+    Check if a path is within one of the allowed directories.
+    Prevents directory traversal attacks.
+    """
+    try:
+        path_obj = Path(path).resolve()
+
+        for allowed_dir in allowed_dirs:
+            # Also resolve allowed_dir to ensure we compare absolute paths
+            allowed_path = Path(allowed_dir).resolve()
+
+            # Check if path is relative to allowed_dir
+            if path_obj.is_relative_to(allowed_path):
+                return True
+
+        logger.warning(f"Blocked unsafe path access: {path_obj} not in allowed dirs")
+        return False
+    except Exception as e:
+        logger.error(f"Error validating path {path}: {e}")
+        return False

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -10,21 +10,24 @@ from wet_mcp.llm import analyze_media, get_llm_config
 
 
 @pytest.fixture
-def mock_settings():
+def mock_settings(tmp_path):
     """Mock settings for testing."""
     original_keys = settings.api_keys
     original_models = settings.llm_models
     original_temperature = settings.llm_temperature
+    original_download_dir = settings.download_dir
 
     settings.api_keys = "GOOGLE_API_KEY:fake-key"
     settings.llm_models = "gemini/fake-model"
     settings.llm_temperature = None
+    settings.download_dir = str(tmp_path)
 
     yield
 
     settings.api_keys = original_keys
     settings.llm_models = original_models
     settings.llm_temperature = original_temperature
+    settings.download_dir = original_download_dir
 
 
 def test_get_llm_config(mock_settings):
@@ -89,9 +92,11 @@ def test_analyze_media_no_keys():
     assert "Error: LLM analysis requires API_KEYS" in result
 
 
-def test_analyze_media_file_not_found(mock_settings):
+def test_analyze_media_file_not_found(mock_settings, tmp_path):
     """Test file not found error."""
-    result = asyncio.run(analyze_media("non_existent_file.jpg"))
+    # Use a path inside tmp_path (which is allowed) but doesn't exist
+    missing_file = tmp_path / "non_existent_file.jpg"
+    result = asyncio.run(analyze_media(str(missing_file)))
     assert "Error: File not found" in result
 
 

--- a/tests/test_security_llm.py
+++ b/tests/test_security_llm.py
@@ -1,0 +1,56 @@
+"""Security tests for LLM integration."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wet_mcp.config import settings
+from wet_mcp.llm import analyze_media
+
+
+@pytest.fixture
+def mock_settings(tmp_path):
+    """Mock settings with a safe download directory."""
+    original_keys = settings.api_keys
+    original_download_dir = settings.download_dir
+
+    settings.api_keys = "provider:key"
+    safe_dir = tmp_path / "safe_downloads"
+    safe_dir.mkdir()
+    settings.download_dir = str(safe_dir)
+
+    yield
+
+    settings.api_keys = original_keys
+    settings.download_dir = original_download_dir
+
+
+@patch("wet_mcp.llm.acompletion")
+def test_analyze_media_path_traversal(mock_completion, mock_settings, tmp_path):
+    """Test that analyze_media blocks access to files outside download_dir."""
+    # Create a file outside the safe directory
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("SUPER_SECRET_DATA")
+
+    # Attempt to analyze it
+    result = asyncio.run(analyze_media(str(secret_file)))
+
+    # Expect access denied error
+    assert "Error: Access denied" in result
+
+    # Ensure acompletion was NOT called for the unsafe file
+    # Note: mock_completion might be called later for safe file, so check call history carefully if needed
+    # But here we just check if result is error, implying it returned early.
+
+    # Verify safe file works
+    safe_file = Path(settings.download_dir) / "safe.txt"
+    safe_file.write_text("Safe content")
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "Analysis complete"
+    mock_completion.return_value = mock_response
+
+    result = asyncio.run(analyze_media(str(safe_file)))
+    assert result == "Analysis complete"

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:**
Fixed an arbitrary file read vulnerability in `analyze_media` (src/wet_mcp/llm.py) where user-supplied paths were not validated against allowed directories.

⚠️ **Risk:**
An attacker could read arbitrary files on the system (e.g., secrets, configuration files) by supplying a path outside the intended download directory.

🛡️ **Solution:**
1.  Implemented `is_safe_path` in `src/wet_mcp/security.py` to check if a path is within a list of allowed directories using `pathlib.Path.resolve()` and `is_relative_to()`.
2.  Updated `analyze_media` in `src/wet_mcp/llm.py` to validate the `media_path` against `settings.download_dir`.
3.  Added a regression test `tests/test_security_llm.py` to confirm the fix and prevent regression.
4.  Updated existing tests in `tests/test_llm.py` to mock `settings.download_dir` correctly.

---
*PR created automatically by Jules for task [2825524748291390659](https://jules.google.com/task/2825524748291390659) started by @n24q02m*