### PR TITLE
feat: add test coverage for get_model_capabilities

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -238,3 +238,31 @@ def test_analyze_media_tilde_download_dir(mock_settings, tmp_path, monkeypatch):
     # File exists and is within download_dir, so we should get past the path check
     # (will fail at LLM call since we didn't mock it, but NOT "Access denied")
     assert "Access denied" not in result
+
+
+@patch("wet_mcp.llm.litellm.supports_vision")
+@patch("wet_mcp.llm.litellm.supports_audio_input")
+@patch("wet_mcp.llm.litellm.supports_audio_output")
+def test_get_model_capabilities(mock_audio_out, mock_audio_in, mock_vision):
+    """Test get_model_capabilities."""
+    from wet_mcp.llm import get_model_capabilities
+
+    # Setup mocks
+    mock_vision.return_value = True
+    mock_audio_in.return_value = False
+    mock_audio_out.return_value = True
+
+    # Call function
+    result = get_model_capabilities("fake-model")
+
+    # Assert result structure
+    assert result == {
+        "vision": True,
+        "audio_input": False,
+        "audio_output": True,
+    }
+
+    # Verify capability checks were called with the correct model
+    mock_vision.assert_called_once_with("fake-model")
+    mock_audio_in.assert_called_once_with("fake-model")
+    mock_audio_out.assert_called_once_with("fake-model")

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `get_model_capabilities` function in `src/wet_mcp/llm.py` was previously missing dedicated unit tests. It relies on external calls to `litellm` capability checkers which needed to be appropriately mocked to test safely.
📊 **Coverage:** A new test case `test_get_model_capabilities` has been added to `tests/test_llm.py` which mocks out `litellm.supports_vision`, `litellm.supports_audio_input`, and `litellm.supports_audio_output`. It covers the expected returned dictionary format and verifies that the correct model identifier is passed to the underlying `litellm` calls.
✨ **Result:** Test coverage and reliability for LLM utility functions are improved, and we can refactor `get_model_capabilities` in the future with confidence.

---
*PR created automatically by Jules for task [17659773396521234949](https://jules.google.com/task/17659773396521234949) started by @n24q02m*