### PR TITLE
feat: code Health: Refactor _warmup function in __main__.py

### DIFF
--- a/src/wet_mcp/__main__.py
+++ b/src/wet_mcp/__main__.py
@@ -24,75 +24,63 @@ def _clear_model_cache(model_name: str) -> None:
         print(f"  Cleared corrupted cache: {model_cache}")
 
 
-def _warmup() -> None:
-    """Pre-download models and run setup to avoid first-run delays.
-
-    Run this before adding wet-mcp to your MCP config:
-        uvx --python 3.13 wet-mcp warmup
-
-    This installs SearXNG, Playwright/Chromium, and downloads the local
-    embedding + reranking models (~1.1 GB total) so the first real
-    connection does not timeout.
-    """
-    print("WET MCP warmup: running first-time setup...")
-
-    # 1. Run auto-setup (SearXNG + Playwright)
+def _run_auto_setup() -> None:
+    """Run auto-setup for SearXNG and Playwright."""
     print("  Step 1/3: Installing SearXNG and Playwright...")
     from wet_mcp.setup import run_auto_setup
 
     run_auto_setup()
     print("  SearXNG and Playwright setup complete.")
 
-    # 2. Check API keys -- if valid cloud keys exist, skip local download
-    from wet_mcp.config import settings
 
-    mode = settings.setup_litellm()
-    if mode in ("proxy", "sdk"):
-        print(f"  LiteLLM mode: {mode}")
-        print("  Step 2/3: Validating cloud embedding models...")
+def _validate_cloud_models(settings) -> bool:
+    """Check if cloud embedding and reranking models are valid.
+    Returns True if cloud models are ready to use and local models are not needed.
+    """
+    from wet_mcp.embedder import init_backend
+    from wet_mcp.server import _EMBEDDING_CANDIDATES
 
-        from wet_mcp.embedder import init_backend
-        from wet_mcp.server import _EMBEDDING_CANDIDATES
+    print("  Step 2/3: Validating cloud embedding models...")
+    model = settings.resolve_embedding_model()
+    candidates = [model] if model else _EMBEDDING_CANDIDATES
+    litellm_kwargs = settings.get_embedding_litellm_kwargs()
 
-        model = settings.resolve_embedding_model()
-        candidates = [model] if model else _EMBEDDING_CANDIDATES
-        litellm_kwargs = settings.get_embedding_litellm_kwargs()
+    cloud_ok = False
+    for candidate in candidates:
+        try:
+            backend = init_backend("litellm", candidate, **litellm_kwargs)
+            dims = backend.check_available()
+            if dims > 0:
+                print(f"  Cloud embedding ready: {candidate} (dims={dims})")
+                cloud_ok = True
+                break
+        except Exception:
+            continue
 
-        cloud_ok = False
-        for candidate in candidates:
+    if cloud_ok:
+        print("  Step 3/3: Validating cloud reranker...")
+        rerank_model = settings.resolve_rerank_model()
+        if rerank_model:
+            from wet_mcp.reranker import init_reranker
+
+            rerank_kwargs = settings.get_rerank_litellm_kwargs()
             try:
-                backend = init_backend("litellm", candidate, **litellm_kwargs)
-                dims = backend.check_available()
-                if dims > 0:
-                    print(f"  Cloud embedding ready: {candidate} (dims={dims})")
-                    cloud_ok = True
-                    break
+                reranker = init_reranker("litellm", rerank_model, **rerank_kwargs)
+                if reranker.check_available():
+                    print(f"  Cloud reranker ready: {rerank_model}")
+                    print("Warmup complete! Cloud models will be used.")
+                    return True
             except Exception:
-                continue
+                pass
 
-        if cloud_ok:
-            # Check reranker too
-            print("  Step 3/3: Validating cloud reranker...")
-            rerank_model = settings.resolve_rerank_model()
-            if rerank_model:
-                from wet_mcp.reranker import init_reranker
+        print("Warmup complete! Cloud embedding will be used.")
+        return True
 
-                rerank_kwargs = settings.get_rerank_litellm_kwargs()
-                try:
-                    reranker = init_reranker("litellm", rerank_model, **rerank_kwargs)
-                    if reranker.check_available():
-                        print(f"  Cloud reranker ready: {rerank_model}")
-                        print("Warmup complete! Cloud models will be used.")
-                        return
-                except Exception:
-                    pass
+    return False
 
-            print("Warmup complete! Cloud embedding will be used.")
-            return
 
-        print("  Cloud embedding not available, falling back to local models...")
-
-    # 3. Download local embedding model
+def _download_local_embedding_model(settings) -> None:
+    """Download and validate the local embedding model."""
     print("  Step 2/3: Downloading local embedding model (~570 MB)...")
     print("  This may take a few minutes on first run.")
 
