### PR TITLE
feat: testing improvement] Add tests for get_model_capabilities

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -238,3 +238,24 @@ def test_analyze_media_tilde_download_dir(mock_settings, tmp_path, monkeypatch):
     # File exists and is within download_dir, so we should get past the path check
     # (will fail at LLM call since we didn't mock it, but NOT "Access denied")
     assert "Access denied" not in result
+
+
+@patch("wet_mcp.llm.litellm")
+def test_get_model_capabilities(mock_litellm):
+    """Test get_model_capabilities function."""
+    mock_litellm.supports_vision.return_value = True
+    mock_litellm.supports_audio_input.return_value = False
+    mock_litellm.supports_audio_output.return_value = True
+
+    from wet_mcp.llm import get_model_capabilities
+
+    caps = get_model_capabilities("fake-model")
+
+    assert caps == {
+        "vision": True,
+        "audio_input": False,
+        "audio_output": True,
+    }
+    mock_litellm.supports_vision.assert_called_once_with("fake-model")
+    mock_litellm.supports_audio_input.assert_called_once_with("fake-model")
+    mock_litellm.supports_audio_output.assert_called_once_with("fake-model")

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `get_model_capabilities` function in `src/wet_mcp/llm.py` was missing tests.
📊 **Coverage:** Added a test that mocks `litellm`'s capability detection functions (`supports_vision`, `supports_audio_input`, `supports_audio_output`) and verifies that the correct capability dictionary is constructed and returned. Also verifies that `litellm` functions are called with the expected arguments.
✨ **Result:** Improved test coverage and reliability for LLM model capability detection.

---
*PR created automatically by Jules for task [4355095253532955567](https://jules.google.com/task/4355095253532955567) started by @n24q02m*