### PR TITLE
fix: fix Hardcoded Secret Placeholder in SearXNG settings

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -407,9 +407,13 @@ def _get_settings_path(port: int) -> Path:
     )
 
     # Generate random secret key for this session
-    # This prevents using the hardcoded secret from the template
+    # We inject it dynamically under the server block to avoid keeping placeholder secrets in the config file
     secret = secrets.token_hex(32)
-    content = content.replace("REPLACE_WITH_REAL_SECRET", secret)
+    content = content.replace(
+        "server:",
+        f'server:\n  secret_key: "{secret}"',
+        1,
+    )
 
     settings_file.write_text(content)
     logger.debug(f"SearXNG settings written to: {settings_file}")

--- a/src/wet_mcp/searxng_settings.yml
+++ b/src/wet_mcp/searxng_settings.yml
@@ -4,7 +4,6 @@
 use_default_settings: true
 
 server:
-  secret_key: "REPLACE_WITH_REAL_SECRET"
   bind_address: "127.0.0.1"
   port: 41592
   limiter: false

--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -53,8 +53,10 @@ def test_get_settings_path():
         mock_bundled_file.read_text.assert_called_once()
 
         # Verify write_text called with correct content
-        expected_content = "server:\n  port: 9090\n"
-        mock_settings_file.write_text.assert_called_once_with(expected_content)
+        mock_settings_file.write_text.assert_called_once()
+        written_content = mock_settings_file.write_text.call_args[0][0]
+        assert "port: 9090" in written_content
+        assert "secret_key:" in written_content
 
 
 # Mock the settings object

--- a/tests/test_security_searxng_secret.py
+++ b/tests/test_security_searxng_secret.py
@@ -25,9 +25,7 @@ def test_secret_key_replacement():
     mock_files.joinpath.return_value = mock_bundled_file
 
     # Mock the template content with the placeholder
-    template_content = (
-        "server:\n  port: 41592\n  secret_key: REPLACE_WITH_REAL_SECRET\n"
-    )
+    template_content = "server:\n  port: 41592\n"
     mock_bundled_file.read_text.return_value = template_content
 
     with (
@@ -60,6 +58,6 @@ def test_secret_key_replacement():
             if "secret_key:" in line:
                 secret = line.split(":", 1)[1].strip()
                 # 32 bytes hex = 64 chars
-                assert len(secret) == 64
+                assert len(secret.strip('"')) == 64
                 # Verify it is hex
-                int(secret, 16)
+                int(secret.strip('"'), 16)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the presence of a hardcoded placeholder secret string (`REPLACE_WITH_REAL_SECRET`) in the `searxng_settings.yml` configuration file. While this placeholder was already being overwritten in `searxng_runner.py` via `replace` logic, keeping such secrets in files is an insecure design pattern.

⚠️ **Risk:** Storing hardcoded secrets or even placeholders that resemble secrets in the source code can easily lead to credential leaks or improper usage by downstream consumers. It can confuse automated secret-scanning tools and establish a bad practice of committing secrets into the repository. 

🛡️ **Solution:** The hardcoded `secret_key: "REPLACE_WITH_REAL_SECRET"` line was removed entirely from `searxng_settings.yml`. Instead, the `searxng_runner.py` script now correctly injects the dynamically generated `secret_key` under the `server:` block by parsing and inserting it using a proper text substitution strategy on the read configuration data. Tests `test_searxng_runner.py` and `test_security_searxng_secret.py` were adjusted to cover the new string manipulation logic safely.

---
*PR created automatically by Jules for task [4833611613757851130](https://jules.google.com/task/4833611613757851130) started by @n24q02m*