### PR TITLE
⚡ optimize download_media with streaming for 96% memory reduction

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -430,28 +430,34 @@ async def download_media(
                 if not is_safe_url(target_url):
                     return {"url": url, "error": "Security Alert: Unsafe URL blocked"}
 
-                response = await client.get(target_url, follow_redirects=True)
-                response.raise_for_status()
+                async with client.stream(
+                    "GET", target_url, follow_redirects=True
+                ) as response:
+                    response.raise_for_status()
 
-                filename = target_url.split("/")[-1].split("?")[0] or "download"
-                filepath = (output_path / filename).resolve()
+                    filename = target_url.split("/")[-1].split("?")[0] or "download"
+                    filepath = (output_path / filename).resolve()
 
-                # Security check: Ensure the resolved path is still
-                # within the output directory
-                if not filepath.is_relative_to(output_path):
-                    raise ValueError(
-                        f"Security Alert: Path traversal attempt detected "
-                        f"for {filename}"
-                    )
+                    # Security check: Ensure the resolved path is still
+                    # within the output directory
+                    if not filepath.is_relative_to(output_path):
+                        raise ValueError(
+                            f"Security Alert: Path traversal attempt detected "
+                            f"for {filename}"
+                        )
 
-                # Write file in thread to avoid blocking event loop
-                await asyncio.to_thread(filepath.write_bytes, response.content)
+                    total_size = 0
+                    # Write file in thread to avoid blocking event loop
+                    with open(filepath, "wb") as f:
+                        async for chunk in response.aiter_bytes():
+                            await asyncio.to_thread(f.write, chunk)
+                            total_size += len(chunk)
 
-                return {
-                    "url": url,
-                    "path": str(filepath),
-                    "size": len(response.content),
-                }
+                    return {
+                        "url": url,
+                        "path": str(filepath),
+                        "size": total_size,
+                    }
 
             except Exception as e:
                 logger.error(f"Error downloading {url}: {e}")

--- a/tests/benchmark_download.py
+++ b/tests/benchmark_download.py
@@ -1,0 +1,67 @@
+import asyncio
+import os
+import time
+import tracemalloc
+from pathlib import Path
+
+from aiohttp import web
+
+from wet_mcp.sources.crawler import download_media
+
+# Create a large file
+LARGE_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+LARGE_FILE_PATH = Path("large_file.bin")
+
+
+def create_large_file():
+    if not LARGE_FILE_PATH.exists():
+        with open(LARGE_FILE_PATH, "wb") as f:
+            f.write(os.urandom(LARGE_FILE_SIZE))
+
+
+async def handle(request):
+    return web.FileResponse(LARGE_FILE_PATH)
+
+
+async def start_server():
+    app = web.Application()
+    app.router.add_get("/large", handle)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", 8080)
+    await site.start()
+    return runner
+
+
+async def main():
+    create_large_file()
+    runner = await start_server()
+
+    urls = [
+        f"http://localhost:8080/large?{i}" for i in range(20)
+    ]  # 20 files = 200MB total
+    output_dir = Path("bench_downloads")
+
+    tracemalloc.start()
+    start_time = time.time()
+
+    await download_media(urls, str(output_dir), concurrency=5)
+
+    end_time = time.time()
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    print(f"Time: {end_time - start_time:.2f}s")
+    print(f"Peak Memory: {peak / 1024 / 1024:.2f} MB")
+
+    await runner.cleanup()
+
+    # Cleanup
+    for f in output_dir.glob("*"):
+        f.unlink()
+    output_dir.rmdir()
+    LARGE_FILE_PATH.unlink()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -9,49 +9,69 @@ from wet_mcp.sources.crawler import download_media
 async def test_download_media_path_traversal(tmp_path):
     """Test that download_media prevents path traversal."""
 
-    # Mock httpx response
-    mock_response = MagicMock()
-    mock_response.content = b"fake content"
+    # Mock stream response
+    mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
 
-    # Mock httpx client context manager
-    mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = None
+    # Mock stream context manager
+    mock_stream_ctx = MagicMock()
+    mock_stream_ctx.__aenter__.return_value = mock_response
+    mock_stream_ctx.__aexit__.return_value = None
 
-    # We need to simulate is_safe_url passing for these URLs, or mock it.
-    # Since we are testing path traversal, we assume the URL is "safe" network-wise but malicious filename-wise.
-    # But wait, is_safe_url checks scheme and IP.
-    # "http://example.com/.." is safe network-wise (resolves to example.com IP).
+    # Mock httpx client
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_stream_ctx)
+
+    # Mock client constructor
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value.__aenter__.return_value = mock_client
+    mock_client_cls.return_value.__aexit__.return_value = None
 
     with patch("wet_mcp.sources.crawler.is_safe_url", return_value=True):
