### PR TITLE
fix: fix silent exception handling in DB delete operations

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -399,8 +399,8 @@ class DocsDB:
                     "(SELECT id FROM doc_chunks WHERE library_id = ?)",
                     (lib_id,),
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"Failed to delete vector chunks: {e}")
 
         # Cascade deletes chunks and versions
         self._conn.execute("DELETE FROM doc_chunks WHERE library_id = ?", (lib_id,))
@@ -553,8 +553,8 @@ class DocsDB:
                     "(SELECT id FROM doc_chunks WHERE version_id = ?)",
                     (version_id,),
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"Failed to delete vector chunks: {e}")
 
         cursor = self._conn.execute(
             "DELETE FROM doc_chunks WHERE version_id = ?", (version_id,)
@@ -878,8 +878,8 @@ class DocsDB:
             if self._vec_enabled:
                 try:
                     self._conn.execute("DELETE FROM doc_chunks_vec")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Failed to clear vector chunks: {e}")
             self._conn.execute("DELETE FROM doc_chunks")
             self._conn.execute("DELETE FROM versions")
             self._conn.execute("DELETE FROM libraries")
@@ -969,5 +969,5 @@ class DocsDB:
         """Close database connection."""
         try:
             self._conn.close()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to close DB connection: {e}")

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced silent exception handling (`except Exception: pass`) in DB delete and close operations with logging (`logger.warning(...)`) in `src/wet_mcp/db.py`.

💡 **Why:** How this improves maintainability
Silent exceptions hide potential database issues (e.g., locks, permission errors). Logging these warnings significantly improves diagnosability, maintainability, and debugging without altering the execution flow. 

✅ **Verification:** How you confirmed the change is safe
- Visually reviewed the edits.
- Successfully ran `uv run ruff format .` and `uv run ruff check . --fix`.
- Executed the full test suite (`uv run pytest`) and verified all tests passed without regressions.
- Received code review feedback that rated the patch as safe, clean, and directly fulfilling the requirements.

✨ **Result:** The improvement achieved
Eliminated 4 instances of swallowed exceptions, increasing visibility into potential database manipulation errors and thereby improving code health across `db.py`.

---
*PR created automatically by Jules for task [5319940331321270490](https://jules.google.com/task/5319940331321270490) started by @n24q02m*