### PR TITLE
feat: add tests for get_llm_config edge cases]

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -335,3 +335,19 @@ def test_get_model_capabilities_exception(mock_audio_out, mock_audio_in, mock_vi
     mock_vision.assert_called_once_with("test-model")
     mock_audio_in.assert_not_called()
     mock_audio_out.assert_not_called()
+
+
+def test_get_llm_config_mixed_empty_models(mock_settings):
+    """Test LLM config with interspersed empty models."""
+    settings.llm_models = "modelA, , modelB,  ,modelC"
+    config = get_llm_config()
+    assert config["model"] == "modelA"
+    assert config["fallbacks"] == ["modelB", "modelC"]
+
+
+def test_get_llm_config_only_commas(mock_settings):
+    """Test LLM config with only commas."""
+    settings.llm_models = ",,,"
+    config = get_llm_config()
+    assert config["model"] == "gemini/gemini-3-flash-preview"
+    assert config["fallbacks"] is None


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `get_llm_config` in `src/wet_mcp/llm.py` had some missing test coverage for specific string formatting edge cases.
📊 **Coverage:** Added tests to cover scenarios with interspersed empty model strings and cases where only commas are provided in the `llm_models` configuration setting.
✨ **Result:** Test coverage for `get_llm_config` is now more robust and correctly handles edge cases.

---
*PR created automatically by Jules for task [15278719140609870009](https://jules.google.com/task/15278719140609870009) started by @n24q02m*