### PR TITLE
feat: testing improvement] Add tests for research_topic prompt function in server.py

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,3 +192,14 @@ async def test_extract_invalid_action():
     """Test invalid action on extract tool."""
     result = await extract(action="invalid_action")
     assert "Error: Unknown action" in result
+
+
+def test_research_topic():
+    """Test research_topic prompt generation."""
+    from wet_mcp.server import research_topic
+
+    topic = "Quantum Computing"
+    result = research_topic(topic=topic)
+    assert "Research the following topic thoroughly: Quantum Computing" in result
+    assert "action='research'" in result
+    assert "action='extract'" in result


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `research_topic` prompt function in `src/wet_mcp/server.py`.
📊 **Coverage:** Covers prompt generation logic and checks that essential elements (the topic and required tool usage actions) are correctly populated in the resulting string.
✨ **Result:** Improves test coverage for prompt tools in the server and ensures structural changes to the instruction string can be caught early.

---
*PR created automatically by Jules for task [3540673670253402770](https://jules.google.com/task/3540673670253402770) started by @n24q02m*