### PR TITLE
fix: security] strict port integer casting to prevent command injection

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -500,7 +500,11 @@ def _kill_stale_port_process(port: int) -> None:
     This prevents 'address already in use' errors when restarting
     after a crash that left a zombie process behind.
     """
-    if not isinstance(port, int) or not (1 <= port <= 65535):
+    try:
+        port = int(port)
+        if not (1 <= port <= 65535):
+            return
+    except (ValueError, TypeError):
         return
     if sys.platform == "win32":
         # On Windows, use netstat to find the PID


### PR DESCRIPTION
🎯 **What:** The `_kill_stale_port_process` function in `searxng_runner.py` previously validated the `port` argument using `isinstance(port, int)`. This has been updated to explicitly cast `port` to an integer using `int(port)` within a `try/except` block, safely catching `ValueError` or `TypeError`.

⚠️ **Risk:** The previous `isinstance(port, int)` check is generally restrictive but theoretically bypassable if a specialized subclass that overrides representations is passed, potentially leading to command/argument injection within the `lsof` or `netstat` subprocess calls that use `f":{port}"` without shell escaping. 

🛡️ **Solution:** By actively forcing the variable into a primitive integer via `int()`, any non-numeric payload will definitively fail at the cast step. If the cast succeeds, it is mathematically guaranteed to be safe for injection into the f-string, and the existing bounds check (`1 <= port <= 65535`) ensures it is a valid port number.

---
*PR created automatically by Jules for task [10908580111009838560](https://jules.google.com/task/10908580111009838560) started by @n24q02m*