### PR TITLE
feat: code health improvement] Suppress PLR0913 on media tool without breaking LLM schema

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -848,7 +848,7 @@ async def extract(
     ),
 )
 @_wrap_tool("media")
-async def media(
+async def media(  # noqa: PLR0913
     action: str,
     url: str | None = None,
     media_type: str = "all",


### PR DESCRIPTION
🎯 **What:** Suppressed the `PLR0913` (too many arguments) Ruff linter warning on the `media` tool in `src/wet_mcp/server.py`.
💡 **Why:** The `media` function is decorated with `@mcp.tool`, meaning its arguments are introspected by the framework to generate an API/Tool JSON schema for LLMs. Refactoring the function signature (e.g., grouping parameters into a Dataclass or `**kwargs`) would alter this exposed schema and break backward compatibility with existing LLM clients. Appending `# noqa: PLR0913` is the safest way to improve code health (by clearing the warning) without changing external behavior.
✅ **Verification:** Ran `uv run pytest` to ensure no functionality is broken.
✨ **Result:** Codebase linting is cleaner, and the `media` tool's schema remains fully intact and backwards-compatible.

---
*PR created automatically by Jules for task [15317273734014170223](https://jules.google.com/task/15317273734014170223) started by @n24q02m*