### PR TITLE
⚡ Bolt: Parallelize crawler BFS

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.4.0b2"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
💡 What: Refactored `crawl` and `sitemap` functions in `src/wet_mcp/sources/crawler.py` to use level-by-level parallel execution.
🎯 Why: The previous implementation processed URLs sequentially within each root URL's BFS traversal, and sequentially across root URLs. This was a significant bottleneck for IO-bound web crawling.
📊 Impact: Expected speedup is roughly proportional to `_MAX_CONCURRENT_OPS` (default 6) for depths > 0, as multiple links can now be fetched in parallel.
🔬 Measurement: Verified with existing unit tests `tests/test_crawler_unit.py` and `tests/test_crawler_sitemap.py`. Existing tests confirm that depth limits, max page limits, and error handling are preserved.

---
*PR created automatically by Jules for task [5709719730163724108](https://jules.google.com/task/5709719730163724108) started by @n24q02m*