### PR TITLE
🧹 Refactor: Deduplicate SearXNG installation logic

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -16,7 +16,6 @@ Resilience features:
 import asyncio
 import atexit
 import os
-import shutil
 import signal
 import socket
 import subprocess
@@ -29,7 +28,7 @@ import httpx
 from loguru import logger
 
 from wet_mcp.config import settings
-from wet_mcp.setup import patch_searxng_version, patch_searxng_windows
+from wet_mcp.setup import install_searxng
 
 # Maximum number of restart attempts before giving up and falling back
 # to the external SearXNG URL.
@@ -44,33 +43,6 @@ _HEALTH_CHECK_TIMEOUT = 2.0
 # Maximum time to wait for SearXNG to become healthy after start (seconds).
 _STARTUP_HEALTH_TIMEOUT = 60.0
 
-
-def _get_pip_command() -> list[str]:
-    """Get cross-platform pip install command.
-
-    Priority:
-    1. uv pip (for uv environments - no pip module)
-    2. pip (for traditional venvs)
-    3. python -m pip (fallback)
-    """
-    # Check uv first (cross-platform, works in uv venvs without pip)
-    uv_path = shutil.which("uv")
-    if uv_path:
-        return [uv_path, "pip", "install"]
-
-    # Check pip executable
-    pip_path = shutil.which("pip")
-    if pip_path:
-        return [pip_path, "install"]
-
-    # Fallback to python -m pip
-    return [sys.executable, "-m", "pip", "install"]
-
-
-# SearXNG install URL (zip archive avoids git filename issues on Windows)
-_SEARXNG_INSTALL_URL = (
-    "https://github.com/searxng/searxng/archive/refs/heads/master.zip"
-)
 
 # Module-level process reference for cleanup
 _searxng_process: subprocess.Popen | None = None
@@ -114,80 +86,6 @@ async def _wait_for_service(url: str, timeout: float = _STARTUP_HEALTH_TIMEOUT) 
                 pass
             await asyncio.sleep(1.0)
     return False
