### PR TITLE
feat: testing improvement] Add missing test for stop_searxng

### DIFF
--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -268,3 +268,11 @@ async def test_ensure_searxng_start_fail(mock_settings, mock_lock, mock_time):
         url = await ensure_searxng()
 
         assert url == "http://external:8080"
+
+
+@patch("wet_mcp.searxng_runner._cleanup_process")
+def test_stop_searxng(mock_cleanup):
+    from wet_mcp.searxng_runner import stop_searxng
+
+    stop_searxng()
+    mock_cleanup.assert_called_once()


### PR DESCRIPTION
🎯 **What:** Add a unit test for `stop_searxng` in `tests/test_searxng_runner.py` to fill a testing gap identified in `src/wet_mcp/searxng_runner.py`.
📊 **Coverage:** The test mocks the internal `_cleanup_process` method to verify `stop_searxng` behaves as a straightforward wrapper exactly calling the underlying logic. 
✨ **Result:** Improved test coverage across `searxng_runner.py` by covering the `stop_searxng` stop hook without side effects.

---
*PR created automatically by Jules for task [13913330768241161256](https://jules.google.com/task/13913330768241161256) started by @n24q02m*