### PR TITLE
fix: fix path traversal in help tool

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -972,6 +972,10 @@ async def help(tool_name: str = "search") -> str:
     - Need media files? Use `media` (discover, download, analyze images/videos/audio)
     - Need server settings? Use `config` (status, cache, settings)
     """
+    allowed_tools = {"search", "extract", "media", "config", "help"}
+    if tool_name not in allowed_tools:
+        return f"Error: Invalid tool_name '{tool_name}'. Valid options: {', '.join(sorted(allowed_tools))}."
+
     try:
         doc_file = files("wet_mcp.docs").joinpath(f"{tool_name}.md")
         return doc_file.read_text()

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -690,7 +690,7 @@ async def test_help_tool_not_found():
             FileNotFoundError("not found")
         )
         res = await server.help("nonexistent_tool")
-        assert "Error: No documentation found" in res
+        assert "Error: Invalid tool_name 'nonexistent_tool'" in res
         assert "nonexistent_tool" in res
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2369,7 +2369,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.14.0"
+version = "2.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `help` tool accepted arbitrary string input for the `tool_name` parameter and joined it into a file path using `importlib.resources.files().joinpath()`. This allowed path traversal (e.g., using `../../../etc/passwd`) to read arbitrary files from the host system.
🎯 **Impact:** An attacker could bypass the intended restriction and read sensitive files outside of the intended `wet_mcp.docs` directory.
🔧 **Fix:** Implemented an explicit allowlist containing only the valid documented tools (`{"search", "extract", "media", "config", "help"}`). Any input not in this list returns a validation error immediately. Also updated `test_help_tool_not_found` to assert the new validation error is correctly returned.
✅ **Verification:** Verified by running `uv run pytest tests/test_server_comprehensive.py::test_help_tool_not_found` and the full test suite.
🧠 **Learning:** Documented the vulnerability in `.jules/sentinel.md` regarding `importlib.resources` being vulnerable to path traversal.

---
*PR created automatically by Jules for task [6159020715903378568](https://jules.google.com/task/6159020715903378568) started by @n24q02m*