### PR TITLE
chore(crawler): fix `ty: ignore` typo in type suppression comments

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -203,9 +203,9 @@ async def extract(
 
             try:
                 result = await crawler.arun(
-                    url,  # ty: ignore[invalid-argument-type]
+                    url,  # type: ignore[invalid-argument-type]
                     config=run_config,
-                )  # ty: ignore[missing-argument]
+                )  # type: ignore[missing-argument]
 
                 if result.success:
                     content = (
@@ -285,9 +285,9 @@ async def crawl(
             async with sem:
                 try:
                     result = await crawler.arun(
-                        url,  # ty: ignore[invalid-argument-type]
+                        url,  # type: ignore[invalid-argument-type]
                         config=CrawlerRunConfig(verbose=False),
-                    )  # ty: ignore[missing-argument]
+                    )  # type: ignore[missing-argument]
 
                     if result.success:
                         content = (
@@ -367,9 +367,9 @@ async def sitemap(
             async with sem:
                 try:
                     result = await crawler.arun(
-                        url,  # ty: ignore[invalid-argument-type]
+                        url,  # type: ignore[invalid-argument-type]
                         config=CrawlerRunConfig(verbose=False),
-                    )  # ty: ignore[missing-argument]
+                    )  # type: ignore[missing-argument]
 
                     if result.success and current_depth < depth:
                         for link in result.links.get("internal", [])[:20]:
@@ -414,9 +414,9 @@ async def list_media(
 
     async with sem:
         result = await crawler.arun(
-            url,  # ty: ignore[invalid-argument-type]
+            url,  # type: ignore[invalid-argument-type]
             config=CrawlerRunConfig(verbose=False),
-        )  # ty: ignore[missing-argument]
+        )  # type: ignore[missing-argument]
 
         if not result.success:
             return json.dumps({"error": result.error_message or "Failed to load page"})


### PR DESCRIPTION
🎯 **What:**
- Fixed typo in type hint suppression comments in `src/wet_mcp/sources/crawler.py`.
- Replaced `# ty: ignore` with `# type: ignore` in multiple locations.

💡 **Why:**
- Ensures that type checkers (like Mypy, Pyright, and the project's `ty` tool) correctly recognize the suppression comments.
- Improves code health and adherence to Python standards.

✅ **Verification:**
- Ran `uv run ty check` to verify type checking passes.
- Ran `uv run ruff check .` to verify linting passes.
- Ran `uv run pytest` (259 tests passed) to ensure no regressions.

✨ **Result:**
- The codebase now uses standard type suppression syntax.

---
*PR created automatically by Jules for task [6989430073131773217](https://jules.google.com/task/6989430073131773217) started by @n24q02m*