### PR TITLE
feat: testing] Improve test coverage for get_llm_config

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -45,6 +45,31 @@ def test_get_llm_config_with_temperature(mock_settings):
     assert config["temperature"] == 0.7
 
 
+def test_get_llm_config_fallbacks(mock_settings):
+    """Test LLM config with fallbacks."""
+    settings.llm_models = "gemini/fake-model, openai/gpt-4"
+    config = get_llm_config()
+    assert config["model"] == "gemini/fake-model"
+    assert config["fallbacks"] == ["openai/gpt-4"]
+
+
+def test_get_llm_config_empty_models(mock_settings):
+    """Test LLM config with empty or whitespace models string."""
+    settings.llm_models = "   ,  "
+    config = get_llm_config()
+    assert config["model"] == "gemini/gemini-3-flash-preview"
+    assert config["fallbacks"] is None
+
+
+def test_get_llm_config_extra_kwargs(mock_settings):
+    """Test LLM config extra litellm kwargs are included."""
+    settings.llm_api_base = "http://localhost:11434"
+    settings.llm_api_key = SecretStr("fake-key")
+    config = get_llm_config()
+    assert config["api_base"] == "http://localhost:11434"
+    assert config["api_key"] == "fake-key"
+
+
 @patch("wet_mcp.llm.acompletion")
 def test_analyze_media(mock_completion, mock_settings, tmp_path):
     """Test analyze_media function using real temp file."""
@@ -83,15 +108,22 @@ def test_analyze_media(mock_completion, mock_settings, tmp_path):
     assert "ZmFrZS1pbWFnZS1kYXRh" in str(call_args["messages"][0]["content"])
 
 
-def test_analyze_media_no_keys():
+def test_analyze_media_no_keys(tmp_path):
     """Test analyze_media without keys."""
     # Temporarily clear keys
     original_keys = settings.api_keys
+    original_api_base = settings.llm_api_base
     settings.api_keys = None
+    settings.llm_api_base = ""
+    settings.download_dir = str(tmp_path)
 
-    result = asyncio.run(analyze_media("test.jpg"))
+    img_path = tmp_path / "test.jpg"
+    img_path.touch()
+
+    result = asyncio.run(analyze_media(str(img_path)))
 
     settings.api_keys = original_keys
+    settings.llm_api_base = original_api_base
     assert "Error: LLM analysis requires LITELLM_PROXY_URL or API_KEYS" in result
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** The `get_llm_config` function in `src/wet_mcp/llm.py` parses comma-separated fallback model names, handles extra LLM proxy keyword arguments, and applies default models. However, it completely lacked testing for these distinct code paths. This pull request adds test methods targeting these edge cases and modifies one existing test case to correctly isolate tests away from global state (using proper isolated pytest `tmp_path` files instead of assuming implicit local paths).

📊 **Coverage:** Adds coverage for parsing multiple fallback models, handling empty or whitespace-only model configurations, testing extraction of API base/keys into the final Litellm kwargs dictionary, and cleans up an existing `test_analyze_media_no_keys` case.

✨ **Result:** Test coverage improved across the `get_llm_config` logic paths, protecting against regressions in Litellm client parameter injection.

---
*PR created automatically by Jules for task [13341515126229790671](https://jules.google.com/task/13341515126229790671) started by @n24q02m*