### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in analyze_media

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -24,6 +24,7 @@ from litellm import acompletion  # noqa: E402
 from loguru import logger  # noqa: E402
 
 from wet_mcp.config import settings  # noqa: E402
+from wet_mcp.security import is_safe_path  # noqa: E402
 
 
 def get_llm_config() -> dict:
@@ -67,6 +68,11 @@ async def analyze_media(
     """Analyze media file using configured LLM with auto-capability detection."""
     if not settings.api_keys:
         return "Error: LLM analysis requires API_KEYS to be configured."
+
+    # Security check: prevent path traversal
+    if not is_safe_path(media_path, settings.download_dir):
+        logger.warning(f"Security Alert: Blocked access to unsafe path {media_path}")
+        return f"Error: Security Alert - File path {media_path} is outside allowed directories."
 
     path_obj = Path(media_path)
     if not path_obj.exists():

--- a/src/wet_mcp/security.py
+++ b/src/wet_mcp/security.py
@@ -1,5 +1,6 @@
 import ipaddress
 import socket
+from pathlib import Path
 from urllib.parse import urlparse
 
 from loguru import logger
@@ -69,3 +70,17 @@ def is_safe_url(url: str) -> bool:
         return False
 
     return True
+
+
+def is_safe_path(target_path: str | Path, base_path: str | Path) -> bool:
+    """
+    Check if target_path is within base_path (prevent path traversal).
+    Resolves symlinks and relative paths.
+    """
+    try:
+        base = Path(base_path).resolve()
+        target = Path(target_path).resolve()
+        return target.is_relative_to(base)
+    except Exception as e:
+        logger.error(f"Error validating path {target_path}: {e}")
+        return False

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -10,21 +10,24 @@ from wet_mcp.llm import analyze_media, get_llm_config
 
 
 @pytest.fixture
-def mock_settings():
+def mock_settings(tmp_path):
     """Mock settings for testing."""
     original_keys = settings.api_keys
     original_models = settings.llm_models
     original_temperature = settings.llm_temperature
+    original_download_dir = settings.download_dir
 
     settings.api_keys = "GOOGLE_API_KEY:fake-key"
     settings.llm_models = "gemini/fake-model"
     settings.llm_temperature = None
+    settings.download_dir = str(tmp_path)
 
     yield
 
     settings.api_keys = original_keys
     settings.llm_models = original_models
     settings.llm_temperature = original_temperature
+    settings.download_dir = original_download_dir
 
 
 def test_get_llm_config(mock_settings):
@@ -89,9 +92,11 @@ def test_analyze_media_no_keys():
     assert "Error: LLM analysis requires API_KEYS" in result
 
 
-def test_analyze_media_file_not_found(mock_settings):
+def test_analyze_media_file_not_found(mock_settings, tmp_path):
     """Test file not found error."""
-    result = asyncio.run(analyze_media("non_existent_file.jpg"))
+    # Use a safe path that doesn't exist
+    safe_path = tmp_path / "non_existent_file.jpg"
+    result = asyncio.run(analyze_media(str(safe_path)))
     assert "Error: File not found" in result
 
 

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -2,6 +2,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from wet_mcp.config import settings
+from wet_mcp.llm import analyze_media
 from wet_mcp.sources.crawler import download_media
 
 
@@ -58,3 +60,47 @@ async def test_download_media_safe(tmp_path):
             expected_file = tmp_path / "image.png"
             assert expected_file.exists()
             assert expected_file.read_bytes() == b"safe content"
+
+
+@pytest.mark.asyncio
+async def test_analyze_media_path_traversal(tmp_path):
+    """Test that analyze_media prevents path traversal."""
+    # Setup directories
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+
+    # Create a secret file outside download_dir
+    secret_file = tmp_path / "secret.txt"
+    secret_content = "This is a secret file"
+    secret_file.write_text(secret_content)
+
+    # Configure settings
+    original_download_dir = settings.download_dir
+    original_api_keys = settings.api_keys
+    settings.download_dir = str(download_dir)
+    settings.api_keys = "fake-provider:fake-key"
+
+    try:
+        # Mock LLM response
+        with patch("wet_mcp.llm.acompletion") as mock_completion:
+            mock_response = MagicMock()
+            mock_response.choices[0].message.content = "Analysis result"
+            mock_completion.return_value = mock_response
+
+            # Call analyze_media with the secret file path
+            result = await analyze_media(str(secret_file))
+
+            # Verify that the file was NOT read
+            assert "Security Alert" in result
+            assert secret_content not in result
+
+            # Verify LLM was NOT called with secret content
+            if mock_completion.called:
+                call_args = mock_completion.call_args[1]
+                messages = call_args.get("messages", [])
+                if messages:
+                    content_sent = messages[0]["content"]
+                    assert secret_content not in content_sent
+    finally:
+        settings.download_dir = original_download_dir
+        settings.api_keys = original_api_keys

--- a/uv.lock
+++ b/uv.lock
@@ -1966,7 +1966,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.5.1"
+version = "2.5.2b2"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },
@@ -1982,6 +1982,9 @@ dependencies = [
 full = [
     { name = "qwen3-embed" },
     { name = "sqlite-vec" },
+]
+gguf = [
+    { name = "qwen3-embed" },
 ]
 local = [
     { name = "qwen3-embed" },
@@ -2011,10 +2014,11 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "qwen3-embed", marker = "extra == 'full'", specifier = ">=0.2.0" },
     { name = "qwen3-embed", marker = "extra == 'local'", specifier = ">=0.2.0" },
+    { name = "qwen3-embed", extras = ["gguf"], marker = "extra == 'gguf'", specifier = ">=0.2.0" },
     { name = "sqlite-vec", marker = "extra == 'full'" },
     { name = "sqlite-vec", marker = "extra == 'vector'" },
 ]
-provides-extras = ["vector", "local", "full"]
+provides-extras = ["vector", "local", "gguf", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
**Vulnerability:** Path Traversal / Arbitrary File Read in `analyze_media`.
**Impact:** Attackers could use the `media` tool with `action="analyze"` to read any file accessible by the process (e.g., `/etc/passwd`) by providing an absolute path or relative path with `..`.
**Fix:**
1.  Implemented `is_safe_path` in `src/wet_mcp/security.py` using `pathlib`'s `resolve()` and `is_relative_to()`.
2.  Enforced `is_safe_path` check in `src/wet_mcp/llm.py` before checking for file existence or reading content.
3.  Updated tests to verify the fix and prevent regressions.

**Verification:**
- Run `uv run pytest tests/test_security_path_traversal.py` to verify the fix.
- Run `uv run pytest tests/test_llm.py` to ensure no regressions in normal functionality.

---
*PR created automatically by Jules for task [10035137092527850862](https://jules.google.com/task/10035137092527850862) started by @n24q02m*