### PR TITLE
🧪 [TEST] Missing test for get_backend in embedder.py

### DIFF
--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -613,6 +613,15 @@ class TestQwen3EmbedBackend:
 
 
 class TestBackendFactory:
+    def test_get_backend(self):
+        """get_backend() returns the current singleton."""
+        # Use patch to avoid messing with global state for other tests
+        with patch("wet_mcp.embedder._backend", None):
+            assert get_backend() is None
+            mock_backend = MagicMock()
+            with patch("wet_mcp.embedder._backend", mock_backend):
+                assert get_backend() is mock_backend
+
     def test_init_cloud_backend(self):
         """init_backend('cloud') creates CloudEmbeddingBackend."""
         backend = init_backend("cloud", "test-model")

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.19.0b1"
+version = "2.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Added a unit test for the get_backend() singleton getter in src/wet_mcp/embedder.py. The test verifies that the function returns the correct singleton instance (initially None and then the mocked instance) using proper isolation via unittest.mock.patch. This improves the test coverage for the embedding backend factory logic.

---
*PR created automatically by Jules for task [9649239706167779427](https://jules.google.com/task/9649239706167779427) started by @n24q02m*