### PR TITLE
🧪 Add tests for `encode_image` in `llm.py`

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -154,3 +154,23 @@ def test_analyze_media_large_text_file(mock_completion, mock_settings, tmp_path)
 
     assert expected_body in sent_content
     assert "a" * 100001 not in sent_content
+
+
+def test_encode_image(tmp_path):
+    """Test image encoding to base64."""
+    img_path = tmp_path / "test.png"
+    # Create valid dummy image file
+    img_path.write_bytes(b"fake-image-data")
+
+    from wet_mcp.llm import encode_image
+
+    result = encode_image(str(img_path))
+    assert result == "ZmFrZS1pbWFnZS1kYXRh"
+
+
+def test_encode_image_file_not_found():
+    """Test encode_image with non-existent file."""
+    from wet_mcp.llm import encode_image
+
+    with pytest.raises(FileNotFoundError):
+        encode_image("non_existent_file.png")

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The testing gap in the `encode_image` functionality of `llm.py` was addressed.
📊 **Coverage:** Now it covers testing image generation with dummy contents using the `tmp_path` fixture, and checking for missing files by verifying `FileNotFoundError` is raised.
✨ **Result:** Test coverage for `llm.py` is improved, securing the codebase.

---
*PR created automatically by Jules for task [9490495818173775262](https://jules.google.com/task/9490495818173775262) started by @n24q02m*