### PR TITLE
🧹 Refactor Massive Docs Search Function in server.py

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1210,26 +1210,17 @@ async def _background_index_and_search(
         logger.error(f"Background indexing failed for {library}: {e}")
 
 
-async def _do_docs_search(
+async def _check_existing_index(
     library: str,
+    lib_key: str,
     query: str,
-    language: str | None = None,
-    version: str | None = None,
-    limit: int = 10,
-) -> str:
-    """Search library documentation. Auto-discovers and indexes if needed."""
-    if not _docs_db:
-        return "Error: Docs database not initialized"
-
-    # Build library identity — include language for DB disambiguation
-    # e.g., "redis" (no lang) vs "redis:python" vs "redis:javascript"
-    lib_key = f"{library}:{language.lower()}" if language else library
-
+    version: str | None,
+    limit: int,
+) -> str | None:
+    """Check if library is already indexed and search it."""
     from wet_mcp.sources.docs import DISCOVERY_VERSION
 
-    # Step 1: Check if library is already indexed
     lib = _docs_db.get_library(lib_key)
-
     if lib:
         # Invalidate cache if discovery scoring has been updated
         cached_version = lib.get("discovery_version", 0)
@@ -1257,6 +1248,8 @@ async def _do_docs_search(
             )
 
             if results:
+                import json
+
                 # Rerank if available, otherwise truncate to limit
                 results = await _rerank_results(query, results, limit)
                 return json.dumps(
@@ -1270,13 +1263,16 @@ async def _do_docs_search(
                     ensure_ascii=False,
                     indent=2,
                 )
+    return None
 
-    # Step 2: Auto-discover and index
-    logger.info(f"Library '{lib_key}' not indexed, discovering docs...")
 
-    from wet_mcp.sources.docs import (
-        discover_library,
-    )
+async def _discover_library_metadata(
+    library: str, language: str | None
+) -> tuple[str, str, str, str]:
+    """Discover library metadata from registries or fallback to SearXNG."""
+    import json
+
+    from wet_mcp.sources.docs import discover_library
 
     # Discover library metadata from registries (with sub-timeout)
     docs_url = ""
@@ -1284,6 +1280,8 @@ async def _do_docs_search(
     registry = ""
     description = ""
     try:
+        import asyncio
+
         discovery = await asyncio.wait_for(
             discover_library(library, language=language),
             timeout=_DISCOVERY_TIMEOUT,
@@ -1309,6 +1307,8 @@ async def _do_docs_search(
         )
         logger.info(f"Registry lookup failed, trying SearXNG for '{library}'...")
         try:
+            import asyncio
+
             searxng_url = await asyncio.wait_for(
                 ensure_searxng(), timeout=_SEARXNG_TIMEOUT
             )
@@ -1329,6 +1329,77 @@ async def _do_docs_search(
             logger.warning("SearXNG discovery fallback timed out")
         except json.JSONDecodeError:
             pass
+
+    return docs_url, repo_url, registry, description
+
+
+async def _do_immediate_fallback_search(
+    library: str, query: str, language: str | None, docs_url: str, limit: int
+) -> list[dict]:
+    """Perform an immediate fallback web search using SearXNG."""
+    import json
+
+    fallback_search_query = (
+        f"site:{urlparse(docs_url).netloc} {query}"
+        if docs_url
+        else f"{library} {language} {query}"
+    )
+    fallback_data = {"results": []}
+    try:
+        import asyncio
+
+        searxng_url = await asyncio.wait_for(ensure_searxng(), timeout=_SEARXNG_TIMEOUT)
+        fallback_result = await asyncio.wait_for(
+            searxng_search(
+                searxng_url=searxng_url,
+                query=fallback_search_query,
+                categories="general",
+                max_results=limit,
+            ),
+            timeout=15,
+        )
+        fallback_data = json.loads(fallback_result)
+        if "results" in fallback_data and fallback_data["results"]:
+            fallback_data["results"] = await _rerank_results(
+                query, fallback_data["results"], top_n=limit
+            )
+    except Exception as e:
+        logger.debug(f"Immediate fallback search failed: {e}")
+
+    return fallback_data.get("results", [])
+
+
+async def _do_docs_search(
+    library: str,
+    query: str,
+    language: str | None = None,
+    version: str | None = None,
+    limit: int = 10,
+) -> str:
+    """Search library documentation. Auto-discovers and indexes if needed."""
+    import asyncio
+    import json
+
+    if not _docs_db:
+        return "Error: Docs database not initialized"
+
+    # Build library identity — include language for DB disambiguation
+    # e.g., "redis" (no lang) vs "redis:python" vs "redis:javascript"
+    lib_key = f"{library}:{language.lower()}" if language else library
+
+    # Step 1: Check if library is already indexed
+    existing_result = await _check_existing_index(
+        library, lib_key, query, version, limit
+    )
+    if existing_result:
+        return existing_result
+
+    # Step 2: Auto-discover and index
+    logger.info(f"Library '{lib_key}' not indexed, discovering docs...")
+
+    docs_url, repo_url, registry, description = await _discover_library_metadata(
+        library, language
+    )
 
     if not docs_url:
         # When no docs URL found but we have a GitHub repo URL,
@@ -1378,36 +1449,15 @@ async def _do_docs_search(
     )
 
     # Do immediate fallback web search
-    fallback_search_query = (
-        f"site:{urlparse(docs_url).netloc} {query}"
-        if docs_url
-        else f"{library} {language} {query}"
+    temporary_results = await _do_immediate_fallback_search(
+        library, query, language, docs_url, limit
     )
-    fallback_data = {"results": []}
-    try:
-        searxng_url = await asyncio.wait_for(ensure_searxng(), timeout=_SEARXNG_TIMEOUT)
-        fallback_result = await asyncio.wait_for(
-            searxng_search(
-                searxng_url=searxng_url,
-                query=fallback_search_query,
-                categories="general",
-                max_results=limit,
-            ),
-            timeout=15,
-        )
-        fallback_data = json.loads(fallback_result)
-        if "results" in fallback_data and fallback_data["results"]:
-            fallback_data["results"] = await _rerank_results(
-                query, fallback_data["results"], top_n=limit
-            )
-    except Exception as e:
-        logger.debug(f"Immediate fallback search failed: {e}")
 
     return json.dumps(
         {
             "status": "indexing_in_progress",
             "message": f"Library '{library}' is currently being downloaded and indexed in the background (this may take 3-5 minutes). In the meantime, here are temporary web search results.",
-            "temporary_results": fallback_data.get("results", []),
+            "temporary_results": temporary_results,
             "library": library,
             "docs_url": docs_url,
         },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The massive `_do_docs_search` function (over 200 lines) was handling discovery, indexing, fetching, embedding, and searching all in one block. This PR refactors it into smaller, distinct helper functions: `_check_existing_index`, `_discover_library_metadata`, and `_do_immediate_fallback_search`.

💡 **Why:** How this improves maintainability
`_do_docs_search` was handling multiple distinct concerns (checking existing DB, external API discovery, and fallback search orchestration). Breaking it down improves maintainability, readability, and testability.

✅ **Verification:** How you confirmed the change is safe
Ran `uv run pytest tests/test_server_comprehensive.py tests/test_server.py tests/test_server_timeout.py` and the full suite (`uv run pytest`) to ensure all functionality is preserved. Used `uv run ruff check . --fix` and `uv run ruff format .` to maintain code health. The logic mirrors the original completely.

✨ **Result:** The improvement achieved
A much cleaner `_do_docs_search` acting as a simple orchestrator instead of a monolithic implementation.

---
*PR created automatically by Jules for task [10126409767915961753](https://jules.google.com/task/10126409767915961753) started by @n24q02m*