### PR TITLE
⚡ Bolt: Optimize SQLite document and vector bulk inserts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - SQLite Insert Optimization
+**Learning:** Using `sqlite3.Cursor.executemany` for bulk inserting records into SQLite tables and virtual tables (like `sqlite-vec`) is significantly faster and more resource-efficient than iterating and calling `.execute()` individually for each row inside a loop. This avoids multiple context switches between Python and SQLite, as well as multiple internal statement preparations per row.
+**Action:** When bulk inserting documents, vectors, or chunks into an SQLite database (including vector search tables), always construct a list of parameter tuples and use `executemany()`.

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -500,14 +500,13 @@ class DocsDB:
         Each chunk dict: {url, title, content, heading_path, chunk_index}
         """
         now = _now_ts()
-        count = 0
+
+        chunk_params = []
+        vec_params = []
 
         for i, chunk in enumerate(chunks):
             chunk_id = uuid.uuid4().hex[:12]
-            self._conn.execute(
-                """INSERT INTO doc_chunks
-                   (id, version_id, library_id, url, title, chunk_index, content, heading_path, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            chunk_params.append(
                 (
                     chunk_id,
                     version_id,
@@ -518,7 +517,7 @@ class DocsDB:
                     chunk["content"],
                     chunk.get("heading_path", ""),
                     now,
-                ),
+                )
             )
 
             # Store embedding if available
@@ -528,18 +527,28 @@ class DocsDB:
                 and i < len(embeddings)
                 and embeddings[i]
             ):
-                try:
-                    self._conn.execute(
-                        "INSERT INTO doc_chunks_vec (id, embedding) VALUES (?, ?)",
-                        (chunk_id, _serialize_f32(embeddings[i])),
-                    )
-                except Exception as e:
-                    logger.debug(f"Failed to store embedding: {e}")
+                vec_params.append((chunk_id, _serialize_f32(embeddings[i])))
 
-            count += 1
+        # Bulk insert chunks
+        self._conn.executemany(
+            """INSERT INTO doc_chunks
+               (id, version_id, library_id, url, title, chunk_index, content, heading_path, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            chunk_params,
+        )
+
+        # Bulk insert embeddings if any exist and feature is enabled
+        if self._vec_enabled and vec_params:
+            try:
+                self._conn.executemany(
+                    "INSERT INTO doc_chunks_vec (id, embedding) VALUES (?, ?)",
+                    vec_params,
+                )
+            except Exception as e:
+                logger.debug(f"Failed to store batch embeddings: {e}")
 
         self._conn.commit()
-        return count
+        return len(chunk_params)
 
     def clear_version_chunks(self, version_id: str) -> int:
         """Remove all chunks for a version (before re-indexing)."""


### PR DESCRIPTION
💡 What: Refactored `add_chunks` within `src/wet_mcp/db.py` to use `executemany` instead of single `execute` statements within an iteration loop.
🎯 Why: Iterating over an array of dictionaries and performing an individual SQLite `execute` operation on every single item results in N+1 overhead due to constant context switching between Python and C/SQLite engine, as well as repetitive query preparation phases.
📊 Impact: Considerably faster throughput of batched inserts for the chunk storage functionality of the `DocsDB` process, speeding up background document indexing operations.
🔬 Measurement: Verify changes in the code logic manually within the `db.py` and run the `tests/test_db.py` to observe that functional output behavior strictly mirrors previous outputs.

---
*PR created automatically by Jules for task [7342375950768214599](https://jules.google.com/task/7342375950768214599) started by @n24q02m*