### PR TITLE
fix: daily compliance audit 2026-02-14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /bin/uv
 
 # Copy project files
 COPY pyproject.toml uv.lock README.md ./
@@ -67,19 +67,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
+# Create a non-root user
+RUN useradd -m -u 1000 app && mkdir -p /app && chown -R app:app /app
+
 # Copy virtual environment from builder
-COPY --from=builder /app/.venv /app/.venv
-COPY --from=builder /app/src /app/src
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+COPY --from=builder --chown=app:app /app/src /app/src
 
 # Copy Playwright browsers from builder
-COPY --from=builder /root/.cache/ms-playwright /root/.cache/ms-playwright
+COPY --from=builder --chown=app:app /root/.cache/ms-playwright /home/app/.cache/ms-playwright
 
 # Activate venv
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app/src
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/app/.cache/ms-playwright
 
 # Mark setup as complete (everything pre-installed)
-RUN mkdir -p /root/.wet-mcp && touch /root/.wet-mcp/.setup-complete
+RUN mkdir -p /home/app/.wet-mcp && touch /home/app/.wet-mcp/.setup-complete
+
+# Switch to non-root user
+USER app
 
 # Stdio transport by default
 CMD ["python", "-m", "wet_mcp"]

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -7,6 +7,7 @@ from importlib.resources import files
 
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from wet_mcp.config import settings
 from wet_mcp.searxng_runner import ensure_searxng, stop_searxng
@@ -104,7 +105,7 @@ async def _with_timeout(coro, action: str) -> str:
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True))
 async def web(
     action: str,
     query: str | None = None,
@@ -172,7 +173,11 @@ async def web(
             return f"Error: Unknown action '{action}'. Valid actions: search, extract, crawl, map"
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True
+    )
+)
 async def media(
     action: str,
     url: str | None = None,
@@ -230,7 +235,7 @@ async def media(
             return f"Error: Unknown action '{action}'. Valid actions: list, download, analyze"
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True))
 async def help(tool_name: str = "web") -> str:
     """Get full documentation for a tool.
     Use when compressed descriptions are insufficient.

--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
=== DAILY AUDIT REPORT - wet-mcp - 2026-02-14 ===

Skills applied: repo-structure, security-practices, mcp-server

RESULTS:
[PASS] mise.toml versions correct (Python 3.13, Node 24)
[PASS] release-please config exists (beta + stable)
[PASS] pre-commit hooks configured correctly
[PASS] CI/CD workflow compliant (release gating present)
[PASS] No hardcoded secrets found
[FIXED] Dockerfile used 'latest' tag for uv -> pinned to '0.9.26'
[FIXED] Dockerfile ran as root -> added non-root 'app' user (UID 1000)
[FIXED] MCP server tools missing annotations -> added readOnlyHint/destructiveHint/idempotentHint
[WARN] Tool naming 'web' and 'media' is generic (but renaming would break API)
[PASS] Unit tests present for all tools
[PASS] Code standards check (ruff, ty) passed

SUMMARY: 8 passed, 3 fixed, 1 warning, 0 failures
Ref: .agents/rules.md, .agents/skills/mcp-server/SKILL.md, .agents/skills/security-practices/SKILL.md

---
*PR created automatically by Jules for task [10986896179016361526](https://jules.google.com/task/10986896179016361526) started by @n24q02m*