### PR TITLE
test: add unit tests for _find_available_port in searxng_runner

### DIFF
--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from wet_mcp.searxng_runner import _get_settings_path
+from wet_mcp.searxng_runner import _find_available_port, _get_settings_path
 
 
 def test_get_settings_path():
@@ -53,3 +53,67 @@ def test_get_settings_path():
         # Verify write_text called with correct content
         expected_content = "server:\n  port: 9090\n"
         mock_settings_file.write_text.assert_called_once_with(expected_content)
+
+
+def test_find_available_port_success():
+    """Test finding the first available port."""
+    with patch("wet_mcp.searxng_runner.socket.socket") as mock_socket_cls:
+        # Create a mock socket instance
+        mock_socket = MagicMock()
+        mock_socket_cls.return_value.__enter__.return_value = mock_socket
+
+        # Call the function
+        start_port = 8080
+        port = _find_available_port(start_port)
+
+        # Verify result
+        assert port == start_port
+
+        # Verify socket created and bind called
+        mock_socket.bind.assert_called_once_with(("127.0.0.1", start_port))
+
+
+def test_find_available_port_conflict():
+    """Test finding a port when the first one is taken."""
+    with patch("wet_mcp.searxng_runner.socket.socket") as mock_socket_cls:
+        # Create a mock socket instance
+        mock_socket = MagicMock()
+        mock_socket_cls.return_value.__enter__.return_value = mock_socket
+
+        # Configure side effect for bind:
+        # First call raises OSError (port taken), second succeeds
+        mock_socket.bind.side_effect = [OSError("Port in use"), None]
+
+        # Call the function
+        start_port = 8080
+        port = _find_available_port(start_port)
+
+        # Verify result is the next port
+        assert port == start_port + 1
+
+        # Verify socket created and bind called twice
+        assert mock_socket.bind.call_count == 2
+        mock_socket.bind.assert_any_call(("127.0.0.1", start_port))
+        mock_socket.bind.assert_any_call(("127.0.0.1", start_port + 1))
+
+
+def test_find_available_port_exhausted():
+    """Test behavior when all ports in range are taken."""
+    with patch("wet_mcp.searxng_runner.socket.socket") as mock_socket_cls:
+        # Create a mock socket instance
+        mock_socket = MagicMock()
+        mock_socket_cls.return_value.__enter__.return_value = mock_socket
+
+        # Always raise OSError
+        mock_socket.bind.side_effect = OSError("Port in use")
+
+        # Call the function with limited tries
+        start_port = 8080
+        max_tries = 3
+        port = _find_available_port(start_port, max_tries=max_tries)
+
+        # Verify result falls back to start_port
+        assert port == start_port
+
+        # Verify attempted max_tries times
+        assert mock_socket.bind.call_count == max_tries


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `_find_available_port` function in `src/wet_mcp/searxng_runner.py`.

### Changes
- Added `test_find_available_port_success`: Verifies that the function returns the starting port when it is available.
- Added `test_find_available_port_conflict`: Verifies that the function correctly increments the port number when the initial port is in use.
- Added `test_find_available_port_exhausted`: Verifies that the function returns the starting port when all ports in the range are unavailable (fallback behavior).

### Testing
- Used `unittest.mock.patch` to mock `socket.socket` and simulate `bind` success and failure (`OSError`).
- Verified tests pass with `uv run pytest tests/test_searxng_runner.py`.
- Verified no regressions with `uv run pytest`.

---
*PR created automatically by Jules for task [6220178088704008487](https://jules.google.com/task/6220178088704008487) started by @n24q02m*