### PR TITLE
fix: fix PLR0913 warning on `extract` function signature

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -704,7 +704,7 @@ async def search(  # noqa: PLR0913
     ),
 )
 @_wrap_tool("extract")
-async def extract(
+async def extract(  # noqa: PLR0913
     action: str,
     urls: list[str] | None = None,
     paths: list[str] | None = None,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a Ruff linter warning (PLR0913: Too many arguments) on the `extract` function in `src/wet_mcp/server.py`.

💡 **Why:** For Model Context Protocol (MCP) tools decorated with `@mcp.tool()`, function parameters explicitly define the tool's expected input JSON schema. Grouping parameters into `**kwargs` or DataClasses would fundamentally alter the schema and external API contract, breaking standard integration patterns. By explicitly opting out of PLR0913 with a `# noqa` comment on this specific interface definition, we preserve external API compatibility and clean up the linter output, improving maintainability.

✅ **Verification:** Verified by ensuring `uv run ruff check .` now passes without any PLR0913 violations. Furthermore, the complete test suite was run and passed successfully, confirming no regressions occurred and schemas behave as expected.

✨ **Result:** The codebase is cleaner and adheres to linting standards without negatively impacting API tool schemas or generating warnings during development.

---
*PR created automatically by Jules for task [1189463140589827428](https://jules.google.com/task/1189463140589827428) started by @n24q02m*