### PR TITLE
🔒 Limit max_pages in extract tool to prevent unbounded crawling

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -554,6 +554,9 @@ async def search(
 # ---------------------------------------------------------------------------
 
 
+_MAX_PAGES_LIMIT = 100
+
+
 @mcp.tool(
     annotations=ToolAnnotations(
         readOnlyHint=True,
@@ -575,6 +578,7 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    max_pages = min(max_pages, _MAX_PAGES_LIMIT)
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,31 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_max_pages_limit():
+    from wet_mcp.server import _MAX_PAGES_LIMIT
+
+    with patch("wet_mcp.server._crawl", new_callable=AsyncMock) as mock_crawl:
+        mock_crawl.return_value = "Success"
+        with patch(
+            "wet_mcp.server._with_timeout", new_callable=AsyncMock
+        ) as mock_with_timeout:
+
+            async def mock_timeout(coro, name):
+                await coro
+                return "Success"
+
+            mock_with_timeout.side_effect = mock_timeout
+
+            # Test that max_pages is capped at _MAX_PAGES_LIMIT
+            await extract(
+                action="crawl",
+                urls=["https://example.com"],
+                max_pages=_MAX_PAGES_LIMIT + 50,
+            )
+
+            mock_crawl.assert_called_once()
+            _, kwargs = mock_crawl.call_args
+            assert kwargs["max_pages"] == _MAX_PAGES_LIMIT


### PR DESCRIPTION
🎯 **What:** The `extract` tool accepted a `max_pages` argument to determine the maximum number of pages to crawl, without any hard limit in place.

⚠️ **Risk:** An attacker or misconfigured client could provide an extremely large value (e.g., `1000000`) for `max_pages`. This would cause the crawler to execute an unbounded deep crawl, leading to significant resource exhaustion (CPU, memory, bandwidth) and potential denial-of-service (DoS) conditions on the server running WET MCP or on the targeted website.

🛡️ **Solution:** Introduced a strict upper limit via `_MAX_PAGES_LIMIT = 100` and enforced `max_pages = min(max_pages, _MAX_PAGES_LIMIT)` within the `extract` function to cap the workload dynamically, neutralizing the vulnerability. Also added a specific unit test to verify this enforcement is behaving as expected.

---
*PR created automatically by Jules for task [3755043837782396044](https://jules.google.com/task/3755043837782396044) started by @n24q02m*