### PR TITLE
🧹 Consolidate Process Killing Logic in searxng_runner.py

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -398,6 +398,20 @@ def _get_settings_path(port: int) -> Path:
     return settings_file
 
 
+def _kill_pid(pid: int, sig: int = signal.SIGTERM) -> None:
+    """Kill a process (and its group on Unix) by PID."""
+    try:
+        if sys.platform != "win32":
+            try:
+                os.killpg(os.getpgid(pid), sig)
+            except (ProcessLookupError, PermissionError):
+                os.kill(pid, sig)
+        else:
+            os.kill(pid, sig)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
 def _force_kill_process(proc: subprocess.Popen) -> None:
     """Force-kill a subprocess and all its children.
 
@@ -411,14 +425,7 @@ def _force_kill_process(proc: subprocess.Popen) -> None:
     logger.debug(f"Force-killing SearXNG process (PID={pid})...")
 
     try:
-        if sys.platform != "win32":
-            # Kill the entire process group on Unix
-            try:
-                os.killpg(os.getpgid(pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError):
-                proc.terminate()
-        else:
-            proc.terminate()
+        _kill_pid(pid, signal.SIGTERM)
 
         # Wait briefly for graceful shutdown
         try:
@@ -430,12 +437,10 @@ def _force_kill_process(proc: subprocess.Popen) -> None:
 
         # Force kill
         if sys.platform != "win32":
-            try:
-                os.killpg(os.getpgid(pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                proc.kill()
+            _kill_pid(pid, signal.SIGKILL)
         else:
-            proc.kill()
+            # On Windows, SIGTERM is equivalent to TerminateProcess, but we try anyway
+            _kill_pid(pid, signal.SIGTERM)
 
         try:
             proc.wait(timeout=3)
@@ -471,11 +476,11 @@ def _kill_stale_port_process(port: int) -> None:
                     try:
                         pid = int(pid_str)
                         if pid > 0:
-                            os.kill(pid, signal.SIGTERM)
+                            _kill_pid(pid)
                             logger.debug(
                                 f"Killed stale process on port {port} (PID={pid})"
                             )
-                    except (ValueError, ProcessLookupError, PermissionError):
+                    except ValueError:
                         pass
         except Exception:
             pass
@@ -494,11 +499,11 @@ def _kill_stale_port_process(port: int) -> None:
                     try:
                         pid = int(pid_str.strip())
                         if pid > 0 and pid != os.getpid():
-                            os.kill(pid, signal.SIGTERM)
+                            _kill_pid(pid)
                             logger.debug(
                                 f"Killed stale process on port {port} (PID={pid})"
                             )
-                    except (ValueError, ProcessLookupError, PermissionError):
+                    except ValueError:
                         pass
         except FileNotFoundError:
             # lsof not available, try fuser

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted repetitive platform-specific process termination logic from `_force_kill_process` and `_kill_stale_port_process` into a new generic helper function `_kill_pid()`.

💡 **Why:** How this improves maintainability
Both functions were independently handling Windows and Unix-specific process logic using similar checks. Consolidating this significantly reduces duplicated code and establishes a single, uniform way to terminate a process by PID.

✅ **Verification:** How you confirmed the change is safe
Tests passed cleanly in `uv run pytest tests/test_searxng_runner.py tests/test_searxng_unit.py` and the main `uv run pytest`. `uv run ruff check .` passed as well.

✨ **Result:** The improvement achieved
Reduced duplication, improved readability of complex platform-specific logic, and ensured cleaner handling when killing process groups.

---
*PR created automatically by Jules for task [14341859065119376185](https://jules.google.com/task/14341859065119376185) started by @n24q02m*