### PR TITLE
🧹 Remove dead legacy functions in embedder.py

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -348,33 +348,3 @@ def init_backend(backend_type: str, model: str | None = None) -> EmbeddingBacken
         raise ValueError(f"Unknown backend type: {backend_type}")
 
     return _backend
-
-
-# Legacy module-level functions for backward compatibility
-def embed_texts(
-    texts: list[str],
-    model: str,
-    dimensions: int | None = None,
-) -> list[list[float]]:
-    """Embed texts using LiteLLM (legacy interface).
-
-    Kept for backward compatibility. Prefer using backend instances directly.
-    """
-    backend = LiteLLMBackend(model)
-    return backend.embed_texts(texts, dimensions)
-
-
-def embed_single(
-    text: str,
-    model: str,
-    dimensions: int | None = None,
-) -> list[float]:
-    """Embed a single text (legacy interface)."""
-    backend = LiteLLMBackend(model)
-    return backend.embed_single(text, dimensions)
-
-
-def check_embedding_available(model: str) -> int:
-    """Check if an embedding model is available (legacy interface)."""
-    backend = LiteLLMBackend(model)
-    return backend.check_available()

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -412,51 +412,6 @@ class TestBackendFactory:
 
 
 # -----------------------------------------------------------------------
-# Legacy compatibility functions
-# -----------------------------------------------------------------------
-
-
-class TestLegacyCompat:
-    def test_embed_texts_legacy(self):
-        """Legacy embed_texts function works."""
-        from wet_mcp.embedder import embed_texts
-
-        mock_response = MagicMock()
-        mock_response.data = [
-            {"index": 0, "embedding": [0.1, 0.2, 0.3]},
-        ]
-
-        with patch("litellm.embedding", return_value=mock_response):
-            vecs = embed_texts(["hello"], model="text-embedding-3-small")
-
-        assert vecs == [[0.1, 0.2, 0.3]]
-
-    def test_embed_single_legacy(self):
-        """Legacy embed_single function works."""
-        from wet_mcp.embedder import embed_single
-
-        mock_response = MagicMock()
-        mock_response.data = [{"index": 0, "embedding": [0.1, 0.2]}]
-
-        with patch("litellm.embedding", return_value=mock_response):
-            vec = embed_single("hello", model="test-model")
-
-        assert vec == [0.1, 0.2]
-
-    def test_check_embedding_available_legacy(self):
-        """Legacy check_embedding_available works."""
-        from wet_mcp.embedder import check_embedding_available
-
-        mock_response = MagicMock()
-        mock_response.data = [{"index": 0, "embedding": [0.0] * 768}]
-
-        with patch("litellm.embedding", return_value=mock_response):
-            dims = check_embedding_available("text-embedding-3-small")
-
-        assert dims == 768
-
-
-# -----------------------------------------------------------------------
 # LiteLLM logging suppression
 # -----------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Removed the legacy module-level functions `embed_texts`, `embed_single`, and `check_embedding_available` from `src/wet_mcp/embedder.py` and deleted their corresponding unit tests (`TestLegacyCompat`) in `tests/test_embedder.py`.
💡 **Why:** These functions were marked as deprecated legacy interfaces and not used internally. Removing them reduces boilerplate, clears dead code, and improves codebase readability and maintainability.
✅ **Verification:** Verified by running `uv run pytest tests/test_embedder.py` and `uv run ruff check . --fix && uv run ruff format .` to ensure the removal did not introduce any test or lint regressions.
✨ **Result:** A cleaner and more maintainable `embedder.py` module with only the required `EmbeddingBackend` interfaces and implementations.

---
*PR created automatically by Jules for task [17104194966836659198](https://jules.google.com/task/17104194966836659198) started by @n24q02m*