### PR TITLE
🔒 Fix Unbounded Crawling Resource Exhaustion in Extract Tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -53,6 +53,9 @@ _DEFAULT_EMBEDDING_DIMS = 768
 # Reranking: retrieve more candidates than final limit, then rerank.
 _RERANK_CANDIDATE_MULTIPLIER = 3
 
+# Hard upper limit for crawler max_pages parameter across all extract tools
+_MAX_PAGES_LIMIT = 100
+
 # Module-level state (set during lifespan)
 _web_cache: WebCache | None = None
 _docs_db: DocsDB | None = None
@@ -575,6 +578,7 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    max_pages = min(max_pages, _MAX_PAGES_LIMIT)
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,38 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_max_pages_limit():
+    """Test that max_pages is correctly capped by _MAX_PAGES_LIMIT."""
+    with patch("wet_mcp.server._MAX_PAGES_LIMIT", 100):
+        with patch("wet_mcp.server._crawl", new_callable=AsyncMock) as mock_crawl:
+            mock_crawl.return_value = "Crawl Results"
+            await extract(
+                action="crawl",
+                urls=["https://example.com"],
+                depth=3,
+                max_pages=500,  # Should be capped at 100
+            )
+            mock_crawl.assert_called_once_with(
+                urls=["https://example.com"],
+                depth=3,
+                max_pages=100,
+                format="markdown",
+                stealth=False,
+            )
+
+        with patch("wet_mcp.server._sitemap", new_callable=AsyncMock) as mock_sitemap:
+            mock_sitemap.return_value = "Sitemap Results"
+            await extract(
+                action="map",
+                urls=["https://example.com"],
+                depth=3,
+                max_pages=150,  # Should be capped at 100
+            )
+            mock_sitemap.assert_called_once_with(
+                urls=["https://example.com"],
+                depth=3,
+                max_pages=100,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is Unbounded Crawling Resource Exhaustion in the `extract` tool. The `max_pages` argument was passed directly to the crawler without an upper limit.
⚠️ **Risk:** An attacker could exploit this to perform a Denial of Service (DoS) attack, causing the server to run out of memory, compute, or network bandwidth by requesting deep or unbounded crawls. This can impact both the MCP server and the domains being crawled.
🛡️ **Solution:** The solution mitigates the risk by introducing a new constant `_MAX_PAGES_LIMIT = 100` and securely capping the `max_pages` parameter inside the `extract` function via `max_pages = min(max_pages, _MAX_PAGES_LIMIT)` before calling any downstream crawler or map functions. Tests were successfully added to ensure this cap is strictly enforced.

---
*PR created automatically by Jules for task [13270630808184372821](https://jules.google.com/task/13270630808184372821) started by @n24q02m*