### PR TITLE
fix: daily compliance audit 2026-02-17

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -6,7 +6,7 @@
 [tools]
 python = "3.13"
 node = "24"
-uv = "latest"
+uv = "0.9.26"
 
 [settings]
 trusted_config_paths = ["."]

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -396,6 +396,7 @@ async def _with_timeout(coro, action: str) -> str:
         readOnlyHint=True,
         openWorldHint=True,
         idempotentHint=True,
+        destructiveHint=False,
     ),
 )
 async def search(
@@ -496,6 +497,8 @@ async def search(
     annotations=ToolAnnotations(
         readOnlyHint=True,
         openWorldHint=True,
+        idempotentHint=True,
+        destructiveHint=False,
     ),
 )
 async def extract(
@@ -585,6 +588,8 @@ async def extract(
     annotations=ToolAnnotations(
         readOnlyHint=False,
         openWorldHint=True,
+        idempotentHint=False,
+        destructiveHint=False,
     ),
 )
 async def media(
@@ -649,6 +654,7 @@ async def media(
         readOnlyHint=True,
         openWorldHint=False,
         idempotentHint=True,
+        destructiveHint=False,
     ),
 )
 async def help(tool_name: str = "search") -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -1966,7 +1966,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.5.1"
+version = "2.5.2b2"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },
@@ -1982,6 +1982,9 @@ dependencies = [
 full = [
     { name = "qwen3-embed" },
     { name = "sqlite-vec" },
+]
+gguf = [
+    { name = "qwen3-embed" },
 ]
 local = [
     { name = "qwen3-embed" },
@@ -2011,10 +2014,11 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "qwen3-embed", marker = "extra == 'full'", specifier = ">=0.2.0" },
     { name = "qwen3-embed", marker = "extra == 'local'", specifier = ">=0.2.0" },
+    { name = "qwen3-embed", extras = ["gguf"], marker = "extra == 'gguf'", specifier = ">=0.2.0" },
     { name = "sqlite-vec", marker = "extra == 'full'" },
     { name = "sqlite-vec", marker = "extra == 'vector'" },
 ]
-provides-extras = ["vector", "local", "full"]
+provides-extras = ["vector", "local", "gguf", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
=== DAILY AUDIT REPORT - wet-mcp - 2026-02-17 ===

Skills applied: repo-structure, security-practices, mcp-server

RESULTS:
[PASS] mise.toml versions correct (python 3.13, node 24)
[FIXED] uv version in mise.toml pinned to 0.9.26 (was latest)
[FIXED] Added missing destructiveHint/idempotentHint to MCP tool annotations
[WARN] release-please missing (using python-semantic-release instead)
[PASS] CD workflow gated by release outputs
[PASS] Dockerfile uses specific base tags
[PASS] No hardcoded secrets found
[PASS] Tests pass (259 passed)

SUMMARY: 6 passed, 2 fixed, 1 warning, 0 failures

---
*PR created automatically by Jules for task [18002470640155088990](https://jules.google.com/task/18002470640155088990) started by @n24q02m*