### PR TITLE
fix: add Semgrep SAST scan to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,22 @@ jobs:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  semgrep:
+    name: Semgrep SAST Scan
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'push')
+      && github.actor != 'dependabot[bot]'
+      && github.actor != 'renovate[bot]'
+    permissions:
+      contents: read
+    container:
+      image: semgrep/semgrep@sha256:3dab091ee3247fce7e4ed3df9f92b3bd72692c083295f53cec3f135b86404db1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run Semgrep scan
+        run: semgrep scan --config auto --error --verbose
+
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Add Semgrep SAST scan job to CI workflow
- Uses same pinned container image as Aiora and other repos
- wet-mcp was the only repo missing Semgrep

## Test plan
- [x] CI workflow syntax is valid
- [ ] Semgrep scan passes on PR