### PR TITLE
🧪 Add tests for the `help` tool in `server.py`

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,10 @@
 """Tests for src/wet_mcp/server.py."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from wet_mcp.server import extract, search
+from wet_mcp.server import extract, help, search
 
 
 @pytest.mark.asyncio
@@ -192,3 +192,36 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_help_success():
+    with patch("wet_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.read_text.return_value = "help_text"
+        mock_files.return_value.joinpath.return_value = mock_path
+
+        res = await help("search")
+        assert res == "help_text"
+
+
+@pytest.mark.asyncio
+async def test_help_not_found():
+    with patch("wet_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.read_text.side_effect = FileNotFoundError()
+        mock_files.return_value.joinpath.return_value = mock_path
+
+        res = await help("nonexistent_tool")
+        assert "Error: No documentation found for tool 'nonexistent_tool'" in res
+
+
+@pytest.mark.asyncio
+async def test_help_exception():
+    with patch("wet_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.read_text.side_effect = Exception("test exception")
+        mock_files.return_value.joinpath.return_value = mock_path
+
+        res = await help("search")
+        assert "Error loading documentation: test exception" in res

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `help` tool in `src/wet_mcp/server.py` was completely untested.
📊 **Coverage:** Added tests in `tests/test_server.py` to cover the happy path (file successfully loaded), `FileNotFoundError` edge case, and generic `Exception` edge case. The `files` loading resource is successfully mocked via `unittest.mock.patch` using `MagicMock()`.
✨ **Result:** 100% statement coverage achieved for the `help` tool, ensuring any future refactoring preserves error messaging format and functionality.

---
*PR created automatically by Jules for task [5354991788673737595](https://jules.google.com/task/5354991788673737595) started by @n24q02m*