### PR TITLE
🔒 Fix Unbounded Crawling Resource Exhaustion in extract tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -554,6 +554,9 @@ async def search(
 # ---------------------------------------------------------------------------
 
 
+_MAX_PAGES_LIMIT = 100
+
+
 @mcp.tool(
     annotations=ToolAnnotations(
         readOnlyHint=True,
@@ -575,6 +578,9 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    if max_pages > _MAX_PAGES_LIMIT:
+        max_pages = _MAX_PAGES_LIMIT
+
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,29 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_max_pages_limit():
+    """Test that max_pages is capped at _MAX_PAGES_LIMIT."""
+    with patch("wet_mcp.server._crawl", new_callable=AsyncMock) as mock_crawl:
+        mock_crawl.return_value = "Crawl Results"
+
+        result = await extract(
+            action="crawl",
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=150,
+            format="json",
+            stealth=False,
+        )
+
+        assert "Crawl Results" in result
+        assert "<untrusted_extract_content>" in result
+        mock_crawl.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=100,  # Should be capped
+            format="json",
+            stealth=False,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `extract` tool lacked an upper limit on the `max_pages` parameter.
⚠️ **Risk:** Malicious users or misconfigured systems could supply arbitrarily large `max_pages` values (e.g. `1000000`), triggering extensive local processing, exhausting server resources (memory/CPU) via uncontrolled downstream web crawling loops, leading to Denial of Service (DoS) conditions.
🛡️ **Solution:** Added a hard upper bound of `_MAX_PAGES_LIMIT = 100` and capped user input in the `extract` function prior to execution. Added a unit test validating that inputs over 100 are strictly capped without breaking the functionality.

---
*PR created automatically by Jules for task [13461746115168697083](https://jules.google.com/task/13461746115168697083) started by @n24q02m*