### PR TITLE
fix: testing Improvement: Add missing tests for `library_docs` and fix string interpolation bug

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1561,7 +1561,7 @@ def library_docs(library: str, question: str) -> str:
     """Generate a prompt to find library documentation."""
     return (
         f"Find documentation for '{library}' to answer: {question}\n\n"
-        "Use the search tool with action='docs', library='{library}', "
+        f"Use the search tool with action='docs', library='{library}', "
         f"query='{question}'. If results are insufficient, use extract tool "
         "to get more content from the documentation URLs."
     )

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -553,6 +553,20 @@ def test_prompts():
     assert "Find documentation" in server.library_docs("lib", "question")
 
 
+def test_library_docs_prompt():
+    """Test library_docs prompt formatting."""
+    result = server.library_docs("react", "how to use hooks")
+    assert "Find documentation for 'react' to answer: how to use hooks" in result
+    assert "library='react'" in result
+    assert "query='how to use hooks'" in result
+
+
+def test_research_topic_prompt():
+    """Test research_topic prompt formatting."""
+    result = server.research_topic("quantum computing")
+    assert "Research the following topic thoroughly: quantum computing" in result
+
+
 def test_main():
     with patch("wet_mcp.server.mcp.run") as mock_run:
         server.main()

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `library_docs` function in `src/wet_mcp/server.py` lacked dedicated tests for prompt generation. Added `test_library_docs_prompt` and `test_research_topic_prompt` to `tests/test_server_comprehensive.py`. While writing the tests, discovered a bug where `{library}` was left un-interpolated in `library_docs` due to a missing `f` string prefix. Fixed the bug.

📊 **Coverage:** What scenarios are now tested
- The prompt formatting logic of `library_docs`, ensuring both `library` and `question` are correctly interpolated.
- The prompt formatting logic of `research_topic`, ensuring `topic` is correctly interpolated.

✨ **Result:** The improvement in test coverage
- `library_docs` now has explicit tests that verify exact output strings and correct string interpolation behavior, catching regressions.
- Increased test coverage and fixed a minor prompt bug.

---
*PR created automatically by Jules for task [13514314780118052810](https://jules.google.com/task/13514314780118052810) started by @n24q02m*