### PR TITLE
fix: fix SQL Injection via Formatted String

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -135,7 +135,7 @@ class DocsDB:
             raise ValueError(
                 f"embedding_dims must be an integer 0-65536, got {embedding_dims!r}"
             )
-        self._embedding_dims = embedding_dims
+        self._embedding_dims = int(embedding_dims)
         self._vec_enabled = False
 
         db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 What:
Fixed a potential SQL injection vulnerability in `src/wet_mcp/db.py` when dynamically creating the virtual vector table `doc_chunks_vec` using f-strings with `self._embedding_dims`.

⚠️ Risk:
The previous check `isinstance(embedding_dims, int)` was insufficient to prevent SQL injection. An attacker could pass a custom object that inherits from `int` but overrides the `__format__` method. When `f"float[{self._embedding_dims}]"` was executed, the custom `__format__` output would be injected into the DDL query, allowing arbitrary SQL execution, potentially compromising database integrity.

🛡️ Solution:
Added an explicit cast using `int(embedding_dims)` during `DocsDB` initialization before storing it in `self._embedding_dims`. This strips any custom subclass methods (like `__format__`) and ensures that `self._embedding_dims` is a pure integer, making it safe to use in f-string formatted SQL queries.

---
*PR created automatically by Jules for task [3858425737390141736](https://jules.google.com/task/3858425737390141736) started by @n24q02m*