### PR TITLE
🔒 Fix arbitrary file write vulnerability in media download

### DIFF
--- a/src/wet_mcp/security.py
+++ b/src/wet_mcp/security.py
@@ -1,5 +1,6 @@
 import ipaddress
 import socket
+from pathlib import Path
 from urllib.parse import urlparse
 
 from loguru import logger
@@ -69,3 +70,26 @@ def is_safe_url(url: str) -> bool:
         return False
 
     return True
+
+
+def is_safe_path(path: str | Path, base_dir: str | Path) -> bool:
+    """
+    Check if a path is safe (relative to base_dir).
+
+    Args:
+        path: The target path to check.
+        base_dir: The base directory that path must be within.
+
+    Returns:
+        True if path is within base_dir, False otherwise.
+    """
+    try:
+        # Use Path objects and resolve to absolute paths
+        base_path = Path(base_dir).expanduser().resolve()
+        target_path = Path(path).expanduser().resolve()
+
+        # Check if target_path is relative to base_path
+        return target_path.is_relative_to(base_path)
+    except Exception as e:
+        logger.error(f"Error validating path {path}: {e}")
+        return False

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -18,7 +18,8 @@ import httpx
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 from loguru import logger
 
-from wet_mcp.security import is_safe_url
+from wet_mcp.security import is_safe_path, is_safe_url
+from wet_mcp.config import settings
 
 # ---------------------------------------------------------------------------
 # Browser pool (singleton)
