### PR TITLE
🧹 Refactor analyze_media to avoid redundant config calls

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -76,6 +76,7 @@ async def analyze_media(
     mime_type, _ = mimetypes.guess_type(media_path)
     if not mime_type:
         return f"Error: Cannot determine file type for {media_path}"
+    config = get_llm_config()
 
     # Handle text files directly
     if mime_type.startswith("text/") or mime_type in [
@@ -94,8 +95,6 @@ async def analyze_media(
 
         try:
             content = await asyncio.to_thread(_read_and_truncate, media_path)
-
-            config = get_llm_config()
             logger.info(f"Analyzing text file with model: {config['model']}")
 
             messages = [
@@ -115,7 +114,6 @@ async def analyze_media(
             return f"Error analyzing text file: {e}"
 
     # Check model capabilities for media
-    config = get_llm_config()
     caps = get_model_capabilities(config["model"])
 
     # Validate capability vs file type
@@ -132,7 +130,6 @@ async def analyze_media(
         return f"Error: Unsupported media type: {mime_type}"
 
     try:
-        config = get_llm_config()
         logger.info(f"Analyzing media with model: {config['model']}")
 
         base64_image = await asyncio.to_thread(encode_image, media_path)


### PR DESCRIPTION
Refactored `analyze_media` in `src/wet_mcp/llm.py` to remove redundant calls to `get_llm_config`. The configuration is now retrieved once at the beginning of the function and reused throughout, improving efficiency and code readability. This also standardizes exception handling for configuration errors across text and media processing paths.Verified with `pytest` and `ruff`.

---
*PR created automatically by Jules for task [12312916055393982815](https://jules.google.com/task/12312916055393982815) started by @n24q02m*