### PR TITLE
fix: fix argument injection in SearXNG runner

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -500,8 +500,14 @@ def _kill_stale_port_process(port: int) -> None:
     This prevents 'address already in use' errors when restarting
     after a crash that left a zombie process behind.
     """
-    if not isinstance(port, int) or not (1 <= port <= 65535):
+    try:
+        port = int(port)
+    except (ValueError, TypeError):
         return
+
+    if not (1 <= port <= 65535):
+        return
+
     if sys.platform == "win32":
         # On Windows, use netstat to find the PID
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `_kill_stale_port_process` function in `src/wet_mcp/searxng_runner.py` used string interpolation (`f':{port}'`) to pass a user-provided `port` value into the arguments array of a `subprocess.run` call for `lsof`, `fuser`, and `netstat`.
⚠️ **Risk:** If the `port` variable was somehow populated with an object overriding `__str__` to return a string containing unexpected characters, an attacker could potentially inject additional flags or arguments into the resulting subprocess execution.
🛡️ **Solution:** The `port` variable is now explicitly cast to an integer (`int(port)`) immediately upon entering the function. If the cast fails due to `ValueError` or `TypeError`, the function returns early. This guarantees that only valid integer values are interpolated into the shell command arguments.

---
*PR created automatically by Jules for task [18026176221828345503](https://jules.google.com/task/18026176221828345503) started by @n24q02m*