@@ -404,6 +405,11 @@ async def download_media(
         JSON string with download results
     """
     logger.info(f"Downloading {len(media_urls)} media files")
+    # Security Check: Ensure output_dir is allowed
+    if not is_safe_path(output_dir, settings.download_dir):
+        msg = f"Security Alert: Unsafe output directory blocked: {output_dir}"
+        logger.error(msg)
+        return json.dumps({"error": msg})
 
     output_path = Path(output_dir).expanduser().resolve()
     output_path.mkdir(parents=True, exist_ok=True)

--- a/tests/test_exploit_arbitrary_write.py
+++ b/tests/test_exploit_arbitrary_write.py
@@ -1,0 +1,63 @@
+import pytest
+import json
+from unittest.mock import MagicMock, AsyncMock, patch
+from pathlib import Path
+from wet_mcp.sources.crawler import download_media
+# from wet_mcp.config import settings # We don't need settings here, we just need a path
+
+@pytest.mark.asyncio
+async def test_arbitrary_write_vulnerability(tmp_path):
+    """
+    Test that we CANNOT write to an arbitrary directory.
+    """
+    # Create a directory that is definitely NOT the configured download_dir
+    # In tests, download_dir is usually mocked or defaults to ~/.wet-mcp/downloads
+    # We will use tmp_path as our 'arbitrary' directory, assuming it is not the configured download_dir.
+    # To be safe, we should mock settings.download_dir to something else.
+
+    safe_dir = tmp_path / "safe_downloads"
+    safe_dir.mkdir()
+
+    arbitrary_dir = tmp_path / "arbitrary"
+    arbitrary_dir.mkdir()
+
+    target_file = arbitrary_dir / "pwned.txt"
+
+    # Mock network response (though it shouldn't reach this point)
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.content = b"pwned"
+    mock_response.raise_for_status = MagicMock()
+    mock_client.get.return_value = mock_response
+
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value.__aenter__.return_value = mock_client
+    mock_client_cls.return_value.__aexit__.return_value = None
+
+    url = "http://example.com/pwned.txt"
+
+    # We patch settings to ensure arbitrary_dir is NOT allowed
+    with patch("wet_mcp.config.settings.download_dir", str(safe_dir)):
+        with patch("httpx.AsyncClient", mock_client_cls):
+            # We pass arbitrary_dir as output_dir
+            # This should now FAIL
+            result_json = await download_media([url], str(arbitrary_dir))
+
+    results = json.loads(result_json)
+
+    # We expect an error
+    if isinstance(results, dict) and "error" in results:
+        assert "Security Alert" in results["error"]
+        assert "Path traversal" in results["error"] or "Unsafe output directory" in results["error"]
+    elif isinstance(results, list) and len(results) > 0 and "error" in results[0]:
+         # It's possible it returns a list of errors if we implemented it that way,
+         # but blocking the whole operation is better.
+         # For now, let's assume it returns a dict with error.
+         pass
+    else:
+        # If it returns an empty list or success, that's a failure of the test
+        # currently, before fix, it returns a list of successes.
+        pass
+
+    # CRITICAL CHECK: The file must NOT exist
+    assert not target_file.exists(), "Vulnerability Exploit Successful: File was written to arbitrary directory!"

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -25,7 +25,7 @@ async def test_download_media_path_traversal(tmp_path):
     # But wait, is_safe_url checks scheme and IP.
     # "http://example.com/.." is safe network-wise (resolves to example.com IP).
 
-    with patch("wet_mcp.sources.crawler.is_safe_url", return_value=True):
+    with patch("wet_mcp.config.settings.download_dir", str(tmp_path)), patch("wet_mcp.sources.crawler.is_safe_url", return_value=True):
         with patch("httpx.AsyncClient", return_value=mock_client):
             # 1. Traversal attempt with '..' as filename
             # This simulates a URL where split('/')[-1] is '..'
@@ -50,7 +50,7 @@ async def test_download_media_safe(tmp_path):
     mock_client.__aenter__.return_value = mock_client
     mock_client.__aexit__.return_value = None
 
-    with patch("wet_mcp.sources.crawler.is_safe_url", return_value=True):
+    with patch("wet_mcp.config.settings.download_dir", str(tmp_path)), patch("wet_mcp.sources.crawler.is_safe_url", return_value=True):
         with patch("httpx.AsyncClient", return_value=mock_client):
             url = "http://example.com/image.png"
             await download_media([url], str(tmp_path))

--- a/tests/test_ssrf_download_media.py
+++ b/tests/test_ssrf_download_media.py
@@ -19,7 +19,7 @@ async def test_download_media_ssrf_protection():
     mock_client_cls.return_value.__aenter__.return_value = mock_client
     mock_client_cls.return_value.__aexit__.return_value = None
 
-    with patch("httpx.AsyncClient", mock_client_cls):
+    with patch("wet_mcp.config.settings.download_dir", "/tmp/downloads"), patch("httpx.AsyncClient", mock_client_cls):
         url = "http://localhost/secret.txt"
         with patch("pathlib.Path.mkdir"), patch("pathlib.Path.write_bytes"):
             result_json = await download_media([url], "/tmp/downloads")


### PR DESCRIPTION
This PR addresses a critical arbitrary file write vulnerability in the `download_media` function.

**Vulnerability:**
Previously, the `download_media` function did not validate the `output_dir` parameter against the configured `settings.download_dir`. This allowed an attacker (or user) to specify any directory (e.g., `/etc/`, `/tmp/`) as the output destination, potentially overwriting sensitive files if the process had permissions.

**Fix:**
- Implemented `is_safe_path` in `src/wet_mcp/security.py` to robustly validate paths using `pathlib.Path.resolve()` and `.is_relative_to()`.
- Updated `download_media` in `src/wet_mcp/sources/crawler.py` to strictly enforce that `output_dir` is within `settings.download_dir` before proceeding with any file operations.
- Added a regression test `tests/test_exploit_arbitrary_write.py` which confirms the fix by asserting that attempts to write to an arbitrary directory are blocked.
- Updated existing tests in `tests/test_security_path_traversal.py` and `tests/test_ssrf_download_media.py` to mock `settings.download_dir` appropriately, as they previously relied on writing to unrestricted temporary directories.

**Verification:**
- `tests/test_exploit_arbitrary_write.py` passes (exploit blocked).
- Full test suite (`pytest`) passes.
- No new dependencies introduced (only standard library `pathlib` usage).

---
*PR created automatically by Jules for task [15813542260158168801](https://jules.google.com/task/15813542260158168801) started by @n24q02m*