### PR TITLE
fix: testing improvement] Add error handling test in url validation

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -215,3 +215,10 @@ def test_pinned_getaddrinfo_ipv6_sockaddr():
     finally:
         with _dns_cache_lock:
             _dns_cache.pop("ipv6-host.example", None)
+
+
+def test_is_safe_url_invalid_format():
+    """Test is_safe_url handles exceptions during urlparse."""
+    # In Python 3.12+, urlparse raises ValueError for malformed URLs
+    # containing square brackets that do not enclose a valid IP address.
+    assert not is_safe_url("http://[example.com]/")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the error handling block during `urlparse` validation in `is_safe_url`. In particular, malformed URLs that cause an exception during `urllib.parse.urlparse` were not tested.
📊 **Coverage:** A new test case `test_is_safe_url_invalid_format` has been added which passes a malformed URL with an invalid IPv6-like format `http://[example.com]/`. This specifically causes `urlparse` to raise a `ValueError` in modern Python versions, directly covering the `except Exception:` block and ensuring it returns `False`.
✨ **Result:** Test coverage for `src/wet_mcp/security.py` has been improved, and regressions involving `is_safe_url` error handling are prevented.

---
*PR created automatically by Jules for task [3882918565831909613](https://jules.google.com/task/3882918565831909613) started by @n24q02m*