### PR TITLE
Security: Fix SSRF bypass via redirects in media download

### DIFF
--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -13,6 +13,7 @@ async def test_download_media_path_traversal(tmp_path):
     mock_response = MagicMock()
     mock_response.content = b"fake content"
     mock_response.raise_for_status = MagicMock()
+    mock_response.is_redirect = False  # Important for manual redirect loop
 
     # Mock httpx client context manager
     mock_client = AsyncMock()
@@ -44,6 +45,7 @@ async def test_download_media_safe(tmp_path):
     mock_response = MagicMock()
     mock_response.content = b"safe content"
     mock_response.raise_for_status = MagicMock()
+    mock_response.is_redirect = False  # Important for manual redirect loop
 
     mock_client = AsyncMock()
     mock_client.get.return_value = mock_response


### PR DESCRIPTION
This change fixes a Server-Side Request Forgery (SSRF) vulnerability in the `download_media` function. Previously, `httpx` was configured to automatically follow redirects (`follow_redirects=True`), which bypassed the initial `is_safe_url` check if a safe URL redirected to an unsafe internal IP (e.g., via an open redirect).

The fix implements a manual redirect loop that:
1. Validates the URL *before* every request using `is_safe_url`.
2. Handles redirects explicitly (up to 5 hops) using `response.headers.get("Location")` and `urljoin`.
3. Ensures that every hop in the redirect chain is safe, effectively blocking SSRF attacks that rely on redirecting to private network resources.

Tests in `tests/test_security_path_traversal.py` were updated to compatible mocks.

---
*PR created automatically by Jules for task [7641052933206915672](https://jules.google.com/task/7641052933206915672) started by @n24q02m*