### PR TITLE
fix: testing improvement] Add comprehensive error handling tests for is_safe_url

### DIFF
--- a/src/wet_mcp/security.py
+++ b/src/wet_mcp/security.py
@@ -89,6 +89,7 @@ def is_safe_url(url: str) -> bool:
     """
     try:
         parsed = urlparse(url)
+        _ = parsed.port  # trigger ValueError for invalid ports like "abc"
     except Exception:
         return False
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,8 @@
 import socket
 from unittest.mock import patch
 
+import pytest
+
 from wet_mcp.security import is_safe_local_path, is_safe_url
 
 # Tests mock ``wet_mcp.security._original_getaddrinfo`` because
@@ -183,10 +185,21 @@ def test_is_safe_url_empty_hostname():
     assert not is_safe_url("https:///path")
 
 
-def test_is_safe_url_malformed_urlparse_exception():
+@pytest.mark.parametrize(
+    "invalid_url",
+    [
+        "http://[invalid_ipv6_format]",  # Python 3.12+ urlparse raises ValueError
+        "http://[::1",  # Unclosed IPv6
+        "http://]",  # Unopened IPv6
+        "http://example.com:abc",  # Invalid port
+        "http://a b.com",  # Spaces in hostname
+        123,  # Wrong type (int instead of str)
+        None,  # Wrong type (None instead of str)
+    ],
+)
+def test_is_safe_url_malformed_urlparse_exception(invalid_url):
     """Test is_safe_url returns False when urlparse raises an exception."""
-    # In Python 3.12+, urlparse raises ValueError for invalid IPv6 URLs
-    assert not is_safe_url("http://[invalid_ipv6_format]")
+    assert not is_safe_url(invalid_url)
 
 
 def test_is_safe_url_general_exception():


### PR DESCRIPTION
🎯 **What:** The `is_safe_url` error handling block lacked comprehensive tests for malformed inputs and incorrect types. The underlying URL parser does not immediately catch invalid ports unless `.port` is accessed, so it was updated as well.
📊 **Coverage:** Now tests invalid IPv6 formats, unclosed/unopened brackets, invalid ports, spaces in hostnames, and invalid types like integer and None.
✨ **Result:** Improved test coverage and reliability for `is_safe_url` error handling.

---
*PR created automatically by Jules for task [9429452875115178797](https://jules.google.com/task/9429452875115178797) started by @n24q02m*