### PR TITLE
fix: fix Hardcoded Secret Placeholder

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -19,6 +19,7 @@ import asyncio
 import atexit
 import json as _json
 import os
+import re
 import secrets
 import shutil
 import signal
@@ -407,9 +408,14 @@ def _get_settings_path(port: int) -> Path:
     )
 
     # Generate random secret key for this session
-    # This prevents using the hardcoded secret from the template
+    # This prevents using a hardcoded secret from the template
     secret = secrets.token_hex(32)
-    content = content.replace("REPLACE_WITH_REAL_SECRET", secret)
+    content = re.sub(
+        r"(server:\n)",
+        f'\\1  secret_key: "{secret}"\n',
+        content,
+        count=1,
+    )
 
     settings_file.write_text(content)
     logger.debug(f"SearXNG settings written to: {settings_file}")

--- a/src/wet_mcp/searxng_settings.yml
+++ b/src/wet_mcp/searxng_settings.yml
@@ -4,7 +4,6 @@
 use_default_settings: true
 
 server:
-  secret_key: "REPLACE_WITH_REAL_SECRET"
   bind_address: "127.0.0.1"
   port: 41592
   limiter: false

--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -53,8 +53,11 @@ def test_get_settings_path():
         mock_bundled_file.read_text.assert_called_once()
 
         # Verify write_text called with correct content
-        expected_content = "server:\n  port: 9090\n"
-        mock_settings_file.write_text.assert_called_once_with(expected_content)
+        # It injects the secret dynamically now
+        args, _ = mock_settings_file.write_text.call_args
+        written_content = args[0]
+        assert "port: 9090" in written_content
+        assert "secret_key:" in written_content
 
 
 # Mock the settings object

--- a/tests/test_searxng_runner_comprehensive.py
+++ b/tests/test_searxng_runner_comprehensive.py
@@ -262,14 +262,14 @@ def test_get_settings_path(tmp_path):
         patch("importlib.resources.files") as mock_files,
     ):
         mock_files.return_value.joinpath.return_value.read_text.return_value = (
-            "port: 41592\nsecret_key: 'REPLACE_WITH_REAL_SECRET'"
+            "server:\n  port: 41592\n"
         )
 
         path = _get_settings_path(8080)
         assert path.exists()
         content = path.read_text()
         assert "port: 8080" in content
-        assert "REPLACE_WITH_REAL_SECRET" not in content
+        assert "secret_key: " in content
 
 
 def test_force_kill_process():

--- a/tests/test_security_searxng_secret.py
+++ b/tests/test_security_searxng_secret.py
@@ -24,10 +24,8 @@ def test_secret_key_replacement():
     mock_bundled_file = MagicMock()
     mock_files.joinpath.return_value = mock_bundled_file
 
-    # Mock the template content with the placeholder
-    template_content = (
-        "server:\n  port: 41592\n  secret_key: REPLACE_WITH_REAL_SECRET\n"
-    )
+    # Mock the template content without the placeholder
+    template_content = "server:\n  port: 41592\n"
     mock_bundled_file.read_text.return_value = template_content
 
     with (
@@ -50,15 +48,15 @@ def test_secret_key_replacement():
         # Verify port replacement
         assert "port: 9090" in written_content
 
-        # Verify secret key replacement
-        assert "REPLACE_WITH_REAL_SECRET" not in written_content
+        # Verify secret key injection
         assert "secret_key: " in written_content
 
         # Extract the secret key to verify length/format
         # "  secret_key: <secret>\n"
         for line in written_content.splitlines():
             if "secret_key:" in line:
-                secret = line.split(":", 1)[1].strip()
+                # strip the outer quotes
+                secret = line.split(":", 1)[1].strip().strip('"')
                 # 32 bytes hex = 64 chars
                 assert len(secret) == 64
                 # Verify it is hex

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
## 🛡️ Sentinel: [MEDIUM] Fix Hardcoded Secret Placeholder

🎯 **What:** Removed the hardcoded placeholder string `REPLACE_WITH_REAL_SECRET` from the default `searxng_settings.yml` configuration file and replaced the static `.replace()` injection logic with a dynamic `re.sub()` injection method in `searxng_runner.py`.

⚠️ **Risk:** Keeping static secret placeholders in version control is an anti-pattern. While the placeholder was successfully swapped at runtime under normal operation, if the replacement logic were bypassed, failed silently, or if the template file were manually copied, it could lead to the deployment of the application with a known, insecure default secret key.

🛡️ **Solution:**
- Removed the placeholder value entirely from `src/wet_mcp/searxng_settings.yml`.
- Updated `src/wet_mcp/searxng_runner.py` to use a robust regular expression (`re.sub`) to dynamically inject the `secret_key` field at runtime.
- Updated unit tests (`test_security_searxng_secret.py` and `test_searxng_runner.py`) to reflect and assert the new dynamic injection mechanism instead of the placeholder replacement logic.

---
*PR created automatically by Jules for task [15872029352532496212](https://jules.google.com/task/15872029352532496212) started by @n24q02m*