### PR TITLE
🧹 Refactor massive `_do_docs_search` into helper functions

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1210,79 +1210,77 @@ async def _background_index_and_search(
         logger.error(f"Background indexing failed for {library}: {e}")
 
 
-async def _do_docs_search(
+async def _search_existing_index(
     library: str,
+    lib_key: str,
     query: str,
-    language: str | None = None,
-    version: str | None = None,
-    limit: int = 10,
-) -> str:
-    """Search library documentation. Auto-discovers and indexes if needed."""
-    if not _docs_db:
-        return "Error: Docs database not initialized"
-
-    # Build library identity — include language for DB disambiguation
-    # e.g., "redis" (no lang) vs "redis:python" vs "redis:javascript"
-    lib_key = f"{library}:{language.lower()}" if language else library
-
+    version: str | None,
+    limit: int,
+) -> str | None:
+    """Search the existing index for a library if it is already indexed."""
     from wet_mcp.sources.docs import DISCOVERY_VERSION
 
-    # Step 1: Check if library is already indexed
+    if not _docs_db:
+        return None
+
     lib = _docs_db.get_library(lib_key)
+    if not lib:
+        return None
 
-    if lib:
-        # Invalidate cache if discovery scoring has been updated
-        cached_version = lib.get("discovery_version", 0)
-        if cached_version < DISCOVERY_VERSION:
-            logger.info(
-                f"Library '{lib_key}' cached with discovery v{cached_version} "
-                f"(current v{DISCOVERY_VERSION}), forcing re-index"
+    # Invalidate cache if discovery scoring has been updated
+    cached_version = lib.get("discovery_version", 0)
+    if cached_version < DISCOVERY_VERSION:
+        logger.info(
+            f"Library '{lib_key}' cached with discovery v{cached_version} "
+            f"(current v{DISCOVERY_VERSION}), forcing re-index"
+        )
+        return None
+
+    # Check if we have indexed chunks
+    ver = _docs_db.get_best_version(lib["id"], version)
+    if ver and ver.get("chunk_count", 0) > 0:
+        # Search existing index — retrieve extra candidates for reranking
+        query_embedding = await _embed(query, is_query=True)
+        retrieve_limit = limit * _RERANK_CANDIDATE_MULTIPLIER
+
+        results = _docs_db.search(
+            query=query,
+            library_name=lib_key,
+            version=version,
+            limit=retrieve_limit,
+            query_embedding=query_embedding,
+        )
+
+        if results:
+            # Rerank if available, otherwise truncate to limit
+            results = await _rerank_results(query, results, limit)
+            import json
+
+            return json.dumps(
+                {
+                    "library": library,
+                    "version": ver.get("version", "latest"),
+                    "results": results,
+                    "total": len(results),
+                    "source": "cached_index",
+                },
+                ensure_ascii=False,
+                indent=2,
             )
-            lib = None  # Force re-discovery below
+    return None
 
-    if lib:
-        # Check if we have indexed chunks
-        ver = _docs_db.get_best_version(lib["id"], version)
-        if ver and ver.get("chunk_count", 0) > 0:
-            # Search existing index — retrieve extra candidates for reranking
-            query_embedding = await _embed(query, is_query=True)
-            retrieve_limit = limit * _RERANK_CANDIDATE_MULTIPLIER
 
-            results = _docs_db.search(
-                query=query,
-                library_name=lib_key,
-                version=version,
-                limit=retrieve_limit,
-                query_embedding=query_embedding,
-            )
+async def _discover_library_metadata(
+    library: str, language: str | None
+) -> tuple[str, str, str, str]:
+    """Discover library metadata from registries and fallback to SearXNG."""
+    from wet_mcp.sources.docs import discover_library
 
-            if results:
-                # Rerank if available, otherwise truncate to limit
-                results = await _rerank_results(query, results, limit)
-                return json.dumps(
-                    {
-                        "library": library,
-                        "version": ver.get("version", "latest"),
-                        "results": results,
-                        "total": len(results),
-                        "source": "cached_index",
-                    },
-                    ensure_ascii=False,
-                    indent=2,
-                )
-
-    # Step 2: Auto-discover and index
-    logger.info(f"Library '{lib_key}' not indexed, discovering docs...")
-
-    from wet_mcp.sources.docs import (
-        discover_library,
-    )
-
-    # Discover library metadata from registries (with sub-timeout)
     docs_url = ""
     repo_url = ""
     registry = ""
     description = ""
+
     try:
         discovery = await asyncio.wait_for(
             discover_library(library, language=language),
@@ -1301,7 +1299,6 @@ async def _do_docs_search(
         description = discovery.get("description", "")
     else:
         # Fallback: use SearXNG to find docs
-        # Include language context for better results
         search_query = (
             f"{library} {language} documentation"
             if language
@@ -1321,6 +1318,8 @@ async def _do_docs_search(
                 ),
                 timeout=15,
             )
+            import json
+
             search_data = json.loads(search_result)
             top_results = search_data.get("results", [])
             if top_results:
@@ -1330,6 +1329,76 @@ async def _do_docs_search(
         except json.JSONDecodeError:
             pass
 
+    return docs_url, repo_url, registry, description
+
+
+async def _immediate_fallback_search(
+    library: str, language: str | None, query: str, docs_url: str, limit: int
+) -> list[dict]:
+    """Perform an immediate fallback web search while background indexing occurs."""
+    import json
+
+    fallback_search_query = (
+        f"site:{urlparse(docs_url).netloc} {query}"
+        if docs_url
+        else f"{library} {language} {query}"
+    )
+    fallback_data = {"results": []}
+    try:
+        searxng_url = await asyncio.wait_for(ensure_searxng(), timeout=_SEARXNG_TIMEOUT)
+        fallback_result = await asyncio.wait_for(
+            searxng_search(
+                searxng_url=searxng_url,
+                query=fallback_search_query,
+                categories="general",
+                max_results=limit,
+            ),
+            timeout=15,
+        )
+        fallback_data = json.loads(fallback_result)
+        if "results" in fallback_data and fallback_data["results"]:
+            fallback_data["results"] = await _rerank_results(
+                query, fallback_data["results"], top_n=limit
+            )
+    except Exception as e:
+        logger.debug(f"Immediate fallback search failed: {e}")
+
+    return fallback_data.get("results", [])
+
+
+async def _do_docs_search(
+    library: str,
+    query: str,
+    language: str | None = None,
+    version: str | None = None,
+    limit: int = 10,
+) -> str:
+    """Search library documentation. Auto-discovers and indexes if needed."""
+    if not _docs_db:
+        return "Error: Docs database not initialized"
+
+    # Build library identity — include language for DB disambiguation
+    # e.g., "redis" (no lang) vs "redis:python" vs "redis:javascript"
+    lib_key = f"{library}:{language.lower()}" if language else library
+
+    # Step 1: Check if library is already indexed
+    existing_result = await _search_existing_index(
+        library=library,
+        lib_key=lib_key,
+        query=query,
+        version=version,
+        limit=limit,
+    )
+    if existing_result:
+        return existing_result
+
+    # Step 2: Auto-discover and index
+    logger.info(f"Library '{lib_key}' not indexed, discovering docs...")
+
+    docs_url, repo_url, registry, description = await _discover_library_metadata(
+        library, language
+    )
+
     if not docs_url:
         # When no docs URL found but we have a GitHub repo URL,
         # use it as the docs source — _fetch_and_chunk_docs will
@@ -1338,6 +1407,8 @@ async def _do_docs_search(
             docs_url = repo_url
             logger.info(f"No docs URL for '{library}', using GitHub repo: {repo_url}")
         else:
+            import json
+
             return json.dumps(
                 {
                     "error": f"Could not find documentation URL for '{library}'",
@@ -1378,36 +1449,21 @@ async def _do_docs_search(
     )
 
     # Do immediate fallback web search
-    fallback_search_query = (
-        f"site:{urlparse(docs_url).netloc} {query}"
-        if docs_url
-        else f"{library} {language} {query}"
+    temporary_results = await _immediate_fallback_search(
+        library=library,
+        language=language,
+        query=query,
+        docs_url=docs_url,
+        limit=limit,
     )
-    fallback_data = {"results": []}
-    try:
-        searxng_url = await asyncio.wait_for(ensure_searxng(), timeout=_SEARXNG_TIMEOUT)
-        fallback_result = await asyncio.wait_for(
-            searxng_search(
-                searxng_url=searxng_url,
-                query=fallback_search_query,
-                categories="general",
-                max_results=limit,
-            ),
-            timeout=15,
-        )
-        fallback_data = json.loads(fallback_result)
-        if "results" in fallback_data and fallback_data["results"]:
-            fallback_data["results"] = await _rerank_results(
-                query, fallback_data["results"], top_n=limit
-            )
-    except Exception as e:
-        logger.debug(f"Immediate fallback search failed: {e}")
+
+    import json
 
     return json.dumps(
         {
             "status": "indexing_in_progress",
             "message": f"Library '{library}' is currently being downloaded and indexed in the background (this may take 3-5 minutes). In the meantime, here are temporary web search results.",
-            "temporary_results": fallback_data.get("results", []),
+            "temporary_results": temporary_results,
             "library": library,
             "docs_url": docs_url,
         },

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.9.3"
+version = "2.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored the massive `_do_docs_search` function inside `src/wet_mcp/server.py` into distinct helper functions: `_search_existing_index`, `_discover_library_metadata`, and `_immediate_fallback_search`.

💡 **Why:** How this improves maintainability
The original `_do_docs_search` handled discovery, indexing, fetching, embedding, and searching, making it monolithic and difficult to read or test in isolation. By breaking it into smaller, single-responsibility async functions, the code is much easier to maintain, understand, and unit test independently.

✅ **Verification:** How you confirmed the change is safe
- Verified all the original control flows are preserved.
- Passed `ruff check` and `ruff format` successfully.
- Passed the existing extensive test suite via `pytest tests/`.
- Validated logic using the `request_code_review` MCP tool.

✨ **Result:** The improvement achieved
A highly readable, decoupled orchestration function (`_do_docs_search`) delegating complex work to distinct background and asynchronous helper components without dropping any original functionality or variables.

---
*PR created automatically by Jules for task [7448133978921284801](https://jules.google.com/task/7448133978921284801) started by @n24q02m*