### PR TITLE
feat: code health] Improve diagnosability in SearXNG port cleanup

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -520,10 +520,12 @@ def _kill_stale_port_process(port: int) -> None:
                         pid = int(pid_str)
                         if pid > 0:
                             _sigterm_then_kill(pid, f"stale port {port}")
-                    except (ValueError, ProcessLookupError, PermissionError):
-                        pass
-        except Exception:
-            pass
+                    except (ValueError, ProcessLookupError, PermissionError) as e:
+                        logger.debug(
+                            f"Could not kill process {pid_str} on port {port}: {e}"
+                        )
+        except Exception as e:
+            logger.debug(f"Error finding processes on port {port} using netstat: {e}")
     else:
         # On Unix, use lsof or fuser
         try:
@@ -540,8 +542,10 @@ def _kill_stale_port_process(port: int) -> None:
                         pid = int(pid_str.strip())
                         if pid > 0 and pid != os.getpid():
                             _sigterm_then_kill(pid, f"stale port {port}")
-                    except (ValueError, ProcessLookupError, PermissionError):
-                        pass
+                    except (ValueError, ProcessLookupError, PermissionError) as e:
+                        logger.debug(
+                            f"Could not kill process {pid_str} on port {port}: {e}"
+                        )
         except FileNotFoundError:
             # lsof not available, try fuser
             try:
@@ -551,10 +555,10 @@ def _kill_stale_port_process(port: int) -> None:
                     capture_output=True,
                     timeout=5,
                 )
-            except (FileNotFoundError, subprocess.TimeoutExpired):
-                pass
-        except Exception:
-            pass
+            except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+                logger.debug(f"Could not free port {port} using fuser: {e}")
+        except Exception as e:
+            logger.debug(f"Error finding processes on port {port} using lsof: {e}")
 
 
 def _cleanup_process() -> None:

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -757,6 +757,7 @@ async def test_lifespan_startup_backend_init_error():
         patch("wet_mcp.server.DocsDB"),
         patch("wet_mcp.server.shutdown_crawler", new_callable=AsyncMock),
         patch("wet_mcp.server.stop_searxng"),
+        patch("wet_mcp.server._warmup_searxng", new_callable=AsyncMock),
         patch(
             "wet_mcp.server._init_embedding_backend",
             new_callable=AsyncMock,

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 What: Replaced silent exception handling (`pass`) with `logger.debug` statements in `_kill_stale_port_process` routines for `netstat`, `lsof`, and `fuser`. Also added a small patch for `_warmup_searxng` in a test fixture to fix intermittent CI timeouts.
💡 Why: Silent exceptions hide potential underlying issues with port cleanup (like permission errors or transient process states), making debugging difficult. Logging the exception provides visibility without altering the control flow or application behavior.
✅ Verification: Ran `uv run ruff check . --fix`, `uv run ruff format .`, and the full test suite (`uv run pytest`), with all checks and tests passing.
✨ Result: Improved diagnosability of SearXNG lifecycle management.

---
*PR created automatically by Jules for task [3664071608924589536](https://jules.google.com/task/3664071608924589536) started by @n24q02m*