### PR TITLE
🔒 Fix Arbitrary File Read in Media Analysis

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -24,6 +24,7 @@ from litellm import acompletion  # noqa: E402
 from loguru import logger  # noqa: E402
 
 from wet_mcp.config import settings  # noqa: E402
+from wet_mcp.security import is_safe_path  # noqa: E402
 
 
 def get_llm_config() -> dict:
@@ -69,6 +70,9 @@ async def analyze_media(
         return "Error: LLM analysis requires API_KEYS to be configured."
 
     path_obj = Path(media_path)
+    if not is_safe_path(path_obj, settings.download_dir):
+        return f"Error: Security Alert: Access denied to {media_path}"
+
     if not path_obj.exists():
         return f"Error: File not found at {media_path}"
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -10,21 +10,24 @@ from wet_mcp.llm import analyze_media, get_llm_config
 
 
 @pytest.fixture
-def mock_settings():
+def mock_settings(tmp_path):
     """Mock settings for testing."""
     original_keys = settings.api_keys
     original_models = settings.llm_models
     original_temperature = settings.llm_temperature
+    original_download_dir = settings.download_dir
 
     settings.api_keys = "GOOGLE_API_KEY:fake-key"
     settings.llm_models = "gemini/fake-model"
     settings.llm_temperature = None
+    settings.download_dir = str(tmp_path)
 
     yield
 
     settings.api_keys = original_keys
     settings.llm_models = original_models
     settings.llm_temperature = original_temperature
+    settings.download_dir = original_download_dir
 
 
 def test_get_llm_config(mock_settings):
@@ -89,9 +92,11 @@ def test_analyze_media_no_keys():
     assert "Error: LLM analysis requires API_KEYS" in result
 
 
-def test_analyze_media_file_not_found(mock_settings):
+def test_analyze_media_file_not_found(mock_settings, tmp_path):
     """Test file not found error."""
-    result = asyncio.run(analyze_media("non_existent_file.jpg"))
+    # Use a safe path that doesn't exist
+    safe_non_existent = tmp_path / "non_existent_file.jpg"
+    result = asyncio.run(analyze_media(str(safe_non_existent)))
     assert "Error: File not found" in result
 
 


### PR DESCRIPTION
- **What:** Fixed an arbitrary file read vulnerability in `src/wet_mcp/llm.py` where `analyze_media` allowed access to files outside the configured download directory.
- **Risk:** Attackers could potentially read sensitive files on the server if they could control the path passed to `analyze_media`.
- **Solution:** 
    - Added `is_safe_path` utility to `src/wet_mcp/security.py` to validate that a path is relative to a base directory.
    - Updated `src/wet_mcp/llm.py` to validate `media_path` against `settings.download_dir` before processing.
    - Updated `tests/test_llm.py` to include security checks and properly mock `settings.download_dir` for safe testing.

---
*PR created automatically by Jules for task [12922164763995952762](https://jules.google.com/task/12922164763995952762) started by @n24q02m*