### PR TITLE
🧹 Refactor hardcoded crawler timeout to use settings

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -18,6 +18,7 @@ import httpx
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 from loguru import logger
 
+from wet_mcp.config import settings
 from wet_mcp.security import is_safe_url
 
 # ---------------------------------------------------------------------------
@@ -510,7 +511,7 @@ async def download_media(
                 }
 
     async with httpx.AsyncClient(
-        timeout=60, transport=transport, headers=headers
+        timeout=settings.crawler_timeout, transport=transport, headers=headers
     ) as client:
         tasks = [_download_one(url, client) for url in media_urls]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
🎯 **What:**
- Replaced the hardcoded `timeout=60` in `src/wet_mcp/sources/crawler.py` (specifically in `download_media` function) with `settings.crawler_timeout`.

💡 **Why:**
- Improves maintainability by centralizing configuration.
- Allows the timeout value to be configured via environment variables (e.g., `CRAWLER_TIMEOUT`), consistent with other settings.

✅ **Verification:**
- Verified that `settings.crawler_timeout` defaults to 60, preserving existing behavior.
- Ran unit tests `tests/test_crawler_unit.py` and `tests/test_ssrf_download_media.py` (using `uv run pytest`) to ensure no regressions.
- Confirmed that the timeout is configurable by temporarily modifying the environment variable in a test.
- Temporarily modified `pyproject.toml` to allow testing in the current environment (Python 3.12) due to `qwen3-embed`'s Python 3.13 requirement, and successfully reverted these changes.

✨ **Result:**
- The crawler's media download timeout is now configurable and no longer hardcoded.

---
*PR created automatically by Jules for task [6759378030864198704](https://jules.google.com/task/6759378030864198704) started by @n24q02m*