@@ -119,33 +107,68 @@ def _warmup() -> None:
         else:
             raise
 
-    # 4. Download local reranker model
-    if settings.rerank_enabled:
-        print("  Step 3/3: Downloading local reranker model (~570 MB)...")
-        local_rerank_model = settings.resolve_local_rerank_model()
-        from qwen3_embed import TextCrossEncoder
 
-        try:
+def _download_local_reranker_model(settings) -> None:
+    """Download and validate the local reranker model."""
+    if not settings.rerank_enabled:
+        print("  Step 3/3: Reranking disabled, skipping.")
+        return
+
+    print("  Step 3/3: Downloading local reranker model (~570 MB)...")
+    local_rerank_model = settings.resolve_local_rerank_model()
+    from qwen3_embed import TextCrossEncoder
+
+    try:
+        reranker = TextCrossEncoder(model_name=local_rerank_model)
+        scores = list(reranker.rerank("test query", ["test document"]))
+        if scores:
+            print("  Local reranker ready")
+        else:
+            print("  WARNING: Local reranker test failed")
+    except Exception as exc:
+        if "NO_SUCHFILE" in str(exc) or "doesn't exist" in str(exc):
+            print("  Corrupted cache detected, clearing and retrying...")
+            _clear_model_cache(local_rerank_model)
             reranker = TextCrossEncoder(model_name=local_rerank_model)
             scores = list(reranker.rerank("test query", ["test document"]))
             if scores:
                 print("  Local reranker ready")
             else:
-                print("  WARNING: Local reranker test failed")
-        except Exception as exc:
-            if "NO_SUCHFILE" in str(exc) or "doesn't exist" in str(exc):
-                print("  Corrupted cache detected, clearing and retrying...")
-                _clear_model_cache(local_rerank_model)
-                reranker = TextCrossEncoder(model_name=local_rerank_model)
-                scores = list(reranker.rerank("test query", ["test document"]))
-                if scores:
-                    print("  Local reranker ready")
-                else:
-                    print("  WARNING: Local reranker test failed after retry")
-            else:
-                raise
-    else:
-        print("  Step 3/3: Reranking disabled, skipping.")
+                print("  WARNING: Local reranker test failed after retry")
+        else:
+            raise
+
+
+def _warmup() -> None:
+    """Pre-download models and run setup to avoid first-run delays.
+
+    Run this before adding wet-mcp to your MCP config:
+        uvx --python 3.13 wet-mcp warmup
+
+    This installs SearXNG, Playwright/Chromium, and downloads the local
+    embedding + reranking models (~1.1 GB total) so the first real
+    connection does not timeout.
+    """
+    print("WET MCP warmup: running first-time setup...")
+
+    # 1. Run auto-setup (SearXNG + Playwright)
+    _run_auto_setup()
+
+    # 2. Check API keys -- if valid cloud keys exist, skip local download
+    from wet_mcp.config import settings
+
+    mode = settings.setup_litellm()
+    if mode in ("proxy", "sdk"):
+        print(f"  LiteLLM mode: {mode}")
+        if _validate_cloud_models(settings):
+            return
+        print("  Cloud embedding not available, falling back to local models...")
+
+    # 3. Download local embedding model
+    _download_local_embedding_model(settings)
+
+    # 4. Download local reranker model
+    _download_local_reranker_model(settings)
 
     print("Warmup complete!")
 

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Extracted logical blocks of the `_warmup` function in `src/wet_mcp/__main__.py` into distinct helper functions (`_run_auto_setup`, `_validate_cloud_models`, `_download_local_embedding_model`, and `_download_local_reranker_model`).

💡 **Why:** The original `_warmup` function was overly long, handling multiple initialization tasks consecutively (checking API keys, validating cloud models, downloading local embeddings, and downloading rerankers). By extracting these tasks into well-named helper functions, we improve code readability and make it easier to test or modify individual initialization steps in the future without navigating a massive block of procedural code. 

✅ **Verification:** 
- Used `cat` to visually inspect the modifications and ensure logic parity.
- Ran format and lint checks (`uv run ruff format .` and `uv run ruff check . --fix`) successfully.
- Ran the full test suite (`uv run pytest tests/ -v`), and all tests passed (1077 tests passed, no regressions).

✨ **Result:** A significantly cleaner and more maintainable `_warmup` entry point that relies on small, focused, single-responsibility functions. No functionality was altered or broken.

---
*PR created automatically by Jules for task [11803962766053449988](https://jules.google.com/task/11803962766053449988) started by @n24q02m*