### PR TITLE
feat: code health] Refactor `_init_embedding_backend` to reduce nesting

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -237,41 +237,37 @@ async def _init_embedding_backend(mode: str) -> None:
 
     backend_type = settings.resolve_embedding_backend()
 
+    async def try_cloud_model(
+        candidate_model: str, warn_on_error: bool = False
+    ) -> bool:
+        global _embedding_dims
+        try:
+            backend = await asyncio.to_thread(init_backend, "litellm", candidate_model)
+            native_dims = await asyncio.to_thread(backend.check_available)
+            if native_dims > 0:
+                if _embedding_dims == 0:
+                    _embedding_dims = _DEFAULT_EMBEDDING_DIMS
+                logger.info(
+                    f"Embedding: {candidate_model} "
+                    f"(native={native_dims}, stored={_embedding_dims})"
+                )
+                return True
+        except Exception as e:
+            if warn_on_error:
+                logger.warning(f"Embedding model {candidate_model} not available: {e}")
+        return False
+
     if backend_type == "litellm":
         model = settings.resolve_embedding_model()
         if model:
             # Explicit model -- validate it
-            try:
-                backend = await asyncio.to_thread(init_backend, "litellm", model)
-                native_dims = await asyncio.to_thread(backend.check_available)
-                if native_dims > 0:
-                    if _embedding_dims == 0:
-                        _embedding_dims = _DEFAULT_EMBEDDING_DIMS
-                    logger.info(
-                        f"Embedding: {model} "
-                        f"(native={native_dims}, stored={_embedding_dims})"
-                    )
-                    return
-            except Exception as e:
-                logger.warning(f"Embedding model {model} not available: {e}")
+            if await try_cloud_model(model, warn_on_error=True):
+                return
         elif mode in ("proxy", "sdk"):
             # Auto-detect: try candidate models
             for candidate in _EMBEDDING_CANDIDATES:
-                try:
-                    backend = await asyncio.to_thread(
-                        init_backend, "litellm", candidate
-                    )
-                    native_dims = await asyncio.to_thread(backend.check_available)
-                    if native_dims > 0:
-                        if _embedding_dims == 0:
-                            _embedding_dims = _DEFAULT_EMBEDDING_DIMS
-                        logger.info(
-                            f"Embedding: {candidate} "
-                            f"(native={native_dims}, stored={_embedding_dims})"
-                        )
-                        return
-                except Exception:
-                    continue
+                if await try_cloud_model(candidate):
+                    return
         # Cloud not available -- fallback to local
         logger.warning("Cloud embedding not available, using local fallback")
 


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested and duplicated cloud model initialization logic inside `_init_embedding_backend` into a clean async helper function `try_cloud_model`.
💡 **Why:** The previous implementation contained heavily duplicated logic between the explicit model fallback and the auto-detect candidate loop, resulting in deeply nested `try/except` and conditional blocks. The helper simplifies the main function body, making it significantly easier to read and maintain while preserving the exact fallback and error logging behaviors.
✅ **Verification:** Verified via strict type checking (`uv run ty check`), automated formatting (`uv run ruff format .`), linting (`uv run ruff check . --fix`), and executing the comprehensive test suite (`uv run pytest tests/`).
✨ **Result:** Improved readability and maintainability of the `_init_embedding_backend` function with less duplication and shallower nesting, without altering any functionality.

---
*PR created automatically by Jules for task [3070787429524713409](https://jules.google.com/task/3070787429524713409) started by @n24q02m*