### PR TITLE
[CLEANUP] Remove unused function 'research_topic'

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ Configure env vars in `~/.claude/settings.local.json` or your shell profile. See
 
 | Prompt | Parameters | Description |
 |:-------|:-----------|:------------|
-| `research_topic` | `topic` | Research a topic using academic search |
 | `library_docs` | `library`, `question` | Find library documentation |
 
 ## Zero-Config Setup

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1820,17 +1820,6 @@ async def _do_immediate_fallback_search(
 
 
 @mcp.prompt()
-def research_topic(topic: str) -> str:
-    """Generate a prompt to research a topic using academic search."""
-    return (
-        f"Research the following topic thoroughly: {topic}\n\n"
-        "1. Use the search tool with action='research' to find academic papers.\n"
-        "2. Use the extract tool with action='extract' on the most relevant URLs.\n"
-        "3. Synthesize findings into a comprehensive summary with citations."
-    )
-
-
-@mcp.prompt()
 def library_docs(library: str, question: str) -> str:
     """Generate a prompt to find library documentation."""
     return (

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -540,7 +540,6 @@ async def test_with_timeout_expired():
 
 
 def test_prompts():
-    assert "Research" in server.research_topic("topic")
     assert "Find documentation" in server.library_docs("lib", "question")
 
 
@@ -550,12 +549,6 @@ def test_library_docs_prompt():
     assert "Find documentation for 'react' to answer: how to use hooks" in result
     assert "library='react'" in result
     assert "query='how to use hooks'" in result
-
-
-def test_research_topic_prompt():
-    """Test research_topic prompt formatting."""
-    result = server.research_topic("quantum computing")
-    assert "Research the following topic thoroughly: quantum computing" in result
 
 
 def test_main():


### PR DESCRIPTION
This PR removes the unused `research_topic` prompt from `server.py`, along with its associated documentation in `README.md` and unit tests in `tests/test_server_comprehensive.py`.

---
*PR created automatically by Jules for task [275956976825744146](https://jules.google.com/task/275956976825744146) started by @n24q02m*