### PR TITLE
🧹 [Refactor `_lifespan` function in `server.py` to use helper functions]

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,10 @@
+🎯 **What:** The `_lifespan` function in `src/wet_mcp/server.py` was too long and complex, handling multiple distinct setup operations (API keys, web cache, docs db, searxng, etc.) inline. We refactored it by extracting these logical blocks into separate, focused helper functions: `_setup_api_keys`, `_setup_searxng`, `_setup_web_cache`, `_setup_docs_db`, and `_cleanup_resources`.
+
+💡 **Why:** Breaking the function into smaller, well-named helpers drastically improves readability and maintainability. Each function now has a single, clear responsibility, making the codebase easier to understand, test, and modify without risking unintended side effects in unrelated initialization logic.
+
+✅ **Verification:**
+1. Ran format and lint checks (`uv run ruff format .` and `uv run ruff check . --fix`) to ensure the changes adhere to the project's strict styling rules.
+2. Ran the full test suite (`uv run pytest`) which passed successfully, confirming that the functionality remained completely unchanged.
+3. Manually reviewed `_lifespan` to verify the structure matches the intended abstraction.
+
+✨ **Result:** A simplified `_lifespan` method that acts as a clean orchestrator for initialization and teardown tasks, leaving the implementation details to the newly created helper functions.

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -81,46 +81,102 @@ async def _warmup_searxng() -> None:
         logger.debug(f"SearXNG pre-warm failed (non-fatal): {e}")
 
 
-@asynccontextmanager
-async def _lifespan(_server: FastMCP):
-    """Server lifespan: startup SearXNG, init cache/docs DB, cleanup on shutdown."""
-    global _web_cache, _docs_db, _embedding_dims
-
-    logger.info("Starting WET MCP Server...")
-
-    # 1. Setup API keys (+ aliases like GOOGLE_API_KEY -> GEMINI_API_KEY)
+def _setup_api_keys():
     from wet_mcp.config import settings
 
     keys = settings.setup_api_keys()
     if keys:
         logger.info(f"API keys configured: {', '.join(keys.keys())}")
 
