### PR TITLE
🧹 [Code Health] Consolidate Process Killing Logic in searxng_runner.py

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -398,6 +398,32 @@ def _get_settings_path(port: int) -> Path:
     return settings_file
 
 
+def _send_process_signal(
+    proc: __import__("subprocess").Popen, sig: int, fallback_method
+) -> None:
+    """Send a signal to a process group on Unix, or fallback to the provided method."""
+    if sys.platform != "win32":
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError):
+            fallback_method()
+    else:
+        fallback_method()
+
+
+def _kill_process_by_pid(pid_str: str, port: int) -> None:
+    """Safely parse a PID string and kill the corresponding process."""
+    try:
+        pid = int(pid_str.strip())
+        if pid > 0 and pid != os.getpid():
+            os.kill(pid, signal.SIGTERM)
+            from loguru import logger
+
+            logger.debug(f"Killed stale process on port {port} (PID={pid})")
+    except (ValueError, ProcessLookupError, PermissionError):
+        pass
+
+
 def _force_kill_process(proc: subprocess.Popen) -> None:
     """Force-kill a subprocess and all its children.
 
@@ -411,14 +437,7 @@ def _force_kill_process(proc: subprocess.Popen) -> None:
     logger.debug(f"Force-killing SearXNG process (PID={pid})...")
 
     try:
-        if sys.platform != "win32":
-            # Kill the entire process group on Unix
-            try:
-                os.killpg(os.getpgid(pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError):
-                proc.terminate()
-        else:
-            proc.terminate()
+        _send_process_signal(proc, signal.SIGTERM, proc.terminate)
 
         # Wait briefly for graceful shutdown
         try:
@@ -429,13 +448,7 @@ def _force_kill_process(proc: subprocess.Popen) -> None:
             pass
 
         # Force kill
-        if sys.platform != "win32":
-            try:
-                os.killpg(os.getpgid(pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                proc.kill()
-        else:
-            proc.kill()
+        _send_process_signal(proc, signal.SIGKILL, proc.kill)
 
         try:
             proc.wait(timeout=3)
@@ -468,15 +481,7 @@ def _kill_stale_port_process(port: int) -> None:
                 if f"127.0.0.1:{port}" in line and "LISTENING" in line:
                     parts = line.split()
                     pid_str = parts[-1]
-                    try:
-                        pid = int(pid_str)
-                        if pid > 0:
-                            os.kill(pid, signal.SIGTERM)
-                            logger.debug(
-                                f"Killed stale process on port {port} (PID={pid})"
-                            )
-                    except (ValueError, ProcessLookupError, PermissionError):
-                        pass
+                    _kill_process_by_pid(pid_str, port)
         except Exception:
             pass
     else:
@@ -491,15 +496,7 @@ def _kill_stale_port_process(port: int) -> None:
             )
             if result.returncode == 0 and result.stdout.strip():
                 for pid_str in result.stdout.strip().splitlines():
-                    try:
-                        pid = int(pid_str.strip())
-                        if pid > 0 and pid != os.getpid():
-                            os.kill(pid, signal.SIGTERM)
-                            logger.debug(
-                                f"Killed stale process on port {port} (PID={pid})"
-                            )
-                    except (ValueError, ProcessLookupError, PermissionError):
-                        pass
+                    _kill_process_by_pid(pid_str, port)
         except FileNotFoundError:
             # lsof not available, try fuser
             try:

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:**
Extracted duplicated logic for killing processes into `_send_process_signal` and `_kill_process_by_pid` helper functions. Refactored `_force_kill_process` and `_kill_stale_port_process` to use these helpers.

💡 **Why:**
Improves maintainability by removing redundant code for OS-specific logic when sending signals to processes (such as Windows `proc.terminate()` vs Unix `os.killpg()`) and parsing PIDs from process strings. Reduces the chance of desync between Unix and Windows codepaths.

✅ **Verification:**
Confirmed via pytest tests that SearXNG lifecycle tests (`test_searxng_runner.py` and others) still pass. Linted code with `ruff` and formatted successfully.

✨ **Result:**
Cleaned up 2 duplicated blocks in `_force_kill_process` and 2 duplicated blocks in `_kill_stale_port_process`, replacing them with readable, centralized helpers.

---
*PR created automatically by Jules for task [7526950646290666557](https://jules.google.com/task/7526950646290666557) started by @n24q02m*