### PR TITLE
fix: add debug logging to SearXNG stale port process cleanup

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -518,8 +518,10 @@ def _kill_stale_port_process(port: int) -> None:
                         pid = int(pid_str)
                         if pid > 0:
                             _sigterm_then_kill(pid, f"stale port {port}")
-                    except (ValueError, ProcessLookupError, PermissionError):
-                        pass
+                    except (ValueError, ProcessLookupError, PermissionError) as e:
+                        logger.debug(
+                            f"Failed to kill stale port process {pid_str}: {e}"
+                        )
         except Exception:
             pass
     else:
@@ -538,8 +540,10 @@ def _kill_stale_port_process(port: int) -> None:
                         pid = int(pid_str.strip())
                         if pid > 0 and pid != os.getpid():
                             _sigterm_then_kill(pid, f"stale port {port}")
-                    except (ValueError, ProcessLookupError, PermissionError):
-                        pass
+                    except (ValueError, ProcessLookupError, PermissionError) as e:
+                        logger.debug(
+                            f"Failed to kill stale port process {pid_str.strip()}: {e}"
+                        )
         except FileNotFoundError:
             # lsof not available, try fuser
             try:

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Replaced the silent exception handling (`pass`) during the cleanup of stale processes in `_kill_stale_port_process` with explicit debug logging on both Unix and Windows blocks.
💡 **Why:** This improves maintainability and code diagnosability without changing the program's actual execution flow, addressing a common code health anti-pattern.
✅ **Verification:** Verified by running `uv run ruff check . --fix`, `uv run ruff format .`, and running the entire `pytest` suite.
✨ **Result:** Better visibility into edge case failures when a target port process is unable to be correctly identified or cleaned up.

---
*PR created automatically by Jules for task [4370662623493708555](https://jules.google.com/task/4370662623493708555) started by @n24q02m*