### PR TITLE
feat: code health] Reduce nesting in _background_index_and_search

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1387,27 +1387,24 @@ async def _background_index_and_search(
 
         # Generate embeddings
         embeddings = None
-        if all_chunks:
-            from wet_mcp.embedder import get_backend
+        from wet_mcp.embedder import get_backend
 
-            if get_backend() is not None:
-                embed_texts_list = []
-                for c in all_chunks:
-                    parts = []
-                    if c.get("title"):
-                        parts.append(c["title"])
-                    if c.get("heading_path") and c.get("heading_path") != c.get(
-                        "title"
-                    ):
-                        parts.append(c["heading_path"])
-                    parts.append(c["content"])
-                    embed_texts_list.append(" | ".join(parts)[:2000])
-                try:
-                    embeddings = await asyncio.wait_for(
-                        _embed_batch(embed_texts_list), timeout=_EMBED_TIMEOUT
-                    )
-                except TimeoutError:
-                    embeddings = None
+        if get_backend() is not None:
+            embed_texts_list = []
+            for c in all_chunks:
+                parts = []
+                if c.get("title"):
+                    parts.append(c["title"])
+                if c.get("heading_path") and c.get("heading_path") != c.get("title"):
+                    parts.append(c["heading_path"])
+                parts.append(c["content"])
+                embed_texts_list.append(" | ".join(parts)[:2000])
+            try:
+                embeddings = await asyncio.wait_for(
+                    _embed_batch(embed_texts_list), timeout=_EMBED_TIMEOUT
+                )
+            except TimeoutError:
+                pass
 
         # Store chunks
         _docs_db.add_chunks(


### PR DESCRIPTION
🎯 **What:** Removed redundant conditional checks inside `_background_index_and_search` in `src/wet_mcp/server.py`. Specifically, removed `if all_chunks:` and `embeddings = None` in the `except TimeoutError` block.
💡 **Why:** Reduces nesting, simplifies the codebase, and improves maintainability without changing any functionality.
✅ **Verification:** Ran `uv run pytest` to ensure no functionality is broken and format/lint checks via `uv run ruff check . --fix && uv run ruff format . && uv run ty check`.
✨ **Result:** A cleaner and more readable `_background_index_and_search` function with less indentation and fewer redundant operations.

---
*PR created automatically by Jules for task [11637152901991594657](https://jules.google.com/task/11637152901991594657) started by @n24q02m*