### PR TITLE
feat: optimize markitdown conversion to non-blocking

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -205,7 +205,9 @@ async def _extract_with_markitdown(url: str) -> dict:
 
         ext = Path(urlparse(url).path).suffix.lower() or ".pdf"
         md = MarkItDown()
-        result = md.convert_stream(io.BytesIO(resp.content), file_extension=ext)
+        result = await asyncio.to_thread(
+            md.convert_stream, io.BytesIO(resp.content), file_extension=ext
+        )
 
         return {
             "url": url,

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
💡 **What:** Replaced the synchronous, blocking `md.convert_stream` call inside the `_extract_with_markitdown` coroutine with `await asyncio.to_thread`.
🎯 **Why:** The `markitdown` library performs intensive I/O parsing of documents (PDFs, DOCX, etc.) synchronously. By executing this synchronously inside the main asyncio event loop, other concurrent crawler tasks (e.g., downloading other files) were blocked until the document parsing finished, significantly slowing down concurrent operations.
📊 **Measured Improvement:** 
- A benchmark measuring 4 simulated concurrent `convert_stream` calls taking 0.5s each was run.
- **Baseline:** 2.0s total elapsed time (showing strictly serial execution in the event loop).
- **Improved:** 0.5s total elapsed time (showing correct background thread offloading and concurrent execution).

---
*PR created automatically by Jules for task [10424106859569683168](https://jules.google.com/task/10424106859569683168) started by @n24q02m*