### PR TITLE
🔒 Fix unbounded crawling resource exhaustion in extract tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -50,8 +50,12 @@ _EMBEDDING_CANDIDATES = [
 # breaks the vector table. Override via EMBEDDING_DIMS env var.
 _DEFAULT_EMBEDDING_DIMS = 768
 
+
 # Reranking: retrieve more candidates than final limit, then rerank.
 _RERANK_CANDIDATE_MULTIPLIER = 3
+
+# Hard limit for max_pages in extract tool to prevent resource exhaustion
+_MAX_PAGES_LIMIT = 100
 
 # Module-level state (set during lifespan)
 _web_cache: WebCache | None = None
@@ -575,6 +579,7 @@ async def extract(
     - map: Discover site structure without content (requires urls)
     Use `help` tool for full documentation.
     """
+    max_pages = min(max_pages, _MAX_PAGES_LIMIT)
     match action:
         case "extract":
             if not urls:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -188,6 +188,45 @@ async def test_search_invalid_action():
 
 
 @pytest.mark.asyncio
+async def test_extract_max_pages_limit():
+    """Test that max_pages is correctly limited for crawl and map actions."""
+    with patch("wet_mcp.server._crawl", new_callable=AsyncMock) as mock_crawl:
+        mock_crawl.return_value = "Crawl Results"
+
+        result = await extract(
+            action="crawl",
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=150,
+            format="json",
+            stealth=False,
+        )
+
+        assert "Crawl Results" in result
+        mock_crawl.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=100,
+            format="json",
+            stealth=False,
+        )
+
+    with patch("wet_mcp.server._sitemap", new_callable=AsyncMock) as mock_sitemap:
+        mock_sitemap.return_value = "Sitemap Content"
+
+        result = await extract(
+            action="map", urls=["https://example.com"], depth=3, max_pages=150
+        )
+
+        assert "Sitemap Content" in result
+        mock_sitemap.assert_called_once_with(
+            urls=["https://example.com"],
+            depth=3,
+            max_pages=100,
+        )
+
+
+@pytest.mark.asyncio
 async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `extract` tool's `max_pages` parameter could accept arbitrarily large values, leading to unbounded resource consumption during `crawl` or `map` actions.
⚠️ **Risk:** An attacker could exploit this by providing a massive `max_pages` value, causing excessive memory usage, database bloat, and compute resource exhaustion, potentially leading to denial of service.
🛡️ **Solution:** Enforce a hard maximum limit (`_MAX_PAGES_LIMIT = 100`) within the `extract` tool implementation by clamping the user-provided `max_pages` value using `min(max_pages, _MAX_PAGES_LIMIT)`. Added tests to verify the capping behavior.

---
*PR created automatically by Jules for task [2794937422406507988](https://jules.google.com/task/2794937422406507988) started by @n24q02m*