### PR TITLE
⚡ perf: wrap _force_kill_process in to_thread

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -371,7 +371,7 @@ async def _start_searxng_subprocess() -> str | None:
 
     # Kill any existing process first
     if _searxng_process is not None:
-        _force_kill_process(_searxng_process)
+        await asyncio.to_thread(_force_kill_process, _searxng_process)
         _searxng_process = None
         _searxng_port = None
 
@@ -436,7 +436,7 @@ async def _start_searxng_subprocess() -> str | None:
     except Exception as e:
         logger.error(f"Failed to start SearXNG subprocess: {e}")
         if _searxng_process is not None:
-            _force_kill_process(_searxng_process)
+            await asyncio.to_thread(_force_kill_process, _searxng_process)
             _searxng_process = None
             _searxng_port = None
         return None


### PR DESCRIPTION
The task referenced a blocking file write in settings setup (`_get_settings_path`), but investigation showed it was already wrapped in `asyncio.to_thread`. However, `_force_kill_process` (which calls `subprocess.Popen.wait` with a 3s timeout) was being called synchronously in `_start_searxng_subprocess`, blocking the event loop.

This change wraps `_force_kill_process` calls in `asyncio.to_thread` to ensure the event loop remains responsive during process cleanup.

Verified with a reproduction script that showed event loop blocking reduced from ~0.5s (mocked wait) to ~0.05s. Existing tests passed.

---
*PR created automatically by Jules for task [17768088428327751799](https://jules.google.com/task/17768088428327751799) started by @n24q02m*