### PR TITLE
feat: code Health] Refactor `_create_tables` to improve maintainability

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -162,6 +162,14 @@ class DocsDB:
         logger.debug(f"DocsDB initialized at {db_path} (vec={self._vec_enabled})")
 
     def _create_tables(self) -> None:
+        self._create_libraries_table()
+        self._create_versions_table()
+        self._create_doc_chunks_table()
+        self._create_fts_table()
+        self._create_vector_table()
+        self._conn.commit()
+
+    def _create_libraries_table(self) -> None:
         # Libraries metadata
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS libraries (
@@ -189,6 +197,7 @@ class DocsDB:
         except sqlite3.OperationalError:
             pass  # Column already exists
 
+    def _create_versions_table(self) -> None:
         # Versions
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS versions (
@@ -205,6 +214,7 @@ class DocsDB:
             )
         """)
 
+    def _create_doc_chunks_table(self) -> None:
         # Document chunks
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS doc_chunks (
@@ -234,6 +244,7 @@ class DocsDB:
             ON doc_chunks(url, version_id, chunk_index)
         """)
 
+    def _create_fts_table(self) -> None:
         # FTS5 (content-sync mode)
         self._conn.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS doc_chunks_fts
@@ -270,6 +281,7 @@ class DocsDB:
             END
         """)
 
+    def _create_vector_table(self) -> None:
         # Vector table (optional)
         if self._vec_enabled and self._embedding_dims > 0:
             row = self._conn.execute(
@@ -283,8 +295,6 @@ class DocsDB:
                         embedding float[{self._embedding_dims}]
                     )
                 """)
-
-        self._conn.commit()
 
     # -----------------------------------------------------------------------
     # Stats

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Extract table creation logic from the overly long `_create_tables` method into smaller, targeted helper methods (`_create_libraries_table`, `_create_versions_table`, etc.).
💡 **Why:** Reduces method complexity and length, improving maintainability and readability by allowing easier identification of schema setup for different components (libraries, versions, chunks, fts, vector).
✅ **Verification:** Passed lint and full test suite successfully without breaking existing table structures or triggers.
✨ **Result:** Cleaner schema initialization sequence.

---
*PR created automatically by Jules for task [9393593403957998224](https://jules.google.com/task/9393593403957998224) started by @n24q02m*