### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix plain text API keys in config

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -110,15 +110,15 @@ class Settings(BaseSettings):
 
     # LiteLLM Proxy (selfhosted gateway)
     litellm_proxy_url: str = ""  # e.g. http://10.0.0.20:4000
-    litellm_proxy_key: str = ""
+    litellm_proxy_key: SecretStr | None = None
 
     # Custom endpoints (e.g. modalcom-ai-workers on Modal.com)
     embedding_api_base: str = ""
-    embedding_api_key: str = ""
+    embedding_api_key: SecretStr | None = None
     rerank_api_base: str = ""
-    rerank_api_key: str = ""
+    rerank_api_key: SecretStr | None = None
     llm_api_base: str = ""
-    llm_api_key: str = ""
+    llm_api_key: SecretStr | None = None
 
     llm_models: str = "gemini/gemini-3-flash-preview"  # provider/model (fallback chain)
     llm_temperature: float | None = None
@@ -370,7 +370,11 @@ class Settings(BaseSettings):
             import litellm
 
             os.environ["LITELLM_PROXY_API_BASE"] = self.litellm_proxy_url
-            os.environ["LITELLM_PROXY_API_KEY"] = self.litellm_proxy_key
+            os.environ["LITELLM_PROXY_API_KEY"] = (
+                self.litellm_proxy_key.get_secret_value()
+                if self.litellm_proxy_key
+                else ""
+            )
             litellm.use_litellm_proxy = True
             logger.info(f"LiteLLM Proxy mode: {self.litellm_proxy_url}")
         elif mode == "sdk":
@@ -387,7 +391,7 @@ class Settings(BaseSettings):
         if self.embedding_api_base:
             kwargs["api_base"] = self.embedding_api_base
         if self.embedding_api_key:
-            kwargs["api_key"] = self.embedding_api_key
+            kwargs["api_key"] = self.embedding_api_key.get_secret_value()
         return kwargs
 
     def get_rerank_litellm_kwargs(self) -> dict:
@@ -396,7 +400,7 @@ class Settings(BaseSettings):
         if self.rerank_api_base:
             kwargs["api_base"] = self.rerank_api_base
         if self.rerank_api_key:
-            kwargs["api_key"] = self.rerank_api_key
+            kwargs["api_key"] = self.rerank_api_key.get_secret_value()
         return kwargs
 
     def get_llm_litellm_kwargs(self) -> dict:
@@ -405,7 +409,7 @@ class Settings(BaseSettings):
         if self.llm_api_base:
             kwargs["api_base"] = self.llm_api_base
         if self.llm_api_key:
-            kwargs["api_key"] = self.llm_api_key
+            kwargs["api_key"] = self.llm_api_key.get_secret_value()
         return kwargs
 
 

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -942,7 +942,10 @@ async def _probe_docs_url(homepage: str, lib_name: str, registry: str = "") -> s
             if any(seg in final_path for seg in _auth_segments):
                 return None
             # Avoid redirect loops back to the original homepage
-            if urlparse(final_url).netloc == parsed.netloc and label not in ("docs_path", "original"):
+            if urlparse(final_url).netloc == parsed.netloc and label not in (
+                "docs_path",
+                "original",
+            ):
                 final_parsed = urlparse(final_url)
                 if not final_parsed.path.startswith("/docs"):
                     if "docs" not in final_parsed.netloc:

--- a/uv.lock
+++ b/uv.lock
@@ -2073,7 +2073,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.10.2"
+version = "2.10.11"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: API keys are exposed as plain text `str` within the `Settings` class in `src/wet_mcp/config.py`.
🎯 Impact: This makes the API keys highly susceptible to accidental leakage via logs, error tracebacks, or output functions (e.g. `print()`, `.dict()`).
🔧 Fix: Upgraded the types of `litellm_proxy_key`, `embedding_api_key`, `rerank_api_key`, and `llm_api_key` to Pydantic's `SecretStr`, similar to the `api_keys` property. Added `get_secret_value()` usage in property getter properties/proxy assignment block.
✅ Verification: Ensure tests pass locally (ran `pytest`). The proxy setting and `kwargs` generation methods properly extract strings using `.get_secret_value()`.

---
*PR created automatically by Jules for task [9145310376189484266](https://jules.google.com/task/9145310376189484266) started by @n24q02m*