### PR TITLE
🧪 Add tests for server help tool

### DIFF
--- a/tests/test_server_help.py
+++ b/tests/test_server_help.py
@@ -1,0 +1,68 @@
+"""Tests for the help tool in src/wet_mcp/server.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wet_mcp.server import help
+
+
+@pytest.mark.asyncio
+async def test_help_success():
+    """Test help tool success path."""
+    with patch("wet_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.read_text.return_value = "# Search Tool\nDocumentation here."
+        mock_files.return_value.joinpath.return_value = mock_path
+
+        result = await help(tool_name="search")
+
+        assert result == "# Search Tool\nDocumentation here."
+        mock_files.assert_called_once_with("wet_mcp.docs")
+        mock_files.return_value.joinpath.assert_called_once_with("search.md")
+        mock_path.read_text.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_help_default():
+    """Test help tool with default argument."""
+    with patch("wet_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.read_text.return_value = "# Default Tool\nDocs."
+        mock_files.return_value.joinpath.return_value = mock_path
+
+        result = await help()
+
+        assert result == "# Default Tool\nDocs."
+        mock_files.assert_called_once_with("wet_mcp.docs")
+        mock_files.return_value.joinpath.assert_called_once_with("search.md")
+
+
+@pytest.mark.asyncio
+async def test_help_file_not_found():
+    """Test help tool when documentation file is not found."""
+    with patch("wet_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.read_text.side_effect = FileNotFoundError()
+        mock_files.return_value.joinpath.return_value = mock_path
+
+        result = await help(tool_name="nonexistent")
+
+        assert result == "Error: No documentation found for tool 'nonexistent'"
+        mock_files.assert_called_once_with("wet_mcp.docs")
+        mock_files.return_value.joinpath.assert_called_once_with("nonexistent.md")
+
+
+@pytest.mark.asyncio
+async def test_help_generic_exception():
+    """Test help tool handles generic exceptions."""
+    with patch("wet_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.read_text.side_effect = Exception("Disk error")
+        mock_files.return_value.joinpath.return_value = mock_path
+
+        result = await help(tool_name="extract")
+
+        assert result == "Error loading documentation: Disk error"
+        mock_files.assert_called_once_with("wet_mcp.docs")
+        mock_files.return_value.joinpath.assert_called_once_with("extract.md")

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Added tests to cover the untested `help` tool in `src/wet_mcp/server.py`.
📊 **Coverage:** Covered success path (loading an existing doc), default parameter `tool_name="search"`, `FileNotFoundError` branch, and generic `Exception` fallback using `unittest.mock.patch` on `importlib.resources.files`.
✨ **Result:** Improved test coverage and reliability for the `help` tool. Tests are fast and properly isolated.

---
*PR created automatically by Jules for task [751224626091714113](https://jules.google.com/task/751224626091714113) started by @n24q02m*