### PR TITLE
⚡ Bolt: Optimize crawler queue with deque

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-23 - BFS Queue Optimization
+**Learning:** Python's `list.pop(0)` is O(n), which can become a bottleneck in queue-based algorithms like BFS crawlers. `collections.deque.popleft()` is O(1).
+**Action:** Always use `collections.deque` for FIFO queues.

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import os
 import tempfile
+from collections import deque
 from pathlib import Path
 
 import httpx
@@ -272,10 +273,11 @@ async def crawl(
             logger.warning(f"Skipping unsafe URL: {root_url}")
             continue
 
-        to_crawl: list[tuple[str, int]] = [(root_url, 0)]
+        # Use deque for O(1) pops from the left, compared to O(n) for list.pop(0)
+        to_crawl: deque[tuple[str, int]] = deque([(root_url, 0)])
 
         while to_crawl and len(all_results) < max_pages:
-            url, current_depth = to_crawl.pop(0)
+            url, current_depth = to_crawl.popleft()
 
             if url in visited or current_depth > depth:
                 continue
@@ -352,11 +354,12 @@ async def sitemap(
             logger.warning(f"Skipping unsafe URL: {root_url}")
             continue
 
-        to_visit: list[tuple[str, int]] = [(root_url, 0)]
+        # Use deque for O(1) pops from the left, compared to O(n) for list.pop(0)
+        to_visit: deque[tuple[str, int]] = deque([(root_url, 0)])
         site_urls: list[dict[str, object]] = []
 
         while to_visit and len(site_urls) < max_pages:
-            url, current_depth = to_visit.pop(0)
+            url, current_depth = to_visit.popleft()
 
             if url in visited or current_depth > depth:
                 continue

--- a/uv.lock
+++ b/uv.lock
@@ -1966,7 +1966,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.6.3"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
💡 What: Replaced Python lists with `collections.deque` for crawler queues.
🎯 Why: `list.pop(0)` is an O(n) operation, which can degrade performance as the queue grows. `deque.popleft()` is O(1).
📊 Impact: Reduced time complexity for queue operations from O(n^2) to O(n) for the entire crawl process.
🔬 Measurement: Verified with existing tests `tests/test_crawler_unit.py` and `tests/test_crawler_sitemap.py`.

---
*PR created automatically by Jules for task [5082245629710458312](https://jules.google.com/task/5082245629710458312) started by @n24q02m*