### PR TITLE
fix: testing improvement] Add error handling test for urlparse in URL validation

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -215,3 +215,10 @@ def test_pinned_getaddrinfo_ipv6_sockaddr():
     finally:
         with _dns_cache_lock:
             _dns_cache.pop("ipv6-host.example", None)
+
+
+def test_is_safe_url_urlparse_exception():
+    """Test is_safe_url catches urlparse exceptions for malformed URLs."""
+    # In Python 3.12+, urlparse raises a ValueError for malformed URLs
+    # containing square brackets that do not enclose a valid IP address.
+    assert not is_safe_url("http://[example.com]/")

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The testing gap in `src/wet_mcp/security.py` where the exception handling block for `urlparse` within `is_safe_url` was untested.
📊 **Coverage:** A new test `test_is_safe_url_urlparse_exception` was added to `tests/test_security.py` to cover the scenario where a malformed URL with invalid IPv6 brackets (e.g., `http://[example.com]/`) raises a `ValueError` in Python 3.12+.
✨ **Result:** Test coverage improved, ensuring that unexpected `urlparse` failures are safely handled and correctly return `False`, preventing potential crashes during URL validation.

---
*PR created automatically by Jules for task [6873818099475110889](https://jules.google.com/task/6873818099475110889) started by @n24q02m*