### PR TITLE
docs: Verify and document httpx usage in download_media

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -393,7 +393,7 @@ async def download_media(
     output_dir: str,
     concurrency: int = 5,
 ) -> str:
-    """Download media files.
+    """Download media files using httpx.
 
     Args:
         media_urls: List of media URLs to download

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
- Updated `download_media` docstring in `src/wet_mcp/sources/crawler.py` to explicitly mention `httpx` usage.
- Verified that `import httpx` is correctly placed at the module level (line 17) and not inside the function, resolving the code health task.
- Verified that `download_media` function signature includes `concurrency` argument, differing from the task description.
- Confirmed tests `tests/test_crawler_unit.py` and `tests/test_ssrf_download_media.py` pass.

---
*PR created automatically by Jules for task [15268418204999270221](https://jules.google.com/task/15268418204999270221) started by @n24q02m*