### PR TITLE
🔒 Security Fix: Unbounded Crawling Resource Exhaustion in extract tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -53,6 +53,8 @@ _DEFAULT_EMBEDDING_DIMS = 768
 # Reranking: retrieve more candidates than final limit, then rerank.
 _RERANK_CANDIDATE_MULTIPLIER = 3
 
+_MAX_PAGES_LIMIT = 100
+
 # Module-level state (set during lifespan)
 _web_cache: WebCache | None = None
 _docs_db: DocsDB | None = None
@@ -575,6 +577,7 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    max_pages = min(max_pages, _MAX_PAGES_LIMIT)
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -131,6 +131,33 @@ async def test_crawl_defaults():
 
 
 @pytest.mark.asyncio
+async def test_extract_max_pages_limit():
+    """Test that max_pages is correctly capped at _MAX_PAGES_LIMIT."""
+    from wet_mcp.server import _MAX_PAGES_LIMIT
+
+    with patch("wet_mcp.server._crawl", new_callable=AsyncMock) as mock_crawl:
+        mock_crawl.return_value = "Crawl Results"
+
+        # Pass a max_pages value far larger than the limit
+        huge_max_pages = 1000000
+        result = await extract(
+            action="crawl",
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=huge_max_pages,
+        )
+
+        assert "Crawl Results" in result
+        mock_crawl.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=_MAX_PAGES_LIMIT,
+            format="markdown",
+            stealth=False,
+        )
+
+
+@pytest.mark.asyncio
 async def test_crawl_missing_urls():
     """Test crawl action missing urls."""
     result = await extract(action="crawl", urls=None)

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `extract` tool now enforces a hard upper limit of 100 on the `max_pages` parameter.
⚠️ **Risk:** An attacker or misconfigured client could pass an excessively large value for `max_pages` (e.g., 1000000), causing the crawler to consume excessive CPU, memory, and network bandwidth, leading to resource exhaustion or denial of service.
🛡️ **Solution:** Introduced `_MAX_PAGES_LIMIT = 100` and `max_pages = min(max_pages, _MAX_PAGES_LIMIT)` in `src/wet_mcp/server.py`. Added `test_extract_max_pages_limit` to `tests/test_server.py` to verify the limit is enforced correctly without breaking existing functionality.

---
*PR created automatically by Jules for task [7277294606544023908](https://jules.google.com/task/7277294606544023908) started by @n24q02m*