### PR TITLE
feat: add tests for `sync_pull`

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -308,3 +308,85 @@ class TestAutoSyncLifecycle:
             assert not sync._sync_task.done()
 
             await sync._sync_task
+
+
+# -----------------------------------------------------------------------
+# sync.sync_pull
+# -----------------------------------------------------------------------
+
+
+class TestSyncPull:
+    @pytest.mark.asyncio
+    async def test_sync_pull_success(self):
+        """Returns downloaded file path on success."""
+        rclone_path = Path("/mock/rclone")
+        db_path = Path("/mock/db/local.sqlite")
+        remote = "gdrive"
+        folder = "backup"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        with (
+            patch(
+                "wet_mcp.sync.asyncio.to_thread", return_value=mock_result
+            ) as mock_thread,
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.exists", return_value=True),
+        ):
+            result = await sync.sync_pull(rclone_path, db_path, remote, folder)
+
+            assert result is not None
+            assert result.name == "remote_local.sqlite"
+            assert str(result.parent).endswith("sync_temp")
+
+            mock_thread.assert_called_once()
+            args = mock_thread.call_args[0]
+            assert args[1] == rclone_path
+            assert "copyto" in args[2]
+
+    @pytest.mark.asyncio
+    async def test_sync_pull_failure_return_code(self):
+        """Returns None and cleans up when command fails."""
+        rclone_path = Path("/mock/rclone")
+        db_path = Path("/mock/db/local.sqlite")
+        remote = "gdrive"
+        folder = "backup"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Command failed"
+
+        with (
+            patch("wet_mcp.sync.asyncio.to_thread", return_value=mock_result),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.unlink") as mock_unlink,
+        ):
+            result = await sync.sync_pull(rclone_path, db_path, remote, folder)
+
+            assert result is None
+            mock_unlink.assert_called_once_with(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_sync_pull_failure_file_missing(self):
+        """Returns None and cleans up when downloaded file is missing despite success exit code."""
+        rclone_path = Path("/mock/rclone")
+        db_path = Path("/mock/db/local.sqlite")
+        remote = "gdrive"
+        folder = "backup"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        with (
+            patch("wet_mcp.sync.asyncio.to_thread", return_value=mock_result),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.exists", return_value=False),
+            patch("pathlib.Path.unlink") as mock_unlink,
+        ):
+            result = await sync.sync_pull(rclone_path, db_path, remote, folder)
+
+            assert result is None
+            mock_unlink.assert_called_once_with(missing_ok=True)


### PR DESCRIPTION
🎯 **What:** The `sync_pull` function in `src/wet_mcp/sync.py` was missing test coverage. This gap is addressed by adding a new `TestSyncPull` class to `tests/test_sync.py` that tests downloading remote DB files via `rclone`.

📊 **Coverage:** The following scenarios are now tested:
- 🟢 Success: Validates that downloading an existing remote file properly returns the downloaded file path.
- 🔴 Failure via exit code: Validates that if `rclone` returns a non-zero exit code (e.g., connection error or command failure), `sync_pull` correctly cleans up and returns `None`.
- 🔴 Failure via missing file: Validates that if `rclone` exits successfully but the file is not created, `sync_pull` correctly cleans up and returns `None`.

✨ **Result:** Increased test coverage for the `sync` module and improved resilience of the application by validating subprocess handling during remote pull actions.

---
*PR created automatically by Jules for task [14358491013244560251](https://jules.google.com/task/14358491013244560251) started by @n24q02m*