### PR TITLE
⚡ Bolt: [performance improvement] Reduce SQLite queries on cache hit

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-07 - [Performance Improvement] Reduce SQLite queries on cache hit
+**Learning:** SQLite versions 3.35.0+ support the `RETURNING` clause on `UPDATE` statements. This allows combining a `SELECT` and `UPDATE` into a single atomic operation. In a cache implementation (like `WebCache`), cache hits previously required two queries: `SELECT` to check existence and retrieve content, followed by `UPDATE` to increment the hit count.
+**Action:** Replace separate `SELECT` and `UPDATE` statements with a single `UPDATE ... RETURNING` query to cut database operations by 50% on cache hits and eliminate potential race conditions.

--- a/src/wet_mcp/cache.py
+++ b/src/wet_mcp/cache.py
@@ -80,16 +80,16 @@ class WebCache:
         key = _cache_key(action, params)
         now = time.time()
 
+        # Optimize: single query using RETURNING instead of SELECT + UPDATE
         row = self._conn.execute(
-            "SELECT content FROM web_cache WHERE key = ? AND expires_at > ?",
+            """UPDATE web_cache
+               SET hit_count = hit_count + 1
+               WHERE key = ? AND expires_at > ?
+               RETURNING content""",
             (key, now),
         ).fetchone()
 
         if row:
-            self._conn.execute(
-                "UPDATE web_cache SET hit_count = hit_count + 1 WHERE key = ?",
-                (key,),
-            )
             self._conn.commit()
             logger.debug(f"Cache HIT: {action} ({key[:12]}...)")
             return row["content"]

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -209,7 +209,11 @@ class LiteLLMBackend:
         try:
             from litellm import embedding as litellm_embedding
 
-            kwargs = {"model": self.model, "input": ["test"], "encoding_format": "float"}
+            kwargs = {
+                "model": self.model,
+                "input": ["test"],
+                "encoding_format": "float",
+            }
             if self.api_base:
                 kwargs["api_base"] = self.api_base
             if self.api_key:

--- a/uv.lock
+++ b/uv.lock
@@ -2303,7 +2303,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.10.12"
+version = "2.11.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
💡 What: Replaced a two-step `SELECT` then `UPDATE` query pattern with a single `UPDATE ... RETURNING content` query in `src/wet_mcp/cache.py`'s `get` method.

🎯 Why: To reduce database overhead. A cache is typically hit frequently, and prior to this change, each hit required two distinct queries to extract the data and increment the hit counter. A single query effectively cuts the SQLite overhead by 50% on cache hits and eliminates a minor race condition in the read-then-write flow.

📊 Impact: Reduces SQLite queries by 50% for web cache hits.

🔬 Measurement: Verify by monitoring database interaction logs or reviewing the query executed in the `get` method. Tests can also be run via `uv run pytest tests/test_server_comprehensive.py`.

---
*PR created automatically by Jules for task [14273226892630535988](https://jules.google.com/task/14273226892630535988) started by @n24q02m*