### PR TITLE
🧪 Add tests for docs action in search tool

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,42 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_search_docs_success():
+    """Test docs action success path."""
+    with patch("wet_mcp.server._do_docs_search", new_callable=AsyncMock) as mock_docs:
+        mock_docs.return_value = "Docs Results"
+
+        result = await search(
+            action="docs",
+            query="how to install",
+            library="react",
+            version="18",
+            language="javascript",
+            limit=5,
+        )
+
+        assert "Docs Results" in result
+        mock_docs.assert_called_once_with(
+            library="react",
+            query="how to install",
+            language="javascript",
+            version="18",
+            limit=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_docs_missing_library():
+    """Test docs action missing library."""
+    result = await search(action="docs", query="test query")
+    assert "Error: library is required for docs action" in result
+
+
+@pytest.mark.asyncio
+async def test_search_docs_missing_query():
+    """Test docs action missing query."""
+    result = await search(action="docs", library="react")
+    assert "Error: query is required for docs action" in result


### PR DESCRIPTION
🎯 What: The `docs` action within the `search` tool in `src/wet_mcp/server.py` was untested, meaning the happy path (calling `_do_docs_search`) and edge cases (missing `library` or `query` arguments) lacked safety nets.
📊 Coverage: Added three tests (`test_search_docs_success`, `test_search_docs_missing_library`, `test_search_docs_missing_query`) in `tests/test_server.py`. The tests mock out `_do_docs_search` to verify it gets called properly with the provided arguments and that the argument validation paths work correctly.
✨ Result: The `search` tool now has robust test coverage for its internal routing logic, ensuring that any future refactoring of the server action dispatching remains safe.

---
*PR created automatically by Jules for task [11613588717652043933](https://jules.google.com/task/11613588717652043933) started by @n24q02m*