-    # Warn about GitHub token for library docs discovery
     if not (os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")):
         logger.warning(
             "No GITHUB_TOKEN set. Library docs discovery will use unauthenticated "
             "GitHub API (60 req/hr limit). Set GITHUB_TOKEN for 5000 req/hr."
         )
+    return keys
 
-    # SearXNG is pre-warmed eagerly as a background task to eliminate
-    # startup latency on the first search call. If this instance finds an
-    # existing healthy SearXNG (started by another MCP server instance), it
-    # reuses it instead of spawning a new subprocess.
+
+def _setup_searxng():
+    from wet_mcp.config import settings
+
     _searxng_warmup_task: asyncio.Task | None = None
     if settings.wet_auto_searxng:
         _searxng_warmup_task = asyncio.create_task(_warmup_searxng())
+    return _searxng_warmup_task
 
-    # 2. Initialize web cache
+
+def _setup_web_cache():
+    from wet_mcp.config import settings
+
+    global _web_cache
+
     if settings.wet_cache:
         cache_path = settings.get_cache_db_path()
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         _web_cache = WebCache(cache_path)
         logger.info("Web cache enabled")
 
-    # 3. Initialize embedding backend (dual-backend: litellm or local)
+
+def _setup_docs_db():
+    from wet_mcp.config import settings
+
+    global _docs_db, _embedding_dims
+
     _embedding_dims = settings.resolve_embedding_dims()
     if _embedding_dims == 0:
         _embedding_dims = _DEFAULT_EMBEDDING_DIMS
+
+    docs_path = settings.get_db_path()
+    docs_path.parent.mkdir(parents=True, exist_ok=True)
+    _docs_db = DocsDB(docs_path, embedding_dims=_embedding_dims)
+
+    if settings.sync_enabled:
+        from wet_mcp.sync import start_auto_sync
+
+        start_auto_sync(_docs_db)
+
+
+async def _cleanup_resources(_searxng_warmup_task):
+    from wet_mcp.config import settings
+
+    global _web_cache, _docs_db
+
+    if _searxng_warmup_task and not _searxng_warmup_task.done():
+        _searxng_warmup_task.cancel()
+        try:
+            await _searxng_warmup_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    if settings.sync_enabled:
+        from wet_mcp.sync import stop_auto_sync
+
+        stop_auto_sync()
+
+    if _docs_db:
+        _docs_db.close()
+        _docs_db = None
+    if _web_cache:
+        _web_cache.close()
+        _web_cache = None
+
+    try:
+        await shutdown_crawler()
+    except Exception as exc:
+        logger.debug(f"Browser pool shutdown error (non-fatal): {exc}")
+
+    stop_searxng()
+
+
+@asynccontextmanager
+async def _lifespan(_server: FastMCP):
+    """Server lifespan: startup SearXNG, init cache/docs DB, cleanup on shutdown."""
+    logger.info("Starting WET MCP Server...")
+
+    keys = _setup_api_keys()
+    _searxng_warmup_task = _setup_searxng()
+    _setup_web_cache()
+    _setup_docs_db()
 
     async def _init_backends_task():
         try:
@@ -131,50 +187,10 @@ async def _lifespan(_server: FastMCP):
 
     asyncio.create_task(_init_backends_task())
 
-    # 5. Initialize docs DB
-    docs_path = settings.get_db_path()
-    docs_path.parent.mkdir(parents=True, exist_ok=True)
-    _docs_db = DocsDB(docs_path, embedding_dims=_embedding_dims)
-
-    # Start auto-sync if configured
-    if settings.sync_enabled:
-        from wet_mcp.sync import start_auto_sync
-
-        start_auto_sync(_docs_db)
-
     yield
 
     logger.info("Shutting down WET MCP Server...")
-
-    # Cancel SearXNG warmup task if still running
-    if _searxng_warmup_task and not _searxng_warmup_task.done():
-        _searxng_warmup_task.cancel()
-        try:
-            await _searxng_warmup_task
-        except (asyncio.CancelledError, Exception):
-            pass
-
-    # Stop auto-sync
-    if settings.sync_enabled:
-        from wet_mcp.sync import stop_auto_sync
-
-        stop_auto_sync()
-
-    # Close databases
-    if _docs_db:
-        _docs_db.close()
-        _docs_db = None
-    if _web_cache:
-        _web_cache.close()
-        _web_cache = None
-
-    # Shut down the shared browser pool first (may take a few seconds)
-    try:
-        await shutdown_crawler()
-    except Exception as exc:
-        logger.debug(f"Browser pool shutdown error (non-fatal): {exc}")
-
-    stop_searxng()
+    await _cleanup_resources(_searxng_warmup_task)
 
 
 async def _init_embedding_backend(keys: dict) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `_lifespan` function in `src/wet_mcp/server.py` was too long and complex, handling multiple distinct setup operations (API keys, web cache, docs db, searxng, etc.) inline. We refactored it by extracting these logical blocks into separate, focused helper functions: `_setup_api_keys`, `_setup_searxng`, `_setup_web_cache`, `_setup_docs_db`, and `_cleanup_resources`.

💡 **Why:** Breaking the function into smaller, well-named helpers drastically improves readability and maintainability. Each function now has a single, clear responsibility, making the codebase easier to understand, test, and modify without risking unintended side effects in unrelated initialization logic.

✅ **Verification:**
1. Ran format and lint checks (`uv run ruff format .` and `uv run ruff check . --fix`) to ensure the changes adhere to the project's strict styling rules.
2. Ran the full test suite (`uv run pytest`) which passed successfully, confirming that the functionality remained completely unchanged.
3. Manually reviewed `_lifespan` to verify the structure matches the intended abstraction.

✨ **Result:** A simplified `_lifespan` method that acts as a clean orchestrator for initialization and teardown tasks, leaving the implementation details to the newly created helper functions.

---
*PR created automatically by Jules for task [1462578901595970205](https://jules.google.com/task/1462578901595970205) started by @n24q02m*