### PR TITLE
⚡ Bolt: [performance improvement] Atomic cache lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-08 - Atomic Cache Lookups
+**Learning:** In SQLite >= 3.35.0, you can combine separate read-then-write operations into a single atomic query using the UPDATE ... RETURNING clause. This cuts database operations in half and eliminates race conditions.
+**Action:** Look for read-modify-write patterns and consider using RETURNING to make them atomic.

--- a/src/wet_mcp/cache.py
+++ b/src/wet_mcp/cache.py
@@ -80,16 +80,13 @@ class WebCache:
         key = _cache_key(action, params)
         now = time.time()
 
+        # ⚡ Bolt: Optimize cache lookup into a single atomic query (halves DB ops)
         row = self._conn.execute(
-            "SELECT content FROM web_cache WHERE key = ? AND expires_at > ?",
+            "UPDATE web_cache SET hit_count = hit_count + 1 WHERE key = ? AND expires_at > ? RETURNING content",
             (key, now),
         ).fetchone()
 
         if row:
-            self._conn.execute(
-                "UPDATE web_cache SET hit_count = hit_count + 1 WHERE key = ?",
-                (key,),
-            )
             self._conn.commit()
             logger.debug(f"Cache HIT: {action} ({key[:12]}...)")
             return row["content"]


### PR DESCRIPTION
**💡 What:**
Replaced the separate `SELECT` and `UPDATE` statements in `WebCache.get` with a single atomic `UPDATE ... RETURNING content` query.

**🎯 Why:**
The `get` method previously performed a `SELECT` to check if a cached item existed and was unexpired, and then executed an `UPDATE` to increment the `hit_count`. This is a classic read-modify-write pattern that requires two separate database operations and can theoretically suffer from race conditions in high-concurrency scenarios.

**📊 Impact:**
- Reduces database operations by exactly 50% on every successful cache hit.
- Eliminates the need for application-level locks or reliance purely on WAL mode to prevent race conditions during hit counting.

**🔬 Measurement:**
Run `uv run pytest tests/test_cache.py`. The existing test suite comprehensively covers TTL expiration, hit counting, and retrieval logic, all of which pass flawlessly with the new atomic query.

---
*PR created automatically by Jules for task [5472752390222339770](https://jules.google.com/task/5472752390222339770) started by @n24q02m*