### PR TITLE
REF: Remove unused `remove_searxng` function

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -753,8 +753,3 @@ def _get_process_kwargs() -> dict:
 def stop_searxng() -> None:
     """Stop SearXNG subprocess if running."""
     _cleanup_process()
-
-
-def remove_searxng() -> None:
-    """Stop SearXNG subprocess (alias for compatibility)."""
-    _cleanup_process()


### PR DESCRIPTION
Removed unused function `remove_searxng` from `src/wet_mcp/searxng_runner.py`.

*   **What:** Removed `remove_searxng` function from `src/wet_mcp/searxng_runner.py`.
*   **Why:** The function was a dead alias for `_cleanup_process` and was not used anywhere in the codebase.
*   **Verification:**
    *   Verified that `remove_searxng` was not imported or called elsewhere using `grep`.
    *   Verified that `stop_searxng` (the preferred alias) is used and remains functional.
    *   Ran `ruff check .` and `ruff format .` via `uv` (passed).
    *   Ran `uv run pytest tests/test_searxng_runner.py tests/test_server.py` (passed).
    *   Ran `uv run ty check` (passed).
*   **Result:** Reduced code clutter and maintenance overhead.

---
*PR created automatically by Jules for task [10257124632066450334](https://jules.google.com/task/10257124632066450334) started by @n24q02m*