### PR TITLE
feat: optimize JSONL export using SQLite native JSON serialization

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -858,29 +858,46 @@ class DocsDB:
         """Export all docs data as JSONL for sync."""
         lines = []
 
-        # Export libraries
+        # Export libraries (using SQLite native JSON serialization for performance)
         for row in self._conn.execute(
-            "SELECT * FROM libraries ORDER BY name"
+            """
+            SELECT json_insert(json_object(
+                'id', id, 'name', name, 'docs_url', docs_url,
+                'registry', registry, 'description', description,
+                'created_at', created_at, 'updated_at', updated_at
+            ), '$._type', 'library')
+            FROM libraries ORDER BY name
+            """
         ).fetchall():
-            d = dict(row)
-            d["_type"] = "library"
-            lines.append(json.dumps(d, ensure_ascii=False))
+            lines.append(row[0])
 
         # Export versions
         for row in self._conn.execute(
-            "SELECT * FROM versions ORDER BY library_id"
+            """
+            SELECT json_insert(json_object(
+                'id', id, 'library_id', library_id, 'version', version,
+                'docs_url', docs_url, 'indexed_at', indexed_at,
+                'page_count', page_count, 'chunk_count', chunk_count,
+                'status', status
+            ), '$._type', 'version')
+            FROM versions ORDER BY library_id
+            """
         ).fetchall():
-            d = dict(row)
-            d["_type"] = "version"
-            lines.append(json.dumps(d, ensure_ascii=False))
+            lines.append(row[0])
 
         # Export chunks (without embeddings — re-generate on target)
         for row in self._conn.execute(
-            "SELECT * FROM doc_chunks ORDER BY library_id, chunk_index"
+            """
+            SELECT json_insert(json_object(
+                'id', id, 'version_id', version_id, 'library_id', library_id,
+                'url', url, 'title', title, 'chunk_index', chunk_index,
+                'content', content, 'heading_path', heading_path,
+                'created_at', created_at
+            ), '$._type', 'chunk')
+            FROM doc_chunks ORDER BY library_id, chunk_index
+            """
         ).fetchall():
-            d = dict(row)
-            d["_type"] = "chunk"
-            lines.append(json.dumps(d, ensure_ascii=False))
+            lines.append(row[0])
 
         return "\n".join(lines)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
💡 **What**:
Refactored the `export_jsonl` method in `src/wet_mcp/db.py` to use SQLite's native JSON serialization (`json_object` and `json_insert`) instead of Python's `dict()` conversion and `json.dumps()`.

🎯 **Why**:
When syncing large databases (like thousands of doc_chunks), iterating through raw SQLite rows, creating dictionary objects in memory for each one, and then running Python's `json.dumps()` creates significant CPU and memory overhead. By moving the serialization into the `SELECT` query itself, SQLite (which is written in highly optimized C) handles the work, and Python only needs to receive and join the pre-formatted JSON strings. It also makes the schema export safer by explicitly listing columns instead of relying on `SELECT *`.

📊 **Impact**:
- Significantly reduces memory allocation in Python by preventing the creation of thousands of intermediate dictionaries.
- Noticeable speedup during data exports and syncing for instances with many chunks.
- Ensures stability by guarding against unintended column exports (e.g., embeddings) if schemas change.

🔬 **Measurement**:
Run `export_jsonl()` on a populated database with >10k chunks and observe the reduced execution time and memory footprint compared to the `dict` + `json.dumps()` approach.

---
*PR created automatically by Jules for task [8995351744638327817](https://jules.google.com/task/8995351744638327817) started by @n24q02m*