### PR TITLE
feat: code health improvement] Remove unused llama_cpp import in config.py

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -1,5 +1,6 @@
 """Configuration settings for WET MCP Server."""
 
+import importlib.util
 import os
 from pathlib import Path
 
@@ -28,12 +29,7 @@ def _detect_gpu() -> bool:
 
 def _has_gguf_support() -> bool:
     """Check if llama-cpp-python is installed for GGUF models."""
-    try:
-        import llama_cpp  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("llama_cpp") is not None
 
 
 def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -502,7 +502,7 @@ def test_has_gguf_support_missing():
     """_has_gguf_support returns False when llama_cpp is not installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch("builtins.__import__", side_effect=ImportError("no llama_cpp")):
+    with mock.patch("importlib.util.find_spec", return_value=None):
         assert _has_gguf_support() is False
 
 
@@ -510,7 +510,7 @@ def test_has_gguf_support_available():
     """_has_gguf_support returns True when llama_cpp is installed."""
     from wet_mcp.config import _has_gguf_support
 
-    with mock.patch.dict("sys.modules", {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 

--- a/tests/test_config_gpu.py
+++ b/tests/test_config_gpu.py
@@ -79,24 +79,14 @@ def test_detect_gpu_import_error():
 
 def test_has_gguf_support_installed():
     """Test _has_gguf_support returns True if llama_cpp is importable."""
-    with mock.patch.dict(sys.modules, {"llama_cpp": mock.MagicMock()}):
+    with mock.patch("importlib.util.find_spec", return_value=mock.MagicMock()):
         assert _has_gguf_support() is True
 
 
 def test_has_gguf_support_not_installed():
     """Test _has_gguf_support returns False if llama_cpp is not importable."""
-    orig_import = __import__
-
-    def side_effect(name, *args, **kwargs):
-        if name == "llama_cpp":
-            raise ImportError("No module named 'llama_cpp'")
-        return orig_import(name, *args, **kwargs)
-
-    with mock.patch("builtins.__import__", side_effect=side_effect):
-        with mock.patch.dict(sys.modules):
-            if "llama_cpp" in sys.modules:
-                del sys.modules["llama_cpp"]
-            assert _has_gguf_support() is False
+    with mock.patch("importlib.util.find_spec", return_value=None):
+        assert _has_gguf_support() is False
 
 
 def test_resolve_local_model_gpu_gguf():

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 What:
Replaced the `try... import llama_cpp ... except ImportError` block in `src/wet_mcp/config.py` with `importlib.util.find_spec("llama_cpp")`. Updated all corresponding unit tests to mock `importlib.util.find_spec` instead of `builtins.__import__` and `sys.modules`.

💡 Why:
The previous implementation imported `llama_cpp` solely to check if it was installed, which triggered an unused import warning (`F401`) that was suppressed with a `# noqa` comment. Using `importlib.util.find_spec` is the standard, cleaner, and faster way to check for module availability without actually loading the module into memory, improving code readability and maintainability.

✅ Verification:
- Verified the code changes in `src/wet_mcp/config.py`.
- Ran `uv run ruff format .` and `uv run ruff check . --fix` with 0 issues.
- Ran the full test suite (`uv run pytest`) and confirmed all tests pass without regressions.

✨ Result:
Cleaned up the unused import, removed the `noqa` comment, and modernized the module availability check.

---
*PR created automatically by Jules for task [10083085510814281976](https://jules.google.com/task/10083085510814281976) started by @n24q02m*