### PR TITLE
🧹 Extract hardcoded timeout in crawler.py to settings

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -18,6 +18,7 @@ import httpx
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 from loguru import logger
 
+from wet_mcp.config import settings
 from wet_mcp.security import is_safe_url
 
 # ---------------------------------------------------------------------------
@@ -510,7 +511,7 @@ async def download_media(
                 }
 
     async with httpx.AsyncClient(
-        timeout=60, transport=transport, headers=headers
+        timeout=settings.crawler_timeout, transport=transport, headers=headers
     ) as client:
         tasks = [_download_one(url, client) for url in media_urls]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
  - Extracted the hardcoded timeout value (60) in `src/wet_mcp/sources/crawler.py` to use `settings.crawler_timeout`.
  - This ensures the `download_media` function uses the configured timeout value from `wet_mcp/config.py`.

💡 **Why:** How this improves maintainability
  - Allows the timeout to be configured via environment variables or configuration files instead of being hardcoded in the source code.
  - Ensures consistency with other crawler-related timeouts.

✅ **Verification:** How you confirmed the change is safe
  - Verified that `settings.crawler_timeout` exists and is set to 60 (preserving default behavior).
  - Ran unit tests `tests/test_crawler_unit.py` and `tests/test_ssrf_download_media.py` which passed (after patching environment).
  - Verified import order using `ruff`.

✨ **Result:** The improvement achieved
  - The codebase is now more configurable and maintainable.

---
*PR created automatically by Jules for task [6734404356937603035](https://jules.google.com/task/6734404356937603035) started by @n24q02m*