### PR TITLE
feat: add test for `research_topic` prompt

### DIFF
--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -2010,3 +2010,13 @@ async def test_with_timeout_task_exception():
 
         with pytest.raises(ValueError, match="task failed"):
             await server._with_timeout(failing_coro(), "test")
+
+
+def test_research_topic():
+    """Test research_topic prompt generation."""
+    topic = "Quantum Computing"
+    res = server.research_topic(topic)
+    assert "Research the following topic thoroughly:" in res
+    assert topic in res
+    assert "action='research'" in res
+    assert "action='extract'" in res

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `research_topic` prompt in `src/wet_mcp/server.py` lacked test coverage.
📊 **Coverage:** Added `test_research_topic` to `tests/test_server_comprehensive.py` to cover prompt string generation, testing that the required substrings and topic parameter are correctly embedded.
✨ **Result:** Test coverage for `src/wet_mcp/server.py` prompt methods is improved, preventing regressions in future refactors.

---
*PR created automatically by Jules for task [13223973516503693339](https://jules.google.com/task/13223973516503693339) started by @n24q02m*