### PR TITLE
feat: code health improvement] Refactor _split_preserving_code to use ChunkContext dataclass

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 import zlib
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -2184,6 +2185,13 @@ _HEADING_RE = re.compile(r"^(#{1,4})\s+(.+)$", re.MULTILINE)
 _CODE_FENCE_RE = re.compile(r"^```")
 
 
+@dataclass
+class ChunkContext:
+    title: str
+    heading_path: str
+    url: str
+
+
 def chunk_markdown(
     content: str,
     url: str = "",
@@ -2215,12 +2223,13 @@ def chunk_markdown(
         if len(text) >= min_chunk_size:
             # Split oversized chunks by double newline, preserving code blocks
             if len(text) > max_chunk_size:
+                ctx = ChunkContext(
+                    title=current_title, heading_path=heading_path, url=url
+                )
                 _split_preserving_code(
                     text,
                     chunks,
-                    current_title,
-                    heading_path,
-                    url,
+                    ctx,
                     max_chunk_size,
                     min_chunk_size,
                 )
@@ -2273,9 +2282,7 @@ def chunk_markdown(
 def _split_preserving_code(
     text: str,
     chunks: list[dict],
-    title: str,
-    heading_path: str,
-    url: str,
+    context: ChunkContext,
     max_chunk_size: int,
     min_chunk_size: int,
 ) -> None:
@@ -2311,9 +2318,9 @@ def _split_preserving_code(
                 chunks.append(
                     {
                         "content": buffer.strip(),
-                        "title": title,
-                        "heading_path": heading_path,
-                        "url": url,
+                        "title": context.title,
+                        "heading_path": context.heading_path,
+                        "url": context.url,
                         "chunk_index": len(chunks),
                     }
                 )
@@ -2325,9 +2332,9 @@ def _split_preserving_code(
         chunks.append(
             {
                 "content": buffer.strip(),
-                "title": title,
-                "heading_path": heading_path,
-                "url": url,
+                "title": context.title,
+                "heading_path": context.heading_path,
+                "url": context.url,
                 "chunk_index": len(chunks),
             }
         )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from wet_mcp.sources.docs import (
+    ChunkContext,
     _is_blocked_content,
     _rst_to_markdown,
     _split_preserving_code,
@@ -412,12 +413,11 @@ class TestSplitPreservingCode:
             "Conclusion text with enough content to matter."
         )
         chunks: list[dict] = []
+        ctx = ChunkContext(title="title", heading_path="heading", url="url")
         _split_preserving_code(
             text,
             chunks,
-            "title",
-            "heading",
-            "url",
+            ctx,
             max_chunk_size=100,
             min_chunk_size=20,
         )
@@ -432,12 +432,11 @@ class TestSplitPreservingCode:
             [f"Paragraph {i} with enough text to fill. " * 3 for i in range(10)]
         )
         chunks: list[dict] = []
+        ctx = ChunkContext(title="t", heading_path="h", url="u")
         _split_preserving_code(
             text,
             chunks,
-            "t",
-            "h",
-            "u",
+            ctx,
             max_chunk_size=200,
             min_chunk_size=20,
         )
@@ -450,12 +449,13 @@ class TestSplitPreservingCode:
         """Each produced chunk has correct title, heading_path, url."""
         text = "Some content. " * 50
         chunks: list[dict] = []
+        ctx = ChunkContext(
+            title="My Title", heading_path="Section > Sub", url="https://example.com"
+        )
         _split_preserving_code(
             text,
             chunks,
-            "My Title",
-            "Section > Sub",
-            "https://example.com",
+            ctx,
             max_chunk_size=100,
             min_chunk_size=10,
         )
@@ -472,12 +472,11 @@ class TestSplitPreservingCode:
             {"content": "existing2", "chunk_index": 1},
         ]
         text = "New content paragraph. " * 20
+        ctx = ChunkContext(title="t", heading_path="h", url="u")
         _split_preserving_code(
             text,
             existing_chunks,
-            "t",
-            "h",
-            "u",
+            ctx,
             max_chunk_size=100,
             min_chunk_size=10,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:**
Grouped related parameters (`title`, `heading_path`, `url`) in `_split_preserving_code` into a new `ChunkContext` dataclass.

💡 **Why:**
This significantly reduces the parameter count of `_split_preserving_code` from 7 to 5, improving readability and maintainability.

✅ **Verification:**
- All linters (`uv run ruff check . --fix`) and formatters (`uv run ruff format .`) passed.
- All unit tests (`uv run pytest`) passed, specifically those in `tests/test_docs.py` testing the chunking logic.
- Behavior is exactly identical to before.

✨ **Result:**
Cleaner, more maintainable code without sacrificing functionality.

---
*PR created automatically by Jules for task [14692846723114137611](https://jules.google.com/task/14692846723114137611) started by @n24q02m*