### PR TITLE
🧪 Improve test coverage for _find_available_port

### DIFF
--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from wet_mcp.searxng_runner import _get_settings_path
+from wet_mcp.searxng_runner import _get_settings_path, _find_available_port
 
 
 def test_get_settings_path():
@@ -53,3 +53,63 @@ def test_get_settings_path():
         # Verify write_text called with correct content
         expected_content = "server:\n  port: 9090\n"
         mock_settings_file.write_text.assert_called_once_with(expected_content)
+
+
+def test_find_available_port_success():
+    start_port = 8080
+
+    # Mock socket context manager
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.__enter__.return_value = mock_socket_instance
+    mock_socket_instance.__exit__.return_value = None
+
+    with patch("wet_mcp.searxng_runner.socket.socket", return_value=mock_socket_instance) as mock_socket_ctor,          patch("random.shuffle", side_effect=lambda x: None):  # No-op shuffle
+
+        port = _find_available_port(start_port)
+
+        assert port == 8080
+        mock_socket_ctor.assert_called()
+        mock_socket_instance.bind.assert_called_with(("127.0.0.1", 8080))
+
+
+def test_find_available_port_collision():
+    start_port = 8080
+
+    # Mock socket context manager
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.__enter__.return_value = mock_socket_instance
+    mock_socket_instance.__exit__.return_value = None
+
+    # First bind fails, second succeeds
+    mock_socket_instance.bind.side_effect = [OSError("Address in use"), None]
+
+    with patch("wet_mcp.searxng_runner.socket.socket", return_value=mock_socket_instance) as mock_socket_ctor,          patch("random.shuffle", side_effect=lambda x: None):  # No-op shuffle
+
+        port = _find_available_port(start_port)
+
+        assert port == 8081
+        assert mock_socket_ctor.call_count == 2
+        # Verify calls
+        mock_socket_instance.bind.assert_any_call(("127.0.0.1", 8080))
+        mock_socket_instance.bind.assert_any_call(("127.0.0.1", 8081))
+
+
+def test_find_available_port_all_taken():
+    start_port = 8080
+    max_tries = 3
+
+    # Mock socket context manager
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.__enter__.return_value = mock_socket_instance
+    mock_socket_instance.__exit__.return_value = None
+
+    # Always fail
+    mock_socket_instance.bind.side_effect = OSError("Address in use")
+
+    with patch("wet_mcp.searxng_runner.socket.socket", return_value=mock_socket_instance) as mock_socket_ctor,          patch("random.shuffle", side_effect=lambda x: None):  # No-op shuffle
+
+        port = _find_available_port(start_port, max_tries=max_tries)
+
+        # Returns start_port if all fail (based on implementation)
+        assert port == 8080
+        assert mock_socket_ctor.call_count == max_tries


### PR DESCRIPTION
This PR improves test coverage for the `_find_available_port` function in `src/wet_mcp/searxng_runner.py`.

🎯 **What:**
- Added unit tests for `_find_available_port` in `tests/test_searxng_runner.py`.
- Mocked `socket.socket` and `random.shuffle` to ensure deterministic behavior and isolate network operations.

📊 **Coverage:**
- **Success Case:** Verifies that the function returns the starting port when it is available.
- **Collision Case:** Verifies that the function correctly retries with the next port when the first one is taken (`OSError`).
- **All Taken Case:** Verifies the fallback behavior when all attempts fail.

✨ **Result:**
- Verified that `_find_available_port` logic is sound and robust against port conflicts.
- All tests passed, including full regression suite.

---
*PR created automatically by Jules for task [4619573773890904330](https://jules.google.com/task/4619573773890904330) started by @n24q02m*