### PR TITLE
🔒 Fix Arbitrary File Write via Media Tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -632,7 +632,6 @@ async def media(
     url: str | None = None,
     media_type: str = "all",
     media_urls: list[str] | None = None,
-    output_dir: str | None = None,
     max_items: int = 10,
     prompt: str = "Describe this image in detail.",
 ) -> str:
@@ -664,7 +663,7 @@ async def media(
             return await _with_timeout(
                 download_media(
                     media_urls=media_urls,
-                    output_dir=output_dir or settings.download_dir,
+                    output_dir=settings.download_dir,
                 ),
                 "media.download",
             )

--- a/tests/test_media_tool.py
+++ b/tests/test_media_tool.py
@@ -39,30 +39,13 @@ async def test_media_list_missing_url():
 
 @pytest.mark.asyncio
 async def test_media_download_success(mock_settings):
-    """Test media download action successfully calls download_media."""
+    """Test media download action successfully calls download_media with default dir."""
     mock_download_media = AsyncMock(return_value='["file1.jpg"]')
 
     with patch("wet_mcp.sources.crawler.download_media", mock_download_media):
         result = await media(
             action="download",
             media_urls=["http://example.com/img.jpg"],
-            output_dir="/custom/dir",
-        )
-
-        mock_download_media.assert_called_once_with(
-            media_urls=["http://example.com/img.jpg"], output_dir="/custom/dir"
-        )
-        assert result == '["file1.jpg"]'
-
-
-@pytest.mark.asyncio
-async def test_media_download_default_dir(mock_settings):
-    """Test media download action uses default directory if not provided."""
-    mock_download_media = AsyncMock(return_value='["file1.jpg"]')
-
-    with patch("wet_mcp.sources.crawler.download_media", mock_download_media):
-        result = await media(
-            action="download", media_urls=["http://example.com/img.jpg"]
         )
 
         mock_download_media.assert_called_once_with(

--- a/uv.lock
+++ b/uv.lock
@@ -1966,7 +1966,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.6.3"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
Removes the `output_dir` parameter from the `media` tool in `src/wet_mcp/server.py` to prevent arbitrary file write vulnerabilities.
Files are now always downloaded to the configured `settings.download_dir`.
Updates `tests/test_media_tool.py` to reflect this API change.

Fixes: Arbitrary File Write via Media Tool

---
*PR created automatically by Jules for task [7768223223955245226](https://jules.google.com/task/7768223223955245226) started by @n24q02m*