### PR TITLE
🔒 Fix Unbounded Crawling Resource Exhaustion in extract tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -53,6 +53,9 @@ _DEFAULT_EMBEDDING_DIMS = 768
 # Reranking: retrieve more candidates than final limit, then rerank.
 _RERANK_CANDIDATE_MULTIPLIER = 3
 
+# Hard upper limit for crawler max_pages to prevent resource exhaustion
+_MAX_PAGES_LIMIT = 100
+
 # Module-level state (set during lifespan)
 _web_cache: WebCache | None = None
 _docs_db: DocsDB | None = None
@@ -575,6 +578,9 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    # Enforce hard upper limit on max_pages
+    max_pages = min(max_pages, _MAX_PAGES_LIMIT)
+
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,41 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_crawl_max_pages_limit():
+    """Test extract crawl action enforces max_pages limit."""
+    with patch("wet_mcp.server._crawl", new_callable=AsyncMock) as mock_crawl:
+        mock_crawl.return_value = "Crawled Content"
+
+        result = await extract(
+            action="crawl", urls=["https://example.com"], depth=2, max_pages=1000
+        )
+
+        assert "Crawled Content" in result
+        mock_crawl.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=2,
+            max_pages=100,  # Clamped to _MAX_PAGES_LIMIT
+            format="markdown",
+            stealth=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_extract_map_max_pages_limit():
+    """Test extract map action enforces max_pages limit."""
+    with patch("wet_mcp.server._sitemap", new_callable=AsyncMock) as mock_sitemap:
+        mock_sitemap.return_value = "Sitemap Content"
+
+        result = await extract(
+            action="map", urls=["https://example.com"], depth=2, max_pages=1000
+        )
+
+        assert "Sitemap Content" in result
+        mock_sitemap.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=2,
+            max_pages=100,  # Clamped to _MAX_PAGES_LIMIT
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Added a hard upper limit (`_MAX_PAGES_LIMIT = 100`) to the `max_pages` parameter in the `extract` tool.
⚠️ **Risk:** An attacker or malicious user could provide an excessively large `max_pages` value, leading to unbounded crawling and server resource exhaustion.
🛡️ **Solution:** Clamped `max_pages` using `min(max_pages, _MAX_PAGES_LIMIT)` before executing actions to strictly limit crawler activity and prevent resource exhaustion. Tests were added to ensure this limit is enforced for both `crawl` and `map` actions.

---
*PR created automatically by Jules for task [1786479819273401759](https://jules.google.com/task/1786479819273401759) started by @n24q02m*