### PR TITLE
🧹 Refactor _lifespan context manager for better code readability

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -81,14 +81,8 @@ async def _warmup_searxng() -> None:
         logger.debug(f"SearXNG pre-warm failed (non-fatal): {e}")
 
 
-@asynccontextmanager
-async def _lifespan(_server: FastMCP):
-    """Server lifespan: startup SearXNG, init cache/docs DB, cleanup on shutdown."""
-    global _web_cache, _docs_db, _embedding_dims
-
-    logger.info("Starting WET MCP Server...")
-
-    # 1. Setup API keys (+ aliases like GOOGLE_API_KEY -> GEMINI_API_KEY)
+def _setup_api_keys() -> dict:
+    """Setup API keys and log warnings for missing optional keys."""
     from wet_mcp.config import settings
 
     keys = settings.setup_api_keys()
@@ -101,23 +95,26 @@ async def _lifespan(_server: FastMCP):
             "No GITHUB_TOKEN set. Library docs discovery will use unauthenticated "
             "GitHub API (60 req/hr limit). Set GITHUB_TOKEN for 5000 req/hr."
         )
+    return keys
 
-    # SearXNG is pre-warmed eagerly as a background task to eliminate
-    # startup latency on the first search call. If this instance finds an
-    # existing healthy SearXNG (started by another MCP server instance), it
-    # reuses it instead of spawning a new subprocess.
-    _searxng_warmup_task: asyncio.Task | None = None
-    if settings.wet_auto_searxng:
-        _searxng_warmup_task = asyncio.create_task(_warmup_searxng())
 
-    # 2. Initialize web cache
+def _setup_cache() -> None:
+    """Initialize web cache."""
+    global _web_cache
+    from wet_mcp.config import settings
+
     if settings.wet_cache:
         cache_path = settings.get_cache_db_path()
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         _web_cache = WebCache(cache_path)
         logger.info("Web cache enabled")
 
-    # 3. Initialize embedding backend (dual-backend: litellm or local)
+
+def _setup_backends(keys: dict) -> None:
+    """Initialize embedding and reranker backends in background."""
+    global _embedding_dims
+    from wet_mcp.config import settings
+
     _embedding_dims = settings.resolve_embedding_dims()
     if _embedding_dims == 0:
         _embedding_dims = _DEFAULT_EMBEDDING_DIMS
@@ -131,20 +128,26 @@ async def _lifespan(_server: FastMCP):
 
     asyncio.create_task(_init_backends_task())
 
-    # 5. Initialize docs DB
+
+def _setup_db() -> None:
+    """Initialize documentation database and auto-sync."""
+    global _docs_db, _embedding_dims
+    from wet_mcp.config import settings
+
     docs_path = settings.get_db_path()
     docs_path.parent.mkdir(parents=True, exist_ok=True)
     _docs_db = DocsDB(docs_path, embedding_dims=_embedding_dims)
 
-    # Start auto-sync if configured
     if settings.sync_enabled:
         from wet_mcp.sync import start_auto_sync
 
         start_auto_sync(_docs_db)
 
-    yield
 
-    logger.info("Shutting down WET MCP Server...")
+async def _shutdown_services(_searxng_warmup_task: asyncio.Task | None) -> None:
+    """Clean up tasks, auto-sync, databases, and background processes."""
+    global _docs_db, _web_cache
+    from wet_mcp.config import settings
 
     # Cancel SearXNG warmup task if still running
     if _searxng_warmup_task and not _searxng_warmup_task.done():
@@ -175,6 +178,29 @@ async def _lifespan(_server: FastMCP):
         logger.debug(f"Browser pool shutdown error (non-fatal): {exc}")
 
     stop_searxng()
+
+
+@asynccontextmanager
+async def _lifespan(_server: FastMCP):
+    """Server lifespan: startup SearXNG, init cache/docs DB, cleanup on shutdown."""
+    logger.info("Starting WET MCP Server...")
+
+    keys = _setup_api_keys()
+
+    from wet_mcp.config import settings
+
+    _searxng_warmup_task: asyncio.Task | None = None
+    if settings.wet_auto_searxng:
+        _searxng_warmup_task = asyncio.create_task(_warmup_searxng())
+
+    _setup_cache()
+    _setup_backends(keys)
+    _setup_db()
+
+    yield
+
+    logger.info("Shutting down WET MCP Server...")
+    await _shutdown_services(_searxng_warmup_task)
 
 
 async def _init_embedding_backend(keys: dict) -> None:


### PR DESCRIPTION
🎯 **What:** Extracted the monolithic server lifespan configuration and teardown into focused helper functions within `src/wet_mcp/server.py`.
💡 **Why:** Improved maintainability and readability by separating `_setup_api_keys()`, `_setup_cache()`, `_setup_backends()`, `_setup_db()`, and `_shutdown_services()` out of the monolithic `_lifespan()` async context manager. This structure keeps individual initialization logic isolated and makes the overall system startup procedure easier to read.
✅ **Verification:** Verified via test suite (`pytest`) specifically `test_server.py`, `test_server_comprehensive.py` and `test_server_timeout.py`, and confirmed that format and linter (`ruff format`, `ruff check`) both pass clean. Tests assert that the server initializes with the necessary configurations and cleanly shuts down.
✨ **Result:** Cleaned up `_lifespan()` significantly; the main entry flow for startup/shutdown is now well-abstracted into descriptive functions.

---
*PR created automatically by Jules for task [9624952097044274826](https://jules.google.com/task/9624952097044274826) started by @n24q02m*