-
-
-def _is_searxng_installed() -> bool:
-    """Check if the SearXNG Python package is installed."""
-    try:
-        import searx  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-def _install_searxng() -> bool:
-    """Install SearXNG from GitHub zip archive.
-
-    Uses zip URL instead of git+ to avoid filename issues on some
-    platforms. Pre-installs build dependencies before SearXNG.
-
-    Returns:
-        True if installation succeeded.
-    """
-    logger.info("Installing SearXNG from GitHub (first run)...")
-
-    try:
-        pip_cmd = _get_pip_command()
-        logger.debug(f"Using pip command: {pip_cmd}")
-
-        # Pre-install build dependencies required by SearXNG
-        logger.debug("Installing SearXNG build dependencies...")
-        deps_result = subprocess.run(
-            [
-                *pip_cmd,
-                "--quiet",
-                "msgspec",
-                "setuptools",
-                "wheel",
-                "pyyaml",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        if deps_result.returncode != 0:
-            logger.error(f"Build deps installation failed: {deps_result.stderr[:500]}")
-            return False
-
-        # Install SearXNG with --no-build-isolation (uses pre-installed deps)
-        result = subprocess.run(
-            [
-                *pip_cmd,
-                "--quiet",
-                "--no-build-isolation",
-                _SEARXNG_INSTALL_URL,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-
-        if result.returncode == 0:
-            logger.info("SearXNG installed successfully")
-            patch_searxng_version()
-            patch_searxng_windows()
-            return True
-        else:
-            logger.error(f"SearXNG installation failed: {result.stderr[:500]}")
-            return False
-
-    except subprocess.TimeoutExpired:
-        logger.error("SearXNG installation timed out")
-        return False
-    except Exception as e:
-        logger.error(f"Failed to install SearXNG: {e}")
-        return False
 
 
 def _get_settings_path(port: int) -> Path:
@@ -496,10 +394,9 @@ async def ensure_searxng() -> str:
         return settings.searxng_url
 
     # Ensure SearXNG package is installed
-    if not await asyncio.to_thread(_is_searxng_installed):
-        if not await asyncio.to_thread(_install_searxng):
-            logger.warning("SearXNG installation failed, using external URL")
-            return settings.searxng_url
+    if not await asyncio.to_thread(install_searxng):
+        logger.warning("SearXNG installation failed, using external URL")
+        return settings.searxng_url
 
     # Attempt to start with cooldown between restarts
     if _restart_count > 0:

--- a/tests/test_setup_logic.py
+++ b/tests/test_setup_logic.py
@@ -1,0 +1,112 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# We import from wet_mcp.setup, but these names might not exist yet if running before refactor.
+# However, we are creating the test file now.
+from wet_mcp.setup import (
+    get_pip_command,
+    install_searxng,
+    is_searxng_installed,
+)
+
+
+class TestGetPipCommand:
+    @patch("shutil.which")
+    def test_uv_found(self, mock_which):
+        """Should prefer uv pip if uv is available."""
+        mock_which.side_effect = lambda cmd: "/usr/bin/uv" if cmd == "uv" else None
+        cmd = get_pip_command()
+        assert cmd == ["/usr/bin/uv", "pip", "install"]
+
+    @patch("shutil.which")
+    def test_pip_found_no_uv(self, mock_which):
+        """Should use pip if uv is missing but pip is found."""
+        mock_which.side_effect = lambda cmd: "/usr/bin/pip" if cmd == "pip" else None
+        cmd = get_pip_command()
+        assert cmd == ["/usr/bin/pip", "install"]
+
+    @patch("shutil.which")
+    def test_fallback_python_m_pip(self, mock_which):
+        """Should fallback to python -m pip if neither uv nor pip is found."""
+        mock_which.return_value = None
+        cmd = get_pip_command()
+        assert cmd == [sys.executable, "-m", "pip", "install"]
+
+
+class TestIsSearxngInstalled:
+    def test_installed(self):
+        """Should return True if searx can be imported."""
+        with patch.dict(sys.modules, {"searx": MagicMock()}):
+            assert is_searxng_installed() is True
+
+
+class TestInstallSearxng:
+    @patch("wet_mcp.setup.is_searxng_installed")
+    @patch("wet_mcp.setup.get_pip_command")
+    @patch("subprocess.run")
+    @patch("wet_mcp.setup.patch_searxng_version")
+    @patch("wet_mcp.setup.patch_searxng_windows")
+    def test_already_installed(
+        self,
+        mock_patch_windows,
+        mock_patch_version,
+        mock_run,
+        mock_get_pip,
+        mock_is_installed,
+    ):
+        """Should return True immediately if already installed."""
+        mock_is_installed.return_value = True
+
+        assert install_searxng() is True
+
+        mock_run.assert_not_called()
+
+    @patch("wet_mcp.setup.is_searxng_installed")
+    @patch("wet_mcp.setup.get_pip_command")
+    @patch("subprocess.run")
+    @patch("wet_mcp.setup.patch_searxng_version")
+    @patch("wet_mcp.setup.patch_searxng_windows")
+    def test_install_success(
+        self,
+        mock_patch_windows,
+        mock_patch_version,
+        mock_run,
+        mock_get_pip,
+        mock_is_installed,
+    ):
+        """Should run pip install and patch functions on success."""
+        mock_is_installed.return_value = False
+        mock_get_pip.return_value = ["pip", "install"]
+
+        # Mock subprocess.run for deps and install
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # deps
+            MagicMock(returncode=0),  # install
+        ]
+
+        assert install_searxng() is True
+
+        assert mock_run.call_count == 2
+        mock_patch_version.assert_called_once()
+        mock_patch_windows.assert_called_once()
+
+    @patch("wet_mcp.setup.is_searxng_installed")
+    @patch("wet_mcp.setup.get_pip_command")
+    @patch("subprocess.run")
+    def test_install_failure(
+        self,
+        mock_run,
+        mock_get_pip,
+        mock_is_installed,
+    ):
+        """Should return False if pip install fails."""
+        mock_is_installed.return_value = False
+        mock_get_pip.return_value = ["pip", "install"]
+
+        # Mock subprocess.run for deps success, install failure
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # deps
+            MagicMock(returncode=1, stderr="Error"),  # install
+        ]
+
+        assert install_searxng() is False

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
Removed duplicate SearXNG installation logic.

- Refactored `_install_searxng` from `src/wet_mcp/searxng_runner.py` into a public `install_searxng` function in `src/wet_mcp/setup.py`.
- Exposed `get_pip_command` and `is_searxng_installed` in `src/wet_mcp/setup.py`.
- Updated `src/wet_mcp/searxng_runner.py` to use `wet_mcp.setup.install_searxng`.
- Added unit tests for setup logic in `tests/test_setup_logic.py`.
- Removed unused imports and constants in `src/wet_mcp/searxng_runner.py`.

🎯 **What:** Consolidated duplicated `_install_searxng` and helper functions into `wet_mcp.setup`.
💡 **Why:** To improve maintainability and avoid code divergence.
✅ **Verification:** Added `tests/test_setup_logic.py` and ran existing `tests/test_searxng_runner.py`.
✨ **Result:** Single source of truth for SearXNG installation.

---
*PR created automatically by Jules for task [16135270447867998175](https://jules.google.com/task/16135270447867998175) started by @n24q02m*