### PR TITLE
fix: fix too many parameters in media tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -848,7 +848,7 @@ async def extract(
     ),
 )
 @_wrap_tool("media")
-async def media(
+async def media(  # noqa: PLR0913
     action: str,
     url: str | None = None,
     media_type: str = "all",


### PR DESCRIPTION
🎯 **What:** Suppressed the PLR0913 rule (too many arguments) for the `media` tool.
💡 **Why:** As per codebase constraints, grouping parameters into Pydantic models or `**kwargs` for `FastMCP` tools breaks the expected JSON schema and API contract with LLMs.
✅ **Verification:** Verified that linting passes and tests succeed.
✨ **Result:** Improved code health by silencing the warning without changing behavior.

---
*PR created automatically by Jules for task [16180865022712432493](https://jules.google.com/task/16180865022712432493) started by @n24q02m*