### PR TITLE
[TEST] Missing test for setup_google_auth in sync.py

### DIFF
--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -193,3 +193,191 @@ class TestSetupSyncTokenSuccess:
             pytest.raises(SystemExit),
         ):
             setup_sync()
+
+
+class TestSetupGoogleAuth:
+    """Cover setup_google_auth function."""
+
+    @pytest.mark.asyncio
+    @patch("wet_mcp.sync.settings")
+    async def test_missing_config(self, mock_settings):
+        from wet_mcp.sync import setup_google_auth
+
+        mock_settings.google_drive_client_id = None
+        assert await setup_google_auth() is False
+
+    @pytest.mark.asyncio
+    @patch("wet_mcp.sync.settings")
+    @patch("wet_mcp.sync.httpx.AsyncClient")
+    async def test_device_code_request_failure(self, mock_client, mock_settings):
+        from wet_mcp.sync import setup_google_auth
+
+        mock_settings.google_drive_client_id = "c"
+        mock_settings.google_drive_client_secret = "s"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "error"
+        mock_instance = AsyncMock()
+        mock_instance.post = AsyncMock(return_value=mock_resp)
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+
+        assert await setup_google_auth() is False
+
+    @pytest.mark.asyncio
+    @patch("wet_mcp.sync.settings")
+    @patch("wet_mcp.sync.httpx.AsyncClient")
+    @patch("wet_mcp.sync._save_token")
+    @patch("wet_mcp.sync.asyncio.sleep")
+    async def test_success_path_stderr(
+        self, mock_sleep, mock_save, mock_client, mock_settings, capsys
+    ):
+        from wet_mcp.sync import setup_google_auth
+
+        mock_settings.google_drive_client_id = "c"
+        mock_settings.google_drive_client_secret = "s"
+
+        # Device code response
+        resp1 = MagicMock()
+        resp1.status_code = 200
+        resp1.json.return_value = {
+            "device_code": "dc",
+            "user_code": "uc",
+            "verification_url": "url",
+            "interval": 1,
+            "expires_in": 60,
+        }
+
+        # Token response
+        resp2 = MagicMock()
+        resp2.status_code = 200
+        resp2.json.return_value = {
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 3600,
+        }
+
+        mock_instance = AsyncMock()
+        mock_instance.post = AsyncMock(side_effect=[resp1, resp2])
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+
+        assert await setup_google_auth() is True
+        mock_save.assert_called_once()
+        captured = capsys.readouterr()
+        assert "Visit: url" in captured.err
+        assert "Enter code: uc" in captured.err
+
+    @pytest.mark.asyncio
+    @patch("wet_mcp.sync.settings")
+    @patch("wet_mcp.sync.httpx.AsyncClient")
+    @patch("wet_mcp.sync._save_token")
+    @patch("wet_mcp.sync.asyncio.sleep")
+    async def test_success_path_relay(
+        self, mock_sleep, mock_save, mock_client, mock_settings
+    ):
+        from wet_mcp.sync import setup_google_auth
+
+        mock_settings.google_drive_client_id = "c"
+        mock_settings.google_drive_client_secret = "s"
+
+        resp_device = MagicMock()
+        resp_device.status_code = 200
+        resp_device.json.return_value = {
+            "device_code": "dc",
+            "user_code": "uc",
+            "verification_url": "url",
+            "interval": 1,
+            "expires_in": 60,
+        }
+
+        resp_relay = MagicMock()
+        resp_relay.status_code = 200
+
+        resp_token = MagicMock()
+        resp_token.status_code = 200
+        resp_token.json.return_value = {"access_token": "at"}
+
+        mock_instance = AsyncMock()
+        mock_instance.post = AsyncMock(
+            side_effect=[resp_device, resp_relay, resp_token]
+        )
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+
+        assert (
+            await setup_google_auth(relay_url="http://relay", session_id="s123") is True
+        )
+        # Verify relay call
+        relay_call = mock_instance.post.call_args_list[1]
+        assert "http://relay/api/sessions/s123/messages" in relay_call.args[0]
+
+    @pytest.mark.asyncio
+    @patch("wet_mcp.sync.settings")
+    @patch("wet_mcp.sync.httpx.AsyncClient")
+    @patch("wet_mcp.sync.asyncio.sleep")
+    async def test_polling_behaviors(self, mock_sleep, mock_client, mock_settings):
+        from wet_mcp.sync import setup_google_auth
+
+        mock_settings.google_drive_client_id = "c"
+        mock_settings.google_drive_client_secret = "s"
+
+        resp_device = MagicMock()
+        resp_device.status_code = 200
+        resp_device.json.return_value = {
+            "device_code": "dc",
+            "user_code": "uc",
+            "verification_url": "url",
+            "interval": 1,
+            "expires_in": 60,
+        }
+
+        # 1. Pending, 2. Slow down, 3. Terminal error
+        resp_pending = MagicMock(status_code=400)
+        resp_pending.json.return_value = {"error": "authorization_pending"}
+
+        resp_slow = MagicMock(status_code=400)
+        resp_slow.json.return_value = {"error": "slow_down"}
+
+        resp_denied = MagicMock(status_code=400)
+        resp_denied.json.return_value = {"error": "access_denied"}
+
+        mock_instance = AsyncMock()
+        mock_instance.post = AsyncMock(
+            side_effect=[resp_device, resp_pending, resp_slow, resp_denied]
+        )
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+
+        assert await setup_google_auth() is False
+        assert mock_instance.post.call_count == 4
+
+    @pytest.mark.asyncio
+    @patch("wet_mcp.sync.settings")
+    @patch("wet_mcp.sync.httpx.AsyncClient")
+    @patch("wet_mcp.sync.time.time")
+    @patch("wet_mcp.sync.asyncio.sleep")
+    async def test_timeout(self, mock_sleep, mock_time, mock_client, mock_settings):
+        from wet_mcp.sync import setup_google_auth
+
+        mock_settings.google_drive_client_id = "c"
+        mock_settings.google_drive_client_secret = "s"
+
+        mock_time.side_effect = [
+            1000,
+            1001,
+            2000,
+        ]  # Start, presentation, poll 1 (expired)
+
+        resp_device = MagicMock()
+        resp_device.status_code = 200
+        resp_device.json.return_value = {
+            "device_code": "dc",
+            "user_code": "uc",
+            "verification_url": "url",
+            "interval": 1,
+            "expires_in": 60,
+        }
+
+        mock_instance = AsyncMock()
+        mock_instance.post = AsyncMock(return_value=resp_device)
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+
+        assert await setup_google_auth() is False


### PR DESCRIPTION
### 🎯 What:
Added comprehensive unit tests for `setup_google_auth` in `src/wet_mcp/sync.py`.

### 📊 Coverage:
- Verified behavior when `GOOGLE_DRIVE_CLIENT_ID` or `CLIENT_SECRET` is missing.
- Mocked `httpx.AsyncClient` to test device code request failures and successful responses.
- Verified presentation of authentication instructions via `stderr` and `relay` messaging.
- Thoroughly tested the token polling loop, including `authorization_pending`, `slow_down`, and terminal error responses.
- Verified timeout handling when device code expires.

### ✨ Result:
Increased test coverage for the Google Drive OAuth flow, ensuring robust handling of various API responses and edge cases.

---
*PR created automatically by Jules for task [17585765632351048312](https://jules.google.com/task/17585765632351048312) started by @n24q02m*