### PR TITLE
feat: code health improvement] Group parameters in _split_preserving_code

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 import zlib
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -2184,6 +2185,15 @@ _HEADING_RE = re.compile(r"^(#{1,4})\s+(.+)$", re.MULTILINE)
 _CODE_FENCE_RE = re.compile(r"^```")
 
 
+@dataclass
+class ChunkContext:
+    title: str
+    heading_path: str
+    url: str
+    max_chunk_size: int
+    min_chunk_size: int
+
+
 def chunk_markdown(
     content: str,
     url: str = "",
@@ -2215,15 +2225,14 @@ def chunk_markdown(
         if len(text) >= min_chunk_size:
             # Split oversized chunks by double newline, preserving code blocks
             if len(text) > max_chunk_size:
-                _split_preserving_code(
-                    text,
-                    chunks,
-                    current_title,
-                    heading_path,
-                    url,
-                    max_chunk_size,
-                    min_chunk_size,
+                ctx = ChunkContext(
+                    title=current_title,
+                    heading_path=heading_path,
+                    url=url,
+                    max_chunk_size=max_chunk_size,
+                    min_chunk_size=min_chunk_size,
                 )
+                _split_preserving_code(text, chunks, ctx)
             else:
                 chunks.append(
                     {
@@ -2273,11 +2282,7 @@ def chunk_markdown(
 def _split_preserving_code(
     text: str,
     chunks: list[dict],
-    title: str,
-    heading_path: str,
-    url: str,
-    max_chunk_size: int,
-    min_chunk_size: int,
+    ctx: ChunkContext,
 ) -> None:
     """Split oversized text by paragraphs without breaking code blocks.
 
@@ -2303,17 +2308,17 @@ def _split_preserving_code(
     if current_segment:
         segments.append("\n".join(current_segment))
 
-    # Merge segments into chunks respecting max_chunk_size
+    # Merge segments into chunks respecting ctx.max_chunk_size
     buffer = ""
     for seg in segments:
-        if buffer and len(buffer) + len(seg) + 2 > max_chunk_size:
-            if buffer.strip() and len(buffer.strip()) >= min_chunk_size:
+        if buffer and len(buffer) + len(seg) + 2 > ctx.max_chunk_size:
+            if buffer.strip() and len(buffer.strip()) >= ctx.min_chunk_size:
                 chunks.append(
                     {
                         "content": buffer.strip(),
-                        "title": title,
-                        "heading_path": heading_path,
-                        "url": url,
+                        "title": ctx.title,
+                        "heading_path": ctx.heading_path,
+                        "url": ctx.url,
                         "chunk_index": len(chunks),
                     }
                 )
@@ -2321,13 +2326,13 @@ def _split_preserving_code(
         else:
             buffer = f"{buffer}\n\n{seg}" if buffer else seg
 
-    if buffer.strip() and len(buffer.strip()) >= min_chunk_size:
+    if buffer.strip() and len(buffer.strip()) >= ctx.min_chunk_size:
         chunks.append(
             {
                 "content": buffer.strip(),
-                "title": title,
-                "heading_path": heading_path,
-                "url": url,
+                "title": ctx.title,
+                "heading_path": ctx.heading_path,
+                "url": ctx.url,
                 "chunk_index": len(chunks),
             }
         )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from wet_mcp.sources.docs import (
+    ChunkContext,
     _is_blocked_content,
     _rst_to_markdown,
     _split_preserving_code,
@@ -412,15 +413,14 @@ class TestSplitPreservingCode:
             "Conclusion text with enough content to matter."
         )
         chunks: list[dict] = []
-        _split_preserving_code(
-            text,
-            chunks,
-            "title",
-            "heading",
-            "url",
+        ctx = ChunkContext(
+            title="title",
+            heading_path="heading",
+            url="url",
             max_chunk_size=100,
             min_chunk_size=20,
         )
+        _split_preserving_code(text, chunks, ctx)
         # Code block should be intact in one chunk
         code_chunks = [c for c in chunks if "```python" in c["content"]]
         assert len(code_chunks) >= 1
@@ -432,15 +432,14 @@ class TestSplitPreservingCode:
             [f"Paragraph {i} with enough text to fill. " * 3 for i in range(10)]
         )
         chunks: list[dict] = []
-        _split_preserving_code(
-            text,
-            chunks,
-            "t",
-            "h",
-            "u",
+        ctx = ChunkContext(
+            title="t",
+            heading_path="h",
+            url="u",
             max_chunk_size=200,
             min_chunk_size=20,
         )
+        _split_preserving_code(text, chunks, ctx)
         assert len(chunks) > 1
         # No chunk should exceed max by much
         for c in chunks:
@@ -450,15 +449,14 @@ class TestSplitPreservingCode:
         """Each produced chunk has correct title, heading_path, url."""
         text = "Some content. " * 50
         chunks: list[dict] = []
-        _split_preserving_code(
-            text,
-            chunks,
-            "My Title",
-            "Section > Sub",
-            "https://example.com",
+        ctx = ChunkContext(
+            title="My Title",
+            heading_path="Section > Sub",
+            url="https://example.com",
             max_chunk_size=100,
             min_chunk_size=10,
         )
+        _split_preserving_code(text, chunks, ctx)
         assert len(chunks) >= 1
         for c in chunks:
             assert c["title"] == "My Title"
@@ -472,15 +470,14 @@ class TestSplitPreservingCode:
             {"content": "existing2", "chunk_index": 1},
         ]
         text = "New content paragraph. " * 20
-        _split_preserving_code(
-            text,
-            existing_chunks,
-            "t",
-            "h",
-            "u",
+        ctx = ChunkContext(
+            title="t",
+            heading_path="h",
+            url="u",
             max_chunk_size=100,
             min_chunk_size=10,
         )
+        _split_preserving_code(text, existing_chunks, ctx)
         # New chunk indices should start from 2
         new_chunks = existing_chunks[2:]
         assert new_chunks[0]["chunk_index"] == 2


### PR DESCRIPTION
🎯 **What:** The `_split_preserving_code` function in `src/wet_mcp/sources/docs.py` had too many individual parameters (`title`, `heading_path`, `url`, `max_chunk_size`, `min_chunk_size`). Grouped them into a new `ChunkContext` dataclass.
💡 **Why:** Reduces parameter bloat, improves readability, and makes it easier to pass shared context down the chunking pipeline without modifying function signatures every time a new piece of metadata is needed.
✅ **Verification:** Verified by ensuring the code formats properly with `uv run ruff check` and `uv run ruff format`, and passes the entire test suite `uv run pytest`.
✨ **Result:** A cleaner interface for document chunking logic.

---
*PR created automatically by Jules for task [15692373652193896209](https://jules.google.com/task/15692373652193896209) started by @n24q02m*