### PR TITLE
⚡ Optimize blocking process kill in SearXNG runner

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -371,7 +371,7 @@ async def _start_searxng_subprocess() -> str | None:
 
     # Kill any existing process first
     if _searxng_process is not None:
-        _force_kill_process(_searxng_process)
+        await asyncio.to_thread(_force_kill_process, _searxng_process)
         _searxng_process = None
         _searxng_port = None
 
@@ -436,7 +436,7 @@ async def _start_searxng_subprocess() -> str | None:
     except Exception as e:
         logger.error(f"Failed to start SearXNG subprocess: {e}")
         if _searxng_process is not None:
-            _force_kill_process(_searxng_process)
+            await asyncio.to_thread(_force_kill_process, _searxng_process)
             _searxng_process = None
             _searxng_port = None
         return None

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
## 💡 What
Optimized the blocking process kill operation in `_start_searxng_subprocess` by offloading `_force_kill_process` to a thread using `asyncio.to_thread`.

## 🎯 Why
The original code in `_start_searxng_subprocess` (which is async) called `_force_kill_process` synchronously. `_force_kill_process` calls `subprocess.Popen.wait(timeout=3)`, which can block the asyncio event loop for up to 3 seconds if the process does not terminate immediately. This blockage prevents other concurrent tasks (e.g., heartbeats, other tool requests) from running.

Note: The user's request mentioned `_install_searxng` as the blocking call. However, inspection of the codebase revealed that `_install_searxng` was *already* optimized with `asyncio.to_thread`. The blocking issue was actually found in the `_force_kill_process` calls within `_start_searxng_subprocess`, which I have now fixed.

## 📊 Measured Improvement
A reproduction script `tests/repro_kill_block.py` (not included in PR) demonstrated that "tick" messages stopped during the `wait` call before the fix. After applying the fix, the "tick" messages continued uninterrupted, proving that the event loop is no longer blocked during process termination.

Baseline: Event loop blocked for ~1s (simulated).
Improvement: Event loop responsive (non-blocking).

---
*PR created automatically by Jules for task [1799755121311807565](https://jules.google.com/task/1799755121311807565) started by @n24q02m*