### PR TITLE
feat: unnest redundant loop conditionals in db search

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -694,18 +694,17 @@ class DocsDB:
                 fts_params.append(candidate_limit)
 
                 rows = self._conn.execute(fts_sql, fts_params).fetchall()
-                if rows:
-                    for row in rows:
-                        chunk = dict(row)
-                        cid = chunk["id"]
-                        score = -chunk.pop("bm25_score", 0)
-                        # Keep the best score across tiers (PHRASE > AND > OR)
-                        if cid not in fts_scores or score > fts_scores[cid]:
-                            fts_scores[cid] = score
-                            fts_chunks[cid] = chunk
-                    # Stop once we have enough candidates across all tiers
-                    if len(fts_scores) >= candidate_limit:
-                        break
+                for row in rows:
+                    chunk = dict(row)
+                    cid = chunk["id"]
+                    score = -chunk.pop("bm25_score", 0)
+                    # Keep the best score across tiers (PHRASE > AND > OR)
+                    if cid not in fts_scores or score > fts_scores[cid]:
+                        fts_scores[cid] = score
+                        fts_chunks[cid] = chunk
+                # Stop once we have enough candidates across all tiers
+                if len(fts_scores) >= candidate_limit:
+                    break
             except Exception as e:
                 logger.debug(f"FTS search error: {e}")
                 continue

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Removed an unnecessary `if rows:` check around a `for row in rows:` loop in `src/wet_mcp/db.py` inside the `search` method's FTS processing block.
💡 **Why:** Because iterating over an empty list (`rows`) simply exits immediately without entering the loop body, wrapping the `for` loop in `if rows:` adds an extra, redundant level of indentation and cognitive load, negatively impacting readability and maintainability without providing any functional benefit.
✅ **Verification:** Verified by running the unit test suite (`uv run pytest tests/test_db.py`) to ensure search functionality remains intact, and ran code quality checks (`uv run ruff check . --fix`, `uv run ruff format .`, `uv run ty check`) which all passed successfully. The removal does not affect any subsequent logic.
✨ **Result:** A flatter, cleaner loop structure with reduced nesting, improving code readability and satisfying the code health initiative without altering existing search behavior.

---
*PR created automatically by Jules for task [4139703915936385659](https://jules.google.com/task/4139703915936385659) started by @n24q02m*