### PR TITLE
feat: testing improvement] Add test coverage for urlparse exception in is_safe_url

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -183,6 +183,12 @@ def test_is_safe_url_empty_hostname():
     assert not is_safe_url("https:///path")
 
 
+def test_is_safe_url_malformed_urlparse_exception():
+    """Test is_safe_url returns False when urlparse raises an exception."""
+    # In Python 3.12+, urlparse raises ValueError for invalid IPv6 URLs
+    assert not is_safe_url("http://[invalid_ipv6_format]")
+
+
 def test_is_safe_url_general_exception():
     """Test is_safe_url returns False when _original_getaddrinfo raises unexpected exception."""
     with patch(

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the `try...except Exception` block for `urlparse(url)` inside `is_safe_url` (`src/wet_mcp/security.py`) lacked test coverage.
📊 **Coverage:** A new test `test_is_safe_url_malformed_urlparse_exception` covers the scenario where an invalid IPv6 format URL (`http://[invalid_ipv6_format]`) causes `urlparse` to raise a `ValueError` in Python 3.12+, verifying it correctly returns `False`.
✨ **Result:** Test coverage for URL validation is improved, ensuring robustness against malformed URLs.

---
*PR created automatically by Jules for task [4015802038871263744](https://jules.google.com/task/4015802038871263744) started by @n24q02m*