### PR TITLE
🔒 Fix unbounded crawling resource exhaustion in extract tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -554,6 +554,9 @@ async def search(
 # ---------------------------------------------------------------------------
 
 
+_MAX_PAGES_LIMIT = 100
+
+
 @mcp.tool(
     annotations=ToolAnnotations(
         readOnlyHint=True,
@@ -575,6 +578,7 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    max_pages = min(max_pages, _MAX_PAGES_LIMIT)
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,47 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_max_pages_limit():
+    """Test that max_pages is correctly clamped to _MAX_PAGES_LIMIT (100)."""
+    with patch("wet_mcp.server._crawl", new_callable=AsyncMock) as mock_crawl:
+        mock_crawl.return_value = "Crawl Results"
+
+        result = await extract(
+            action="crawl",
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=150,  # exceeds limit
+            format="json",
+            stealth=False,
+        )
+
+        assert "Crawl Results" in result
+        assert "<untrusted_extract_content>" in result
+        mock_crawl.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=100,  # should be clamped to 100
+            format="json",
+            stealth=False,
+        )
+
+    with patch("wet_mcp.server._sitemap", new_callable=AsyncMock) as mock_sitemap:
+        mock_sitemap.return_value = "Sitemap Content"
+
+        result = await extract(
+            action="map",
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=999,  # exceeds limit
+        )
+
+        assert "Sitemap Content" in result
+        assert "<untrusted_extract_content>" in result
+        mock_sitemap.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=100,  # should be clamped to 100
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an unbounded crawling resource exhaustion in the `extract` tool. 

⚠️ **Risk:** The potential impact if left unfixed would allow a malicious user or automated tool to provide an extremely high `max_pages` value (e.g., 999999) and trigger resource exhaustion, which could lead to out-of-memory errors, service crashes, excessive bandwidth consumption, and potentially overloading external web services.

🛡️ **Solution:** The `max_pages` argument is now securely clamped to a maximum limit (`_MAX_PAGES_LIMIT = 100`) inside the `extract` tool. This ensures crawling limits are always enforced regardless of the parameter value requested by the user. Extensive test cases were written and run successfully ensuring proper functionality and regression protection.

---
*PR created automatically by Jules for task [16473752868917639657](https://jules.google.com/task/16473752868917639657) started by @n24q02m*