### PR TITLE
feat: refactor _fetch_and_chunk_docs for improved readability

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1170,35 +1170,12 @@ async def _do_research(
 _MIN_GH_CHUNKS = 20
 
 
-async def _fetch_and_chunk_docs(
-    docs_url: str,
-    repo_url: str = "",
-    query: str = "",
-    library_hint: str = "",
-) -> tuple[list[dict], int]:
-    """Fetch library documentation and split into searchable chunks.
+async def _try_tier_0_llms_txt(docs_url: str) -> tuple[list[dict], int] | None:
+    from wet_mcp.sources.docs import chunk_llms_txt, try_llms_txt
 
-    Tries content sources in priority order:
-    1. llms.txt / llms-full.txt (fastest, AI-optimized)
-    2. GitHub raw markdown (clean, no JS rendering needed)
-    3. Crawl4AI page crawling (rendered HTML -> markdown)
-
-    Returns:
-        Tuple of (chunks, page_count).
-    """
-    from wet_mcp.sources.docs import (
-        _try_github_raw_docs,
-        chunk_llms_txt,
-        chunk_markdown,
-        fetch_docs_pages,
-        try_llms_txt,
-    )
-
-    # Tier 0: Try llms.txt (fastest, best quality)
     llms_content = await try_llms_txt(docs_url)
     if llms_content:
         chunks = chunk_llms_txt(llms_content, base_url=docs_url)
-        # Quality gate: skip llms.txt if it's too small (likely a TOC/meta file)
         if len(chunks) >= _MIN_GH_CHUNKS:
             logger.info(f"Indexed {len(chunks)} chunks from llms.txt")
             return chunks, 1
@@ -1207,8 +1184,16 @@ async def _fetch_and_chunk_docs(
                 f"llms.txt produced only {len(chunks)} chunks "
                 f"(min {_MIN_GH_CHUNKS}), falling through"
             )
+    return None
 
-    # Tier 1: Try GitHub raw markdown (clean content, no JS rendering)
+
+async def _try_tier_1_github_raw(
+    docs_url: str,
+    repo_url: str,
+    library_hint: str,
+) -> tuple[list[dict], int]:
+    from wet_mcp.sources.docs import _try_github_raw_docs, chunk_markdown
+
     gh_target = repo_url or docs_url
     gh_pages = await _try_github_raw_docs(
         gh_target, max_files=50, library_hint=library_hint
@@ -1228,23 +1213,15 @@ async def _fetch_and_chunk_docs(
             gh_chunks.extend(page_chunks)
         gh_page_count = len(gh_pages)
 
-        # Quality gate: if GitHub raw produced too few meaningful chunks,
-        # fall through to Tier 2 (crawl docs site). This handles repos
-        # where docs use template macros (Polars), RST, or other formats
-        # that produce poor raw markdown.
-        if len(gh_chunks) >= _MIN_GH_CHUNKS:
-            logger.info(
-                f"Indexed {len(gh_chunks)} chunks from {len(gh_pages)} "
-                "GitHub raw markdown files"
-            )
-            return gh_chunks, len(gh_pages)
-        else:
-            logger.info(
-                f"GitHub raw produced only {len(gh_chunks)} chunks "
-                f"(min {_MIN_GH_CHUNKS}), falling through to crawl"
-            )
+    return gh_chunks, gh_page_count
 
-    # Tier 2: Crawl docs pages (rendered HTML -> markdown)
+
+async def _try_tier_2_crawl_docs(
+    docs_url: str,
+    query: str,
+) -> tuple[list[dict], int]:
+    from wet_mcp.sources.docs import chunk_markdown, fetch_docs_pages
+
     pages = await fetch_docs_pages(
         docs_url=docs_url,
         query=query,
@@ -1262,6 +1239,66 @@ async def _fetch_and_chunk_docs(
                 chunk["title"] = page["title"]
         chunks.extend(page_chunks)
 
+    return chunks, len(pages)
+
+
+async def _try_tier_3_github_readme(
+    docs_url: str,
+    repo_url: str,
+) -> tuple[list[dict], int] | None:
+    from wet_mcp.sources.docs import _fetch_github_readme
+
+    readme_chunks = await _fetch_github_readme(repo_url or docs_url)
+    if readme_chunks:
+        logger.info(
+            f"All tiers failed, using {len(readme_chunks)} chunks "
+            "from GitHub README (last resort)"
+        )
+        return readme_chunks, 1
+    return None
+
+
+async def _fetch_and_chunk_docs(
+    docs_url: str,
+    repo_url: str = "",
+    query: str = "",
+    library_hint: str = "",
+) -> tuple[list[dict], int]:
+    """Fetch library documentation and split into searchable chunks.
+
+    Tries content sources in priority order:
+    1. llms.txt / llms-full.txt (fastest, AI-optimized)
+    2. GitHub raw markdown (clean, no JS rendering needed)
+    3. Crawl4AI page crawling (rendered HTML -> markdown)
+
+    Returns:
+        Tuple of (chunks, page_count).
+    """
+    # Tier 0: Try llms.txt (fastest, best quality)
+    tier_0_res = await _try_tier_0_llms_txt(docs_url)
+    if tier_0_res is not None:
+        return tier_0_res
+
+    # Tier 1: Try GitHub raw markdown (clean content, no JS rendering)
+    gh_chunks, gh_page_count = await _try_tier_1_github_raw(
+        docs_url, repo_url, library_hint
+    )
+
+    if len(gh_chunks) >= _MIN_GH_CHUNKS:
+        logger.info(
+            f"Indexed {len(gh_chunks)} chunks from {gh_page_count} "
+            "GitHub raw markdown files"
+        )
+        return gh_chunks, gh_page_count
+    elif gh_chunks:
+        logger.info(
+            f"GitHub raw produced only {len(gh_chunks)} chunks "
+            f"(min {_MIN_GH_CHUNKS}), falling through to crawl"
+        )
+
+    # Tier 2: Crawl docs pages (rendered HTML -> markdown)
+    chunks, page_count = await _try_tier_2_crawl_docs(docs_url, query)
+
     # If Tier 2 crawl produced no results (e.g. Cloudflare blocked) but
     # Tier 1 GitHub raw had some content (below threshold), use it instead
     # of returning nothing.  Some docs are better than no docs.
@@ -1274,22 +1311,13 @@ async def _fetch_and_chunk_docs(
         return gh_chunks, gh_page_count
 
     # Tier 3: Last-resort README fallback.
-    # When all tiers fail AND we have a GitHub repo, fetch just the
-    # README.md.  This handles repos without a docs/ directory whose
-    # docs site is also uncrawlable (Cloudflare, JS-rendered, etc.).
     if not chunks:
-        from wet_mcp.sources.docs import _fetch_github_readme
+        tier_3_res = await _try_tier_3_github_readme(docs_url, repo_url)
+        if tier_3_res is not None:
+            return tier_3_res
 
-        readme_chunks = await _fetch_github_readme(repo_url or docs_url)
-        if readme_chunks:
-            logger.info(
-                f"All tiers failed, using {len(readme_chunks)} chunks "
-                "from GitHub README (last resort)"
-            )
-            return readme_chunks, 1
-
-    logger.info(f"Indexed {len(chunks)} chunks from {len(pages)} pages")
-    return chunks, len(pages)
+    logger.info(f"Indexed {len(chunks)} chunks from {page_count} pages")
+    return chunks, page_count
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🎯 **What:** Extracted the logic inside `_fetch_and_chunk_docs` into separate functions `_try_tier_0_llms_txt`, `_try_tier_1_github_raw`, `_try_tier_2_crawl_docs`, and `_try_tier_3_github_readme`.\n💡 **Why:** `_fetch_and_chunk_docs` was getting too large and complex.\n✅ **Verification:** Re-ran all tests via `uv run pytest`.\n✨ **Result:** Improved modularity, lower cyclomatic complexity, and better readability.

---
*PR created automatically by Jules for task [2634374787282405135](https://jules.google.com/task/2634374787282405135) started by @n24q02m*