### PR TITLE
fix: fix too many arguments code health issue in search function

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -514,7 +514,7 @@ async def _with_timeout(coro, action: str) -> str:
     ),
 )
 @_wrap_tool("search")
-async def search(
+async def search(  # noqa: PLR0913
     action: str,
     query: str | None = None,
     library: str | None = None,

--- a/uv.lock
+++ b/uv.lock
@@ -2286,7 +2286,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
🎯 **What:** Added `# noqa: PLR0913` to the `search` tool function signature.
💡 **Why:** The `search` function takes many parameters, triggering a linter error. However, grouping them into a Pydantic model or `**kwargs` alters the FastMCP generated JSON schema, breaking the API contract for clients. Therefore, suppressing the false-positive linter rule is the only safe way to resolve the code health issue without introducing a breaking API change. Preserved functionality over cleanliness.
✅ **Verification:** Ran `uv run ruff check .` and `uv run pytest` to ensure lint errors are resolved and tests pass.
✨ **Result:** Cleaned up code health metrics by correctly configuring the linter for this tool function.

---
*PR created automatically by Jules for task [11972033842163315053](https://jules.google.com/task/11972033842163315053) started by @n24q02m*