### PR TITLE
🧹 Consolidate Process Killing Logic in searxng_runner.py

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -398,6 +398,24 @@ def _get_settings_path(port: int) -> Path:
     return settings_file
 
 
+def _kill_pid(pid: int, sig: signal.Signals | int) -> None:
+    """Send a signal to a process (and its process group on Unix).
+
+    On Unix, tries to kill the entire process group to avoid orphaned children.
+    Falls back to killing just the process if the group cannot be determined.
+    """
+    try:
+        if sys.platform != "win32":
+            try:
+                os.killpg(os.getpgid(pid), sig)
+            except (ProcessLookupError, PermissionError):
+                os.kill(pid, sig)
+        else:
+            os.kill(pid, sig)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
 def _force_kill_process(proc: subprocess.Popen) -> None:
     """Force-kill a subprocess and all its children.
 
@@ -411,14 +429,7 @@ def _force_kill_process(proc: subprocess.Popen) -> None:
     logger.debug(f"Force-killing SearXNG process (PID={pid})...")
 
     try:
-        if sys.platform != "win32":
-            # Kill the entire process group on Unix
-            try:
-                os.killpg(os.getpgid(pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError):
-                proc.terminate()
-        else:
-            proc.terminate()
+        _kill_pid(pid, signal.SIGTERM)
 
         # Wait briefly for graceful shutdown
         try:
@@ -429,13 +440,7 @@ def _force_kill_process(proc: subprocess.Popen) -> None:
             pass
 
         # Force kill
-        if sys.platform != "win32":
-            try:
-                os.killpg(os.getpgid(pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                proc.kill()
-        else:
-            proc.kill()
+        _kill_pid(pid, signal.SIGKILL)
 
         try:
             proc.wait(timeout=3)
@@ -471,7 +476,7 @@ def _kill_stale_port_process(port: int) -> None:
                     try:
                         pid = int(pid_str)
                         if pid > 0:
-                            os.kill(pid, signal.SIGTERM)
+                            _kill_pid(pid, signal.SIGTERM)
                             logger.debug(
                                 f"Killed stale process on port {port} (PID={pid})"
                             )
@@ -494,7 +499,7 @@ def _kill_stale_port_process(port: int) -> None:
                     try:
                         pid = int(pid_str.strip())
                         if pid > 0 and pid != os.getpid():
-                            os.kill(pid, signal.SIGTERM)
+                            _kill_pid(pid, signal.SIGTERM)
                             logger.debug(
                                 f"Killed stale process on port {port} (PID={pid})"
                             )

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Created a `_kill_pid` helper function in `src/wet_mcp/searxng_runner.py` that encapsulates OS-specific process signal dispatching (e.g., trying to kill process groups using `os.killpg` on Unix systems and gracefully falling back if that fails, while ensuring Windows handles it via standard `os.kill`).

💡 **Why:** How this improves maintainability
Both `_force_kill_process` and `_kill_stale_port_process` implemented near-identical logic to manage OS-level compatibility when terminating processes. Extracting this logic prevents duplication, streamlines the actual business logic of those functions, and extends process group termination to `_kill_stale_port_process` on Unix (reducing the chance of orphaned processes).

✅ **Verification:** How you confirmed the change is safe
- Executed `uv run ruff check .` to ensure standard linting rules were respected. No errors.
- Ran the test suite using `uv run pytest tests/test_searxng_runner.py tests/test_searxng_runner_comprehensive.py tests/test_searxng_unit.py` and saw all tests passing correctly.
- Reviewed and ensured we cleanly caught `ProcessLookupError` and `PermissionError` as expected. 

✨ **Result:** The improvement achieved
A cleaner `searxng_runner.py` with standard, isolated signal handling logic, ensuring safer shutdowns of stale and hung processes.

---
*PR created automatically by Jules for task [4992110954734752784](https://jules.google.com/task/4992110954734752784) started by @n24q02m*