### PR TITLE
🧪 Add tests for research action in search tool

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,26 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+@pytest.mark.asyncio
+async def test_research_success():
+    """Test research action success path."""
+    with patch("wet_mcp.server._do_research", new_callable=AsyncMock) as mock_research:
+        mock_research.return_value = "Research Results"
+
+        result = await search(action="research", query="test query", max_results=5)
+
+        assert "Research Results" in result
+        assert "<untrusted_search_content>" in result
+        assert "[SECURITY:" in result
+        mock_research.assert_called_once_with(
+            query="test query",
+            max_results=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_research_missing_query():
+    """Test research action missing query."""
+    result = await search(action="research", query=None)
+    assert "Error: query is required" in result


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `research` action in `src/wet_mcp/server.py`.
📊 **Coverage:** Covered the successful execution path (with `query` and `max_results` arguments) using an `AsyncMock` for `_do_research`, as well as the error handling path when the `query` argument is missing.
✨ **Result:** Improved test coverage and reliability for the `search` tool's `research` action.

---
*PR created automatically by Jules for task [13613199712917234861](https://jules.google.com/task/13613199712917234861) started by @n24q02m*