### PR TITLE
⚡ Bolt: Optimized SQLite `IN` clauses for faster JSONL imports

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -954,8 +954,12 @@ class DocsDB:
                 return set()
             ids = [obj["id"] for obj in items]
             existing = set()
-            for i in range(0, len(ids), 999):
-                batch = ids[i : i + 999]
+
+            # Use 32766 batch size for modern SQLite, fallback to 999
+            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+
+            for i in range(0, len(ids), batch_size):
+                batch = ids[i : i + batch_size]
                 placeholders = ",".join("?" * len(batch))
                 # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 res = self._conn.execute(


### PR DESCRIPTION
💡 **What:** Refactored `_get_existing` in `DocsDB.import_jsonl` to use a batch size of 32766 instead of 999 for modern SQLite versions.\n🎯 **Why:** SQLite >= 3.32.0 supports up to 32766 parameters in a query. Increasing the batch size significantly reduces the number of queries executed during large data imports. A safe fallback to 999 is used for older SQLite versions by checking `sqlite3.sqlite_version_info`.\n📊 **Impact:** Speeds up document chunk ingestion by processing up to 32x more items per query.\n🔬 **Measurement:** Verify by running data imports with large datasets and monitoring execution time.

---
*PR created automatically by Jules for task [15012615631096013017](https://jules.google.com/task/15012615631096013017) started by @n24q02m*