### PR TITLE
Refactor: Move `_read_and_truncate` to module level in `src/wet_mcp/llm.py`

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -61,6 +61,15 @@ def encode_image(image_path: str) -> str:
         return base64.b64encode(image_file.read()).decode("utf-8")
 
 
+def _read_and_truncate(path: str) -> str:
+    """Read file and truncate if too long."""
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    if len(text) > 100000:
+        text = text[:100000] + "\n...[truncated]"
+    return text
+
+
 async def analyze_media(
     media_path: str, prompt: str = "Describe this media in detail."
 ) -> str:
@@ -83,15 +92,6 @@ async def analyze_media(
         "application/javascript",
         "application/xml",
     ]:
-
-        def _read_and_truncate(path: str) -> str:
-            """Read file and truncate if too long."""
-            with open(path, encoding="utf-8") as f:
-                text = f.read()
-            if len(text) > 100000:
-                text = text[:100000] + "\n...[truncated]"
-            return text
-
         try:
             content = await asyncio.to_thread(_read_and_truncate, media_path)
 


### PR DESCRIPTION
Moved the inner function `_read_and_truncate` from inside `analyze_media` to the module level in `src/wet_mcp/llm.py`.

**1. What:**
Moved `_read_and_truncate` to the module level.

**2. Why:**
This improves code organization and testability by making the function accessible independently and reducing the complexity of `analyze_media`.

**3. Verification:**
Ran `uv run pytest tests/test_llm.py` and all tests passed.

**4. Result:**
The code is cleaner and the function is now reusable and testable in isolation if needed.

---
*PR created automatically by Jules for task [17405720202449670648](https://jules.google.com/task/17405720202449670648) started by @n24q02m*