### PR TITLE
fix: fix command execution risk via unvalidated port string formatting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-28 - Command Execution Risk with user-provided port
+**Vulnerability:** Argument injection via f-string formatting (`f":{port}"`) in `subprocess.run` inside `_kill_stale_port_process` if the `port` variable contains malicious strings, bypassing the lack of `shell=True`.
+**Learning:** Always validate and safely cast external input (like casting `port` to an `int`) before interpolating it into command line arguments, even when `shell=True` is not used.
+**Prevention:** Strictly enforce integer typing `int(port)` before using it in shell-executed parameters, and run `pytest` to ensure functionality is preserved.

--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -500,6 +500,12 @@ def _kill_stale_port_process(port: int) -> None:
     This prevents 'address already in use' errors when restarting
     after a crash that left a zombie process behind.
     """
+    try:
+        port = int(port)
+    except (ValueError, TypeError):
+        logger.error(f"Invalid port provided to _kill_stale_port_process: {port}")
+        return
+
     if sys.platform == "win32":
         # On Windows, use netstat to find the PID
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `_kill_stale_port_process` function in `src/wet_mcp/searxng_runner.py` used the `port` variable in an f-string inside a `subprocess.run` command argument list.
⚠️ **Risk:** Although `shell=True` was not used, this could lead to argument injection if a malicious string was passed as the `port`.
🛡️ **Solution:** Cast `port` to an `int` at the beginning of the function and handle parsing errors gracefully.

---
*PR created automatically by Jules for task [173602881271746484](https://jules.google.com/task/173602881271746484) started by @n24q02m*