### PR TITLE
feat: add missing tests for library_docs

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,15 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+def test_library_docs():
+    """Test library_docs prompt generation."""
+    from wet_mcp.server import library_docs
+
+    result = library_docs(library="react", question="how to use hooks")
+
+    assert "Find documentation for 'react' to answer: how to use hooks" in result
+    assert "action='docs'" in result
+    assert "query='how to use hooks'" in result
+    assert "If results are insufficient" in result

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The testing gap for `library_docs` function addressed
📊 **Coverage:** The happy path for the `library_docs` function in `src/wet_mcp/server.py` is now tested, ensuring that the library name, question, action, and fallback logic are present in the generated string prompt.
✨ **Result:** Increased test coverage and confidence in `library_docs` prompt generation.

---
*PR created automatically by Jules for task [10899114075038242393](https://jules.google.com/task/10899114075038242393) started by @n24q02m*