### PR TITLE
🧹 Refactor SearXNG health check error handling

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -110,8 +110,8 @@ async def _wait_for_service(url: str, timeout: float = _STARTUP_HEALTH_TIMEOUT) 
                 )
                 if response.status_code == 200:
                     return True
-            except Exception:
-                pass
+            except httpx.RequestError as e:
+                logger.debug(f"Health check failed for {url}: {e}")
             await asyncio.sleep(1.0)
     return False
 

--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -1,7 +1,10 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from wet_mcp.searxng_runner import _get_settings_path
+import httpx
+import pytest
+
+from wet_mcp.searxng_runner import _get_settings_path, _wait_for_service
 
 
 def test_get_settings_path():
@@ -53,3 +56,65 @@ def test_get_settings_path():
         # Verify write_text called with correct content
         expected_content = "server:\n  port: 9090\n"
         mock_settings_file.write_text.assert_called_once_with(expected_content)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_service_success():
+    with patch("wet_mcp.searxng_runner.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client_cls.return_value.__aexit__.return_value = None
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client.get.return_value = mock_response
+
+        # Mock sleep to run immediately
+        with patch("wet_mcp.searxng_runner.asyncio.sleep", new_callable=AsyncMock):
+            result = await _wait_for_service("http://localhost:8080")
+            assert result is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_service_failure_retry():
+    with patch("wet_mcp.searxng_runner.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client_cls.return_value.__aexit__.return_value = None
+
+        # Fail with connection error, then succeed
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_client.get.side_effect = [
+            httpx.ConnectError("Connection refused"),
+            mock_response,
+        ]
+
+        # Mock sleep to verify it was called
+        with patch(
+            "wet_mcp.searxng_runner.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            result = await _wait_for_service("http://localhost:8080", timeout=5.0)
+            assert result is True
+            assert mock_sleep.call_count == 1
+            assert mock_client.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_service_timeout():
+    with patch("wet_mcp.searxng_runner.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client_cls.return_value.__aexit__.return_value = None
+
+        # Always fail with connection error
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+
+        # Mock sleep to verify calls
+        with patch(
+            "wet_mcp.searxng_runner.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            # Short timeout to avoid long test
+            result = await _wait_for_service("http://localhost:8080", timeout=0.1)
+            assert result is False
+            assert mock_sleep.call_count > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
This PR addresses a code health issue in `src/wet_mcp/searxng_runner.py` where errors during the SearXNG health check were being swallowed silently.

Changes:
- Replaced `except Exception:` with `except httpx.RequestError as e:` in `_wait_for_service`.
- Added `logger.debug` to log health check failures.
- Added unit tests for `_wait_for_service` in `tests/test_searxng_runner.py` covering success, retry logic, and timeout scenarios.

Verification:
- Ran `uv run pytest tests/test_searxng_runner.py` to verify the new tests pass.
- Ran full test suite `uv run pytest` to ensure no regressions.
- Ran `uv run ruff check .` and `uv run ruff format .` to ensure code quality.

---
*PR created automatically by Jules for task [4995135841512825500](https://jules.google.com/task/4995135841512825500) started by @n24q02m*