### PR TITLE
feat: testing improvement] Add missing tests for stop_auto_sync in sync.py

### DIFF
--- a/src/wet_mcp/sync.py
+++ b/src/wet_mcp/sync.py
@@ -396,8 +396,9 @@ def start_auto_sync(db: DocsDB) -> None:
 def stop_auto_sync() -> None:
     """Stop background auto-sync task."""
     global _sync_task
-    if _sync_task and not _sync_task.done():
-        _sync_task.cancel()
+    if _sync_task:
+        if not _sync_task.done():
+            _sync_task.cancel()
         _sync_task = None
 
 

--- a/tests/test_sync_comprehensive.py
+++ b/tests/test_sync_comprehensive.py
@@ -548,6 +548,21 @@ def test_stop_auto_sync():
     assert wet_mcp.sync._sync_task is None
 
 
+def test_stop_auto_sync_none():
+    wet_mcp.sync._sync_task = None
+    stop_auto_sync()
+    assert wet_mcp.sync._sync_task is None
+
+
+def test_stop_auto_sync_already_done():
+    mock_task = MagicMock()
+    mock_task.done.return_value = True
+    wet_mcp.sync._sync_task = mock_task
+    stop_auto_sync()
+    mock_task.cancel.assert_not_called()
+    assert wet_mcp.sync._sync_task is None
+
+
 @patch("wet_mcp.sync._get_rclone_path")
 @patch("wet_mcp.sync._download_rclone")
 @patch("wet_mcp.sync.subprocess.run")

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tests for `stop_auto_sync` in `src/wet_mcp/sync.py` were missing coverage for cases where `_sync_task` is `None` and cases where `_sync_task.done()` returns `True`. Also fixed a bug in `stop_auto_sync` where `_sync_task` was not cleared if it was already done.

📊 **Coverage:** What scenarios are now tested
- `test_stop_auto_sync_none()` tests the behavior when `_sync_task` is `None` (it safely handles it).
- `test_stop_auto_sync_already_done()` tests the behavior when `_sync_task` is finished (`done() == True`), ensuring that `cancel()` is not called and `_sync_task` is reset to `None`.

✨ **Result:** The improvement in test coverage
`stop_auto_sync` now has 100% test coverage and is more robust since it always resets `_sync_task` to `None`.

---
*PR created automatically by Jules for task [2274453283208584927](https://jules.google.com/task/2274453283208584927) started by @n24q02m*