### PR TITLE
fix: fix command argument injection risk

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -502,6 +502,7 @@ def _kill_stale_port_process(port: int) -> None:
     """
     if not isinstance(port, int) or not (1 <= port <= 65535):
         return
+    port = int(port)
     if sys.platform == "win32":
         # On Windows, use netstat to find the PID
         try:


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Command argument injection risk via f-string interpolation in `subprocess.run` calls (`f":{port}"`) without strict explicit type casting.

⚠️ **Risk:** The potential impact if left unfixed
If `isinstance(port, int)` is bypassed (e.g. custom types overriding string representation) or the validation logic is refactored away later, a malicious user-provided port could execute arbitrary command arguments within `lsof`, `netstat`, or `fuser` calls.

🛡️ **Solution:** How the fix addresses the vulnerability
Explicitly casting inputs to the expected strict type (`port = int(port)`) immediately before using them in shell or subprocess commands prevents formatting bypasses and neutralizes any f-string argument injection risks.

---
*PR created automatically by Jules for task [14988787311964238504](https://jules.google.com/task/14988787311964238504) started by @n24q02m*