### PR TITLE
🧹 Use importlib.util.find_spec for optional import check in setup.py

### DIFF
--- a/src/wet_mcp/setup.py
+++ b/src/wet_mcp/setup.py
@@ -8,6 +8,7 @@ This module handles automatic first-run setup:
 Setup runs automatically on first server start.
 """
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -26,8 +27,6 @@ _SEARXNG_INSTALL_URL = (
 def _find_searx_package_dir() -> Path | None:
     """Find SearXNG package directory via importlib."""
     try:
-        import importlib.util
-
         spec = importlib.util.find_spec("searx")
         if spec and spec.submodule_search_locations:
             return Path(spec.submodule_search_locations[0])
@@ -129,13 +128,9 @@ def _install_searxng() -> bool:
     Returns:
         True if installation succeeded or already installed.
     """
-    try:
-        import searx  # noqa: F401
-
+    if importlib.util.find_spec("searx"):
         logger.debug("SearXNG already installed")
         return True
-    except ImportError:
-        pass
 
     logger.info("Installing SearXNG from GitHub...")
     try:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,64 @@
+"""Tests for setup module."""
+
+from unittest.mock import MagicMock, patch
+
+from wet_mcp.setup import _install_searxng
+
+
+def test_install_searxng_already_installed():
+    """Test _install_searxng returns True when searx is installed (using find_spec)."""
+    with patch("importlib.util.find_spec") as mock_find_spec:
+        mock_find_spec.return_value = MagicMock()
+
+        # We ensure subprocess is NOT called
+        with patch("subprocess.run") as mock_run:
+            # We also need to patch sys.modules or ensure import searx doesn't fail
+            # if we were running this on the old implementation AND searx was installed.
+            # But since we assume it's NOT installed in the test env, import searx fails,
+            # triggering the installation logic.
+            # So on old code: import searx -> fails -> install -> fails the assertion.
+            # On new code: find_spec -> success -> returns True -> passes assertion.
+
+            assert _install_searxng() is True
+            mock_run.assert_not_called()
+
+
+def test_install_searxng_install_success():
+    """Test _install_searxng installs searx when not present."""
+    with (
+        patch("importlib.util.find_spec") as mock_find_spec,
+        patch("subprocess.run") as mock_run,
+        patch("wet_mcp.setup.patch_searxng_version") as mock_patch_version,
+        patch("wet_mcp.setup.patch_searxng_windows") as mock_patch_windows,
+    ):
+        # Simulate searx not installed
+        mock_find_spec.return_value = None
+
+        # Simulate successful installation
+        mock_run.return_value.returncode = 0
+
+        # We need to ensure import searx fails for the old implementation too.
+        # Since it's not installed, it does fail.
+
+        assert _install_searxng() is True
+
+        # Should have tried to install dependencies and searxng
+        assert mock_run.call_count == 2
+        mock_patch_version.assert_called_once()
+        mock_patch_windows.assert_called_once()
+
+
+def test_install_searxng_deps_fail():
+    """Test _install_searxng fails when dependencies fail to install."""
+    with (
+        patch("importlib.util.find_spec") as mock_find_spec,
+        patch("subprocess.run") as mock_run,
+    ):
+        # Simulate searx not installed
+        mock_find_spec.return_value = None
+
+        # Simulate failed dependency installation
+        mock_run.return_value.returncode = 1
+
+        assert _install_searxng() is False
+        assert mock_run.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
Replaced `try-except ImportError` with `importlib.util.find_spec` in `src/wet_mcp/setup.py` to check for `searx` installation without importing it. This improves code health by avoiding side effects and unnecessary imports. Added `tests/test_setup.py` to verify the installation logic. Verified with `uv run pytest` and formatted with `uv run ruff`.

---
*PR created automatically by Jules for task [8304681125263750571](https://jules.google.com/task/8304681125263750571) started by @n24q02m*