### PR TITLE
fix: fix potential SQL injection in vector table schema creation

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -128,7 +128,7 @@ class DocsDB:
     def __init__(self, db_path: Path, embedding_dims: int = 0):
         self._db_path = db_path
         if (
-            not isinstance(embedding_dims, int)
+            type(embedding_dims) is not int
             or embedding_dims < 0
             or embedding_dims > 65536
         ):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1274,6 +1274,19 @@ class TestChunkQualityEdgeCases:
         )
         assert score >= _chunk_quality_score(content_heavy)
 
+    def test_init_invalid_dims_type(self, tmp_path):
+        """Test that invalid types for embedding_dims raise ValueError."""
+
+        class EvilInt(int):
+            def __str__(self):
+                return "1]; DROP TABLE doc_chunks_vec; --"
+
+        with pytest.raises(ValueError, match="embedding_dims must be an integer"):
+            DocsDB(tmp_path / "invalid.db", embedding_dims=EvilInt(1))
+
+        with pytest.raises(ValueError, match="embedding_dims must be an integer"):
+            DocsDB(tmp_path / "invalid2.db", embedding_dims="4")
+
     def test_chunk_quality_with_definitions(self):
         """Chunks with function/class definitions get boosted."""
         code = "def foo():\n    pass\n\nclass Bar:\n    pass\n\nfunc baz() {}\n"

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 What: Changed the validation of `embedding_dims` in `src/wet_mcp/db.py` from `isinstance(embedding_dims, int)` to `type(embedding_dims) is int`.
⚠️ Risk: A malicious user could pass a custom integer subclass with an overridden `__str__` method as `embedding_dims`. This bypasses `isinstance()` but allows arbitrary SQL to be injected when formatting the schema string for the `doc_chunks_vec` virtual table.
🛡️ Solution: Checking `type(var) is int` strictly enforces that the type is the native Python integer, which prevents subclasses from being evaluated and executing their string-formatting logic. Added a test (`test_init_invalid_dims_type`) to verify that subclasses with overridden string methods are rejected by the constructor.

---
*PR created automatically by Jules for task [8102434461986324941](https://jules.google.com/task/8102434461986324941) started by @n24q02m*