### PR TITLE
feat: optimize string splitting in docs URL sorting

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -3482,7 +3482,16 @@ async def fetch_docs_pages(
         query_words = set(query.lower().split())
         scored = []
         for url in urls:
-            path_words = set(re.split(r"[-_/.]", urlparse(url).path.lower()))
+            # ⚡ Bolt Optimization: Replace slow re.split with fast chained replace+split
+            path_words = set(
+                urlparse(url)
+                .path.lower()
+                .replace("-", " ")
+                .replace("_", " ")
+                .replace("/", " ")
+                .replace(".", " ")
+                .split()
+            )
             overlap = len(query_words & path_words)
             scored.append((url, overlap))
         scored.sort(key=lambda x: x[1], reverse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
💡 What: Replaced `re.split` with a chained series of `.replace()` and a final `.split()` in `_sort_by_query`.
🎯 Why: `re.split` inside a hot loop (like a sorting routine) introduces unnecessary regex overhead and allocates empty strings. Chaining string methods is much faster for simple tokenization on known delimiters.
📊 Impact: Expected to make query matching significantly faster for large batches of URLs by avoiding regex compilation and evaluation per iteration.
🔬 Measurement: The optimization was successfully tested by running the pytest suite (`uv run pytest`) and verified visually to preserve correct logic.

---
*PR created automatically by Jules for task [737285827995160055](https://jules.google.com/task/737285827995160055) started by @n24q02m*