-        with patch("httpx.AsyncClient", return_value=mock_client):
-            # 1. Traversal attempt with '..' as filename
-            # This simulates a URL where split('/')[-1] is '..'
-            url1 = "http://example.com/.."
-            res1 = await download_media([url1], str(tmp_path))
+        with patch("httpx.AsyncClient", mock_client_cls):
+            with patch("builtins.open"):  # Prevent file write attempt
+                # 1. Traversal attempt with '..' as filename
+                url1 = "http://example.com/.."
+                res1 = await download_media([url1], str(tmp_path))
 
-            # Should fail with "Security Alert" because '..' resolves to parent dir
-            assert "Security Alert" in res1
+                # Should fail with "Security Alert" because '..' resolves to parent dir
+                assert "Security Alert" in res1
 
-            # Verify no files were written in parent
-            pass
+                # Verify stream was called (since is_safe_url=True) but processing failed due to path check
+                mock_client.stream.assert_called()
 
 
 @pytest.mark.asyncio
 async def test_download_media_safe(tmp_path):
-    mock_response = MagicMock()
-    mock_response.content = b"safe content"
+    # Mock response
+    mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
 
+    # Mock aiter_bytes
+    async def async_iter():
+        yield b"safe "
+        yield b"content"
+
+    mock_response.aiter_bytes = async_iter
+
+    # Mock stream context manager
+    mock_stream_ctx = MagicMock()
+    mock_stream_ctx.__aenter__.return_value = mock_response
+    mock_stream_ctx.__aexit__.return_value = None
+
+    # Mock client
     mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = None
+    mock_client.stream = MagicMock(return_value=mock_stream_ctx)
+
+    # Mock client constructor
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value.__aenter__.return_value = mock_client
+    mock_client_cls.return_value.__aexit__.return_value = None
 
     with patch("wet_mcp.sources.crawler.is_safe_url", return_value=True):
-        with patch("httpx.AsyncClient", return_value=mock_client):
+        with patch("httpx.AsyncClient", mock_client_cls):
+            # We don't patch open because we want to test actual write (to tmp_path)
+
             url = "http://example.com/image.png"
             await download_media([url], str(tmp_path))
 

--- a/tests/test_ssrf_download_media.py
+++ b/tests/test_ssrf_download_media.py
@@ -10,21 +10,32 @@ from wet_mcp.sources.crawler import download_media
 async def test_download_media_ssrf_protection():
     """Test that download_media blocks unsafe URLs (SSRF protection)."""
     mock_client = AsyncMock()
-    mock_response = MagicMock()
-    mock_response.content = b"secret data"
-    mock_response.raise_for_status = MagicMock()
-    mock_client.get.return_value = mock_response
+    # Mock stream method
+    mock_client.stream = MagicMock()
 
+    # Mock stream context manager
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+
+    mock_stream_ctx = MagicMock()
+    mock_stream_ctx.__aenter__.return_value = mock_response
+    mock_stream_ctx.__aexit__.return_value = None
+    mock_client.stream.return_value = mock_stream_ctx
+
+    # Mock client constructor
     mock_client_cls = MagicMock()
     mock_client_cls.return_value.__aenter__.return_value = mock_client
     mock_client_cls.return_value.__aexit__.return_value = None
 
     with patch("httpx.AsyncClient", mock_client_cls):
         url = "http://localhost/secret.txt"
-        with patch("pathlib.Path.mkdir"), patch("pathlib.Path.write_bytes"):
+
+        # Patch open to prevent actual file I/O
+        with patch("pathlib.Path.mkdir"), patch("builtins.open"):
             result_json = await download_media([url], "/tmp/downloads")
 
         # The request was NOT made because it's unsafe
+        mock_client.stream.assert_not_called()
         mock_client.get.assert_not_called()
 
         results = json.loads(result_json)

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
💡 **What:**
- Optimized `download_media` in `src/wet_mcp/sources/crawler.py` to use `httpx.AsyncClient.stream` for downloading files.
- Implemented chunked writing using `asyncio.to_thread` to ensure non-blocking I/O and constant memory usage.
- Updated `tests/test_ssrf_download_media.py` and `tests/test_security_path_traversal.py` to mock `client.stream` instead of `client.get`.

🎯 **Why:**
- The previous implementation loaded the entire file content into memory (`response.content`) before writing it to disk. This caused high memory usage when downloading large files or multiple files concurrently.
- Writing the entire file content at once (`path.write_bytes`) is a blocking operation (even if wrapped in `to_thread`, it occupies the thread for longer), whereas chunked writing is more efficient and keeps memory footprint low.

📊 **Measured Improvement:**
- **Baseline:** 5.83s, 153.33 MB peak memory (downloading 20x 10MB files).
- **Optimized:** 4.75s, 5.74 MB peak memory.
- **Result:** ~96% reduction in peak memory usage and ~18% faster execution time.

---
*PR created automatically by Jules for task [1043365367213885085](https://jules.google.com/task/1043365367213885085) started by @n24q02m*