### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary file read vulnerability in local file conversion

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -789,13 +789,16 @@ async def convert_local_files(paths: list[str]) -> str:
     from wet_mcp.config import settings as _settings
     from wet_mcp.security import is_safe_local_path
 
-    allowed_dirs = None
     if _settings.convert_allowed_dirs:
         allowed_dirs = [
             Path(d.strip())
             for d in _settings.convert_allowed_dirs.split(",")
             if d.strip()
         ]
+    else:
+        # Default to allowing access only to the home directory and /tmp
+        # to prevent arbitrary file read of sensitive system files.
+        allowed_dirs = [Path.home().resolve(), Path("/tmp").resolve()]
 
     results = []
     for path_str in paths:


### PR DESCRIPTION
🛡️ **Sentinel:** [CRITICAL] Fix arbitrary file read vulnerability in local file conversion

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `convert_local_files` tool defaulted `allowed_dirs` to `None` when `convert_allowed_dirs` was not configured. This bypassed the security check in `is_safe_local_path`, allowing users to read any file on the system (e.g., `/etc/passwd`).
🎯 **Impact:** An attacker could exploit this to read sensitive system files, configuration files, and credentials that the application has access to.
🔧 **Fix:** Changed the default fallback in `src/wet_mcp/sources/crawler.py` to `[Path.home().resolve(), Path("/tmp").resolve()]`. This ensures a secure-by-default posture while preserving functionality for common usage (accessing files in home or temporary directories).
✅ **Verification:** Verified by ensuring unit tests pass and visually confirming the patch prevents unconstrained file access while retaining access to allowed directories.

---
*PR created automatically by Jules for task [4185045093660192822](https://jules.google.com/task/4185045093660192822) started by @n24q02m*