### PR TITLE
fix: fix unused import in config.py

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -28,12 +28,9 @@ def _detect_gpu() -> bool:
 
 def _has_gguf_support() -> bool:
     """Check if llama-cpp-python is installed for GGUF models."""
-    try:
-        import llama_cpp  # noqa: F401
+    import importlib.util
 
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("llama_cpp") is not None
 
 
 def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -502,7 +502,7 @@ def test_has_gguf_support_missing():
     """_has_gguf_support returns False when llama_cpp is not installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch("builtins.__import__", side_effect=ImportError("no llama_cpp")):
+    with mock.patch("importlib.util.find_spec", return_value=None):
         assert _has_gguf_support() is False
 
 
@@ -510,7 +510,7 @@ def test_has_gguf_support_available():
     """_has_gguf_support returns True when llama_cpp is installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch.dict("sys.modules", {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 

--- a/tests/test_config_gpu.py
+++ b/tests/test_config_gpu.py
@@ -79,7 +79,7 @@ def test_detect_gpu_import_error():
 
 def test_has_gguf_support_installed():
     """Test _has_gguf_support returns True if llama_cpp is importable."""
-    with mock.patch.dict(sys.modules, {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused `import llama_cpp` in `src/wet_mcp/config.py` at line 32. Replaced the `try...except ImportError` block containing the raw import with `importlib.util.find_spec("llama_cpp") is not None` to safely and reliably check if the module is installed without triggering an unused import warning. Updated related unit tests in `tests/test_config.py` and `tests/test_config_gpu.py` to correctly mock `importlib.util.find_spec` instead of `builtins.__import__` or `sys.modules`.

💡 **Why:** How this improves maintainability
This eliminates an unused import, cleaning up the code without relying on a `# noqa: F401` suppression comment. Using `importlib.util.find_spec` is the standard Pythonic way to detect package presence without the side effects of importing the entire module.

✅ **Verification:** How you confirmed the change is safe
- Visually confirmed the code updates in `config.py` using `sed`.
- Ran linter (`uv run ruff check . --fix`) and formatter (`uv run ruff format .`) to ensure the codebase remains compliant with our style guidelines.
- Ran the full test suite (`uv run pytest`) which passed successfully, confirming no regressions.

✨ **Result:** The improvement achieved
A cleaner `config.py` file without unused imports and robust tests that correctly mock modern Python import discovery logic.

---
*PR created automatically by Jules for task [16006975522564679055](https://jules.google.com/task/16006975522564679055) started by @n24q02m*