### PR TITLE
fix: suppress Semgrep false positives in db.py and searxng_runner.py

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -296,11 +296,12 @@ class DocsDB:
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='doc_chunks_vec'"
             ).fetchone()
             if not row:
+                # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query, python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 self._conn.execute(f"""
                     CREATE VIRTUAL TABLE doc_chunks_vec
                     USING vec0(
                         id TEXT PRIMARY KEY,
-                        embedding float[{self._embedding_dims}]
+                        embedding float[{int(self._embedding_dims)}]
                     )
                 """)
 
@@ -362,6 +363,7 @@ class DocsDB:
             params.append(now)
             params.append(lib_id)
             if updates:
+                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 self._conn.execute(
                     f"UPDATE libraries SET {', '.join(updates)} WHERE id = ?",
                     params,
@@ -807,6 +809,7 @@ class DocsDB:
                 placeholders = ", ".join(["(?, ?, ?)"] * len(chunk_keys))
                 flat_params = [v for k in chunk_keys for v in k]
 
+                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 rows = self._conn.execute(
                     f"""SELECT url, version_id, chunk_index, content
                         FROM doc_chunks
@@ -950,6 +953,7 @@ class DocsDB:
             for i in range(0, len(ids), 999):
                 batch = ids[i : i + 999]
                 placeholders = ",".join("?" * len(batch))
+                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 res = self._conn.execute(
                     f"SELECT id FROM {table} WHERE id IN ({placeholders})", batch
                 ).fetchall()

--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -26,7 +26,7 @@ import socket
 import subprocess
 import sys
 import time
-from importlib.resources import files
+from importlib.resources import files  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2
 from pathlib import Path
 
 import httpx


### PR DESCRIPTION
## Summary
- Suppress 6 Semgrep false positives that block CI on main
- Add `int()` cast to `_embedding_dims` in vec0 DDL (defense-in-depth)
- All SQL queries use parameterized values — f-strings only build structure

## Findings suppressed
1. `db.py:299` — vec0 DDL requires dimension in CREATE TABLE syntax
2. `db.py:366` — UPDATE SET columns are internal code, values use `?`
3. `db.py:811` — IN VALUES placeholders built from `?`, values parameterized
4. `db.py:955` — table name is internal, IN placeholders use `?`
5. `searxng_runner.py:29` — `importlib.resources` safe (Python 3.13 required)

## Test plan
- [x] 1213 tests pass
- [ ] Semgrep CI passes with suppressions