### PR TITLE
feat: code Health: Clean up unused `llama_cpp` import in `config.py`

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -28,11 +28,11 @@ def _detect_gpu() -> bool:
 
 def _has_gguf_support() -> bool:
     """Check if llama-cpp-python is installed for GGUF models."""
-    try:
-        import llama_cpp  # noqa: F401
+    import importlib.util
 
-        return True
-    except ImportError:
+    try:
+        return importlib.util.find_spec("llama_cpp") is not None
+    except (ImportError, ValueError):
         return False
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -502,7 +502,7 @@ def test_has_gguf_support_missing():
     """_has_gguf_support returns False when llama_cpp is not installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch("builtins.__import__", side_effect=ImportError("no llama_cpp")):
+    with mock.patch("importlib.util.find_spec", return_value=None):
         assert _has_gguf_support() is False
 
 
@@ -510,7 +510,7 @@ def test_has_gguf_support_available():
     """_has_gguf_support returns True when llama_cpp is installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch.dict("sys.modules", {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 

--- a/tests/test_config_gpu.py
+++ b/tests/test_config_gpu.py
@@ -79,7 +79,7 @@ def test_detect_gpu_import_error():
 
 def test_has_gguf_support_installed():
     """Test _has_gguf_support returns True if llama_cpp is importable."""
-    with mock.patch.dict(sys.modules, {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Removed the unused `import llama_cpp # noqa: F401` line at line 32 in `src/wet_mcp/config.py`. Instead of just deleting it, which would break the functionality of `_has_gguf_support()`, the logic was safely refactored to use `importlib.util.find_spec("llama_cpp")`.

💡 **Why:** Having explicit unused imports with `# noqa: F401` comments hurts code readability and maintainability when a more idiomatic Python feature (like `importlib.util.find_spec`) exists for this exact use-case. `find_spec` safely checks if a module is installed without actually executing its top-level code or causing linter warnings.

✅ **Verification:** 
- Formatted and linted code (`uv run ruff check . --fix` and `uv run ruff format .`).
- Updated corresponding unit tests in `tests/test_config.py` and `tests/test_config_gpu.py` to mock `importlib.util.find_spec` instead of `builtins.__import__` or `sys.modules`.
- Ran the entire test suite (`uv run pytest`), which passed 1052 tests with 0 failures.

✨ **Result:** Improved codebase maintainability by using an idiomatic module installation check instead of an explicitly ignored unused import. No functional changes.

---
*PR created automatically by Jules for task [12313312869137169041](https://jules.google.com/task/12313312869137169041) started by @n24q02m*