### PR TITLE
feat: code Health: Refactor overly long _create_tables in db.py

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -155,6 +155,19 @@ class DocsDB:
 
     def _create_tables(self) -> None:
         # Libraries metadata
+        self._create_libraries_table()
+        # Versions
+        self._create_versions_table()
+        # Document chunks
+        self._create_chunks_table()
+        # FTS5 (content-sync mode)
+        self._create_fts_tables_and_triggers()
+        # Vector table (optional)
+        self._create_vector_table()
+
+        self._conn.commit()
+
+    def _create_libraries_table(self) -> None:
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS libraries (
                 id TEXT PRIMARY KEY,
@@ -181,7 +194,7 @@ class DocsDB:
         except sqlite3.OperationalError:
             pass  # Column already exists
 
-        # Versions
+    def _create_versions_table(self) -> None:
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS versions (
                 id TEXT PRIMARY KEY,
@@ -197,7 +210,7 @@ class DocsDB:
             )
         """)
 
-        # Document chunks
+    def _create_chunks_table(self) -> None:
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS doc_chunks (
                 id TEXT PRIMARY KEY,
@@ -226,7 +239,7 @@ class DocsDB:
             ON doc_chunks(url, version_id, chunk_index)
         """)
 
-        # FTS5 (content-sync mode)
+    def _create_fts_tables_and_triggers(self) -> None:
         self._conn.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS doc_chunks_fts
             USING fts5(
@@ -262,7 +275,7 @@ class DocsDB:
             END
         """)
 
-        # Vector table (optional)
+    def _create_vector_table(self) -> None:
         if self._vec_enabled and self._embedding_dims > 0:
             row = self._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='doc_chunks_vec'"
@@ -275,8 +288,6 @@ class DocsDB:
                         embedding float[{self._embedding_dims}]
                     )
                 """)
-
-        self._conn.commit()
 
     # -----------------------------------------------------------------------
     # Stats

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The overly long `_create_tables` function in `src/wet_mcp/db.py` was refactored by extracting its monolithic SQL blocks into smaller, clearly named helper methods (`_create_libraries_table`, `_create_versions_table`, etc.).

💡 **Why:** This drastically improves the maintainability and readability of the `db.py` module by replacing a dense wall of SQL with self-documenting method calls, making it much easier to reason about the schema initialization sequence.

✅ **Verification:** I wrote a Python script to perform an exact string replacement, safely substituting the old method and inserting the new helper methods immediately after it. I then ran `uv run ruff format .` and `uv run ruff check . --fix` to verify syntactic correctness. Finally, I executed the full test suite (`uv run pytest`) and confirmed that 1052 tests passed without any regressions.

✨ **Result:** A cleaner, more modular `DocsDB` class where the setup sequence is self-evident at a glance. Behavior remains completely identical to the previous implementation.

---
*PR created automatically by Jules for task [3507058216683639826](https://jules.google.com/task/3507058216683639826) started by @n24q02m*