### PR TITLE
🔒 Change api_keys to SecretStr to prevent exposure

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `api_keys` setting was typed as `str` instead of Pydantic's `SecretStr`. It has been changed to `SecretStr` to prevent it from being accidentally exposed when settings are dumped or logged.

⚠️ **Risk:** The `api_keys` variable holds highly sensitive information. Before this fix, Pydantic would treat it as a regular string, which could inadvertently lead to it being included in logs, error messages, or JSON exports, potentially exposing credentials.

🛡️ **Solution:** By changing its type to `SecretStr`, Pydantic will redact its value (displaying '**********') when printed or converted to a dictionary. Internally, the code safely accesses the actual string using `.get_secret_value()`.

---
*PR created automatically by Jules for task [2166878656731700774](https://jules.google.com/task/2166878656731700774) started by @n24q02m*