### PR TITLE
🔒 [security fix] Enforce max_pages limit to prevent resource exhaustion

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -404,6 +404,7 @@ _DISCOVERY_TIMEOUT = 30  # discover_library() — registry + probe
 _FETCH_TIMEOUT = 90  # _fetch_and_chunk_docs() — llms.txt + GH raw + crawl
 _EMBED_TIMEOUT = 60  # _embed_batch() — ONNX for all chunks
 _FALLBACK_TIMEOUT = 60  # SearXNG fallback fetch
+_MAX_PAGES_LIMIT = 100  # extract tool hard limit to prevent resource exhaustion
 
 
 async def _with_timeout(coro, action: str) -> str:
@@ -575,6 +576,9 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    if max_pages > _MAX_PAGES_LIMIT:
+        return f"Error: max_pages exceeds maximum limit of {_MAX_PAGES_LIMIT}"
+
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,10 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_max_pages_limit():
+    """Test extract action prevents max_pages > 100 to avoid resource exhaustion."""
+    result = await extract(action="crawl", urls=["https://example.com"], max_pages=101)
+    assert "Error: max_pages exceeds maximum limit of 100" in result


### PR DESCRIPTION
🎯 **What:** The `extract` tool (handling `extract`, `crawl`, and `map` actions) allowed an unbounded `max_pages` argument.
⚠️ **Risk:** An attacker or malfunctioning client could provide an arbitrarily high `max_pages` value (e.g., 10,000), which would cause the crawler to consume unbounded memory, network, and CPU resources, resulting in a Denial of Service (DoS).
🛡️ **Solution:** Introduced a hard upper limit `_MAX_PAGES_LIMIT = 100` in `src/wet_mcp/server.py`. The `extract` tool now immediately validates `max_pages` against this limit and returns an error message if the limit is exceeded, securely bounding resource consumption. Added a corresponding unit test in `tests/test_server.py`.

---
*PR created automatically by Jules for task [5104632901808156196](https://jules.google.com/task/5104632901808156196) started by @n24q02m*