### PR TITLE
🧹 Refactor analyze_media to remove redundant config calls

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -72,6 +72,8 @@ async def analyze_media(
     if not path_obj.exists():
         return f"Error: File not found at {media_path}"
 
+    config = get_llm_config()
+
     # Determine mime type
     mime_type, _ = mimetypes.guess_type(media_path)
     if not mime_type:
@@ -95,7 +97,6 @@ async def analyze_media(
         try:
             content = await asyncio.to_thread(_read_and_truncate, media_path)
 
-            config = get_llm_config()
             logger.info(f"Analyzing text file with model: {config['model']}")
 
             messages = [
@@ -115,7 +116,6 @@ async def analyze_media(
             return f"Error analyzing text file: {e}"
 
     # Check model capabilities for media
-    config = get_llm_config()
     caps = get_model_capabilities(config["model"])
 
     # Validate capability vs file type
@@ -132,7 +132,6 @@ async def analyze_media(
         return f"Error: Unsupported media type: {mime_type}"
 
     try:
-        config = get_llm_config()
         logger.info(f"Analyzing media with model: {config['model']}")
 
         base64_image = await asyncio.to_thread(encode_image, media_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:**
Refactored `analyze_media` in `src/wet_mcp/llm.py` to remove redundant calls to `get_llm_config()`.

💡 **Why:**
The `get_llm_config()` function was being called multiple times within `analyze_media` (inside text handling, before capability checks, and inside media analysis). Since this function performs string processing (splitting `settings.llm_models`), calling it once and reusing the result improves efficiency and code readability. It also ensures that the configuration used is consistent throughout the function execution.

✅ **Verification:**
- Ran `uv run pytest tests/test_llm.py` to ensure no regression in functionality. All tests passed.
- Ran `uv run ruff check .` and `uv run ruff format .` to ensure code style compliance.
- Confirmed that the specific "Dead Logic" (commented out temperature code) mentioned in the original task description was already absent from the codebase, so no action was needed on that specific point.

✨ **Result:**
Cleaner, slightly more efficient code in `src/wet_mcp/llm.py` with no change in external behavior.

---
*PR created automatically by Jules for task [1247343257982419999](https://jules.google.com/task/1247343257982419999) started by @n24q02m*