### PR TITLE
feat: code health improvement] Refactor unused import in config.py

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -1,5 +1,6 @@
 """Configuration settings for WET MCP Server."""
 
+import importlib.util
 import os
 from pathlib import Path
 
@@ -28,12 +29,7 @@ def _detect_gpu() -> bool:
 
 def _has_gguf_support() -> bool:
     """Check if llama-cpp-python is installed for GGUF models."""
-    try:
-        import llama_cpp  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("llama_cpp") is not None
 
 
 def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -502,7 +502,7 @@ def test_has_gguf_support_missing():
     """_has_gguf_support returns False when llama_cpp is not installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch("builtins.__import__", side_effect=ImportError("no llama_cpp")):
+    with mock.patch("importlib.util.find_spec", return_value=None):
         assert _has_gguf_support() is False
 
 
@@ -510,7 +510,7 @@ def test_has_gguf_support_available():
     """_has_gguf_support returns True when llama_cpp is installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch.dict("sys.modules", {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 

--- a/tests/test_config_gpu.py
+++ b/tests/test_config_gpu.py
@@ -79,24 +79,14 @@ def test_detect_gpu_import_error():
 
 def test_has_gguf_support_installed():
     """Test _has_gguf_support returns True if llama_cpp is importable."""
-    with mock.patch.dict(sys.modules, {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 
 def test_has_gguf_support_not_installed():
     """Test _has_gguf_support returns False if llama_cpp is not importable."""
-    orig_import = __import__
-
-    def side_effect(name, *args, **kwargs):
-        if name == "llama_cpp":
-            raise ImportError("No module named 'llama_cpp'")
-        return orig_import(name, *args, **kwargs)
-
-    with mock.patch("builtins.__import__", side_effect=side_effect):
-        with mock.patch.dict(sys.modules):
-            if "llama_cpp" in sys.modules:
-                del sys.modules["llama_cpp"]
-            assert _has_gguf_support() is False
+    with mock.patch("importlib.util.find_spec", return_value=None):
+        assert _has_gguf_support() is False
 
 
 def test_resolve_local_model_gpu_gguf():

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the local `import llama_cpp # noqa: F401` inside `_has_gguf_support` with `importlib.util.find_spec("llama_cpp") is not None`.

💡 **Why:** How this improves maintainability
The previous `try...except ImportError` pattern generated unused import warnings (F401) and executed an unnecessary import. Using `importlib.util.find_spec` safely checks for the package's presence without actually importing it, removing the linter warning and adhering to standard best practices. The test cases were also updated to properly mock `importlib.util.find_spec`.

✅ **Verification:** How you confirmed the change is safe
Ran `uv run ruff check` which confirmed no F401 or other linting errors. Re-ran the full test suite (`uv run pytest`) and all tests passed, confirming no functionality was broken.

✨ **Result:** The improvement achieved
Cleaned up an unused import warning while preserving the capability to detect the `llama_cpp` package.

---
*PR created automatically by Jules for task [4519689503402873400](https://jules.google.com/task/4519689503402873400) started by @n24q02m*