### PR TITLE
fix: add missing error handling test for URL validation

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -215,3 +215,9 @@ def test_pinned_getaddrinfo_ipv6_sockaddr():
     finally:
         with _dns_cache_lock:
             _dns_cache.pop("ipv6-host.example", None)
+
+
+def test_is_safe_url_urlparse_exception():
+    """Test is_safe_url catches exceptions from urlparse."""
+    with patch("wet_mcp.security.urlparse", side_effect=ValueError("malformed URL")):
+        assert not is_safe_url("http://invalid-url.com")


### PR DESCRIPTION
🎯 **What:** The `is_safe_url` function explicitly handles exceptions from `urlparse` via a `try/except Exception:` block, but this branch was completely untested, representing a gap in security coverage.

📊 **Coverage:** A new test has been added to `tests/test_security.py` that specifically mocks `urlparse` to raise a `ValueError`, deterministically verifying that the exception block correctly intercepts parsing failures and returns `False`.

✨ **Result:** Test coverage for URL validation logic in `is_safe_url` has improved, guaranteeing consistent failure-handling behavior across all supported Python versions when malformed URLs are processed.

---
*PR created automatically by Jules for task [6860213507893816832](https://jules.google.com/task/6860213507893816832) started by @n24q02m*