### PR TITLE
🧹 Refactor crawler to reduce duplication using _process_root_bfs

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -12,7 +12,9 @@ import asyncio
 import json
 import os
 import tempfile
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
 
 import httpx
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
@@ -191,6 +193,54 @@ async def extract(
     return json.dumps(results, ensure_ascii=False, indent=2)
 
 
+async def _process_root_bfs(
+    root_url: str,
+    max_depth: int,
+    crawler: AsyncWebCrawler,
+    sem: asyncio.Semaphore,
+    visited: set[str],
+    should_stop: Callable[[], bool],
+    on_result: Callable[[str, int, Any, Exception | None], Awaitable[list[str]]]
+    | None = None,
+    on_visit: Callable[[str, int], None] | None = None,
+) -> None:
+    """Helper to perform BFS crawl for a single root URL."""
+    if not is_safe_url(root_url):
+        logger.warning(f"Skipping unsafe URL: {root_url}")
+        return
+
+    queue: list[tuple[str, int]] = [(root_url, 0)]
+
+    while queue and not should_stop():
+        url, current_depth = queue.pop(0)
+
+        if url in visited or current_depth > max_depth:
+            continue
+
+        visited.add(url)
+
+        if on_visit:
+            on_visit(url, current_depth)
+
+        async with sem:
+            result = None
+            error = None
+            try:
+                result = await crawler.arun(
+                    url,  # ty: ignore[invalid-argument-type]
+                    config=CrawlerRunConfig(verbose=False),
+                )  # ty: ignore[missing-argument]
+            except Exception as e:
+                error = e
+
+            if on_result:
+                new_links = await on_result(url, current_depth, result, error)
+                if new_links and current_depth < max_depth:
+                    for link in new_links:
+                        if link and link not in visited:
+                            queue.append((link, current_depth + 1))
+
+
 async def crawl(
     urls: list[str],
     depth: int = 2,
@@ -218,58 +268,53 @@ async def crawl(
     crawler = await _get_crawler(stealth)
     sem = _get_semaphore()
 
+    async def on_result(
+        url: str,
+        current_depth: int,
+        result: Any,
+        error: Exception | None,
+    ) -> list[str]:
+        if error:
+            logger.error(f"Error crawling {url}: {error}")
+            return []
+
+        if result and result.success:
+            content = result.markdown if format == "markdown" else result.cleaned_html
+            all_results.append(
+                {
+                    "url": url,
+                    "depth": current_depth,
+                    "title": result.metadata.get("title", ""),
+                    "content": content[:5000],  # Limit content size
+                }
+            )
+
+            # Add internal links for next depth
+            internal_links = result.links.get("internal", [])
+            links_to_return = []
+            for link_item in internal_links[:10]:
+                # Crawl4AI returns dicts with "href" key
+                link_url = (
+                    link_item.get("href", "")
+                    if isinstance(link_item, dict)
+                    else link_item
+                )
+                if link_url:
+                    links_to_return.append(link_url)
+            return links_to_return
+
+        return []
+
     for root_url in urls:
-        if not is_safe_url(root_url):
-            logger.warning(f"Skipping unsafe URL: {root_url}")
-            continue
-
-        to_crawl: list[tuple[str, int]] = [(root_url, 0)]
-
-        while to_crawl and len(all_results) < max_pages:
-            url, current_depth = to_crawl.pop(0)
-
-            if url in visited or current_depth > depth:
-                continue
-
-            visited.add(url)
-
-            async with sem:
-                try:
-                    result = await crawler.arun(
-                        url,  # ty: ignore[invalid-argument-type]
-                        config=CrawlerRunConfig(verbose=False),
-                    )  # ty: ignore[missing-argument]
-
-                    if result.success:
-                        content = (
-                            result.markdown
-                            if format == "markdown"
-                            else result.cleaned_html
-                        )
-                        all_results.append(
-                            {
-                                "url": url,
-                                "depth": current_depth,
-                                "title": result.metadata.get("title", ""),
-                                "content": content[:5000],  # Limit content size
-                            }
-                        )
-
-                        # Add internal links for next depth
-                        if current_depth < depth:
-                            internal_links = result.links.get("internal", [])
-                            for link_item in internal_links[:10]:
-                                # Crawl4AI returns dicts with 'href' key
-                                link_url = (
-                                    link_item.get("href", "")
-                                    if isinstance(link_item, dict)
-                                    else link_item
-                                )
-                                if link_url and link_url not in visited:
-                                    to_crawl.append((link_url, current_depth + 1))
-
-                except Exception as e:
-                    logger.error(f"Error crawling {url}: {e}")
+        await _process_root_bfs(
+            root_url,
+            depth,
+            crawler,
+            sem,
+            visited,
+            lambda: len(all_results) >= max_pages,
+            on_result=on_result,
+        )
 
     logger.info(f"Crawled {len(all_results)} pages")
     return json.dumps(all_results, ensure_ascii=False, indent=2)
@@ -299,41 +344,46 @@ async def sitemap(
     sem = _get_semaphore()
 
     for root_url in urls:
-        if not is_safe_url(root_url):
-            logger.warning(f"Skipping unsafe URL: {root_url}")
-            continue
-
-        to_visit: list[tuple[str, int]] = [(root_url, 0)]
         site_urls: list[dict[str, object]] = []
 
-        while to_visit and len(site_urls) < max_pages:
-            url, current_depth = to_visit.pop(0)
+        def on_visit(url: str, current_depth: int) -> None:
+            site_urls.append({"url": url, "depth": current_depth})  # noqa: B023
 
-            if url in visited or current_depth > depth:
-                continue
+        async def on_result(
+            url: str,
+            current_depth: int,
+            result: Any,
+            error: Exception | None,
+        ) -> list[str]:
+            if error:
+                logger.debug(f"Error mapping {url}: {error}")
+                return []
 
-            visited.add(url)
-            site_urls.append({"url": url, "depth": current_depth})
+            if result and result.success:
+                internal_links = result.links.get("internal", [])
+                links_to_return = []
+                for link_item in internal_links[:20]:
+                    # Extract URL from dict if necessary
+                    link_url = (
+                        link_item.get("href", "")
+                        if isinstance(link_item, dict)
+                        else link_item
+                    )
+                    if link_url:
+                        links_to_return.append(link_url)
+                return links_to_return
+            return []
 
-            async with sem:
-                try:
-                    result = await crawler.arun(
-                        url,  # ty: ignore[invalid-argument-type]
-                        config=CrawlerRunConfig(verbose=False),
-                    )  # ty: ignore[missing-argument]
-
-                    if result.success and current_depth < depth:
-                        for link in result.links.get("internal", [])[:20]:
-                            # Extract URL from dict if necessary
-                            link_url = (
-                                link.get("href", "") if isinstance(link, dict) else link
-                            )
-                            if link_url and link_url not in visited:
-                                to_visit.append((link_url, current_depth + 1))
-
-                except Exception as e:
-                    logger.debug(f"Error mapping {url}: {e}")
-
+        await _process_root_bfs(
+            root_url,
+            depth,
+            crawler,
+            sem,
+            visited,
+            lambda: len(site_urls) >= max_pages,  # noqa: B023
+            on_visit=on_visit,
+            on_result=on_result,
+        )
         all_urls.extend(site_urls)
 
     logger.info(f"Mapped {len(all_urls)} URLs")

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
Refactored `crawl` and `sitemap` functions in `src/wet_mcp/sources/crawler.py` to use a shared `_process_root_bfs` helper function. This reduces code duplication for the BFS traversal logic while preserving the specific behavior of each function (different stop conditions, result processing, and logging levels).

Verified with existing tests `tests/test_crawler_unit.py` and `tests/test_crawler_sitemap.py`.

---
*PR created automatically by Jules for task [844447863239437077](https://jules.google.com/task/844447863239437077) started by @n24q02m*