### PR TITLE
[FIX] Refactor '_background_index_and_search' to reduce parameters

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
 from urllib.parse import urlparse
@@ -1387,48 +1388,55 @@ async def _fetch_and_chunk_docs(
 # ---------------------------------------------------------------------------
 
 
-async def _background_index_and_search(
-    library: str,
-    lib_key: str,
-    language: str | None,
-    docs_url: str,
-    repo_url: str,
-    query: str,
-    version: str | None,
-    lib_id: str,
-    ver_id: str,
-):
+@dataclass
+class IndexingTask:
+    """Context for background indexing and search."""
+
+    library: str
+    lib_key: str
+    language: str | None
+    docs_url: str
+    repo_url: str
+    query: str
+    version: str | None
+    lib_id: str
+    ver_id: str
+
+
+async def _background_index_and_search(task: IndexingTask):
     """Background task to fetch, chunk, embed, and store docs."""
     try:
         from urllib.parse import urlparse
 
         from wet_mcp.sources.docs import _normalize_docs_url
 
-        docs_url = _normalize_docs_url(docs_url)
-        logger.info(f"Background indexing started for '{library}' from {docs_url}...")
+        docs_url = _normalize_docs_url(task.docs_url)
+        logger.info(
+            f"Background indexing started for '{task.library}' from {docs_url}..."
+        )
 
         try:
             all_chunks, page_count = await asyncio.wait_for(
                 _fetch_and_chunk_docs(
                     docs_url=docs_url,
-                    repo_url=repo_url,
-                    query=query,
-                    library_hint=library,
+                    repo_url=task.repo_url,
+                    query=task.query,
+                    library_hint=task.library,
                 ),
                 timeout=_FETCH_TIMEOUT,
             )
         except TimeoutError:
             logger.warning(
-                f"Docs fetch timed out after {_FETCH_TIMEOUT}s for '{library}'"
+                f"Docs fetch timed out after {_FETCH_TIMEOUT}s for '{task.library}'"
             )
             all_chunks, page_count = [], 0
 
         # Fallback SearXNG
         if page_count <= 2 and len(all_chunks) < 100:
             fallback_query = (
-                f"{library} {language} documentation"
-                if language
-                else f"{library} documentation"
+                f"{task.library} {task.language} documentation"
+                if task.language
+                else f"{task.library} documentation"
             )
             try:
                 searxng_url = await asyncio.wait_for(
@@ -1456,7 +1464,7 @@ async def _background_index_and_search(
                         continue
                     try:
                         alt_chunks, alt_pages = await asyncio.wait_for(
-                            _fetch_and_chunk_docs(alt_url, "", query),
+                            _fetch_and_chunk_docs(alt_url, "", task.query),
                             timeout=_FALLBACK_TIMEOUT,
                         )
                     except TimeoutError:
@@ -1501,18 +1509,18 @@ async def _background_index_and_search(
 
         # Store chunks
         _docs_db.add_chunks(
-            version_id=ver_id,
-            library_id=lib_id,
+            version_id=task.ver_id,
+            library_id=task.lib_id,
             chunks=all_chunks,
             embeddings=embeddings,
         )
-        _docs_db.mark_version_indexed(ver_id, page_count, len(all_chunks))
+        _docs_db.mark_version_indexed(task.ver_id, page_count, len(all_chunks))
         logger.info(
-            f"Background indexing complete for '{library}'. Pages: {page_count}, Chunks: {len(all_chunks)}"
+            f"Background indexing complete for '{task.library}'. Pages: {page_count}, Chunks: {len(all_chunks)}"
         )
 
     except Exception as e:
-        logger.error(f"Background indexing failed for {library}: {e}")
+        logger.error(f"Background indexing failed for {task.library}: {e}")
 
 
 async def _search_cached_index(
@@ -1744,19 +1752,18 @@ async def _do_docs_search(
     _docs_db.clear_version_chunks(ver_id)
 
     # Step 3: Launch background indexer
-    asyncio.create_task(
-        _background_index_and_search(
-            library=library,
-            lib_key=lib_key,
-            language=language,
-            docs_url=docs_url,
-            repo_url=repo_url,
-            query=query,
-            version=version,
-            lib_id=lib_id,
-            ver_id=ver_id,
-        )
+    task = IndexingTask(
+        library=library,
+        lib_key=lib_key,
+        language=language,
+        docs_url=docs_url,
+        repo_url=repo_url,
+        query=query,
+        version=version,
+        lib_id=lib_id,
+        ver_id=ver_id,
     )
+    asyncio.create_task(_background_index_and_search(task))
 
     fallback_data = await _do_immediate_fallback_search(
         docs_url=docs_url,

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -1489,15 +1489,17 @@ async def test_background_index_fetch_timeout():
         ),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -1535,15 +1537,17 @@ async def test_background_index_with_searxng_fallback():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         server._docs_db.mark_version_indexed.assert_called_once()
@@ -1577,15 +1581,17 @@ async def test_background_index_with_language():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="redis",
-            lib_key="redis:python",
-            language="python",
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="redis",
+                lib_key="redis:python",
+                language="python",
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -1614,15 +1620,17 @@ async def test_background_index_embeddings_and_store():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         call_args = server._docs_db.add_chunks.call_args
@@ -1652,15 +1660,17 @@ async def test_background_index_embed_timeout():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Should still store chunks even without embeddings
         server._docs_db.add_chunks.assert_called_once()
@@ -1678,15 +1688,17 @@ async def test_background_index_exception():
     ):
         # Should not raise
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -1710,15 +1722,17 @@ async def test_background_index_no_chunks():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_not_called()
 
@@ -1760,15 +1774,17 @@ async def test_background_index_fallback_alt_timeout():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.example.com",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.example.com",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Should still use original chunks
         server._docs_db.add_chunks.assert_called_once()
@@ -1812,15 +1828,17 @@ async def test_background_index_fallback_same_netloc():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.example.com",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.example.com",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -784,15 +784,17 @@ async def test_background_index_fetch_timeout():
         ),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # No chunks -> returns early, no add_chunks call
         server._docs_db.add_chunks.assert_not_called()
@@ -838,15 +840,17 @@ async def test_background_index_with_fallback_alt_url():
         patch("wet_mcp.server._embed_batch", new_callable=AsyncMock, return_value=None),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://original.com/docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://original.com/docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         # Alt URL was used (30 chunks > 1 chunk)
@@ -884,15 +888,17 @@ async def test_background_index_with_embeddings():
         mock_embed.return_value = [[0.1], [0.2], [0.3]]
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         call_kwargs = server._docs_db.add_chunks.call_args
@@ -912,15 +918,17 @@ async def test_background_index_exception():
     ):
         # Should not raise
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -946,15 +954,17 @@ async def test_background_index_with_language_fallback():
         mock_search.return_value = json.dumps({"results": []})
 
         await server._background_index_and_search(
-            library="redis",
-            lib_key="redis:python",
-            language="python",
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="redis",
+                lib_key="redis:python",
+                language="python",
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Verify fallback query includes language
         call_args = mock_search.call_args
@@ -987,15 +997,17 @@ async def test_background_index_embed_timeout():
         mock_get_backend.return_value = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Should still add chunks with embeddings=None
         server._docs_db.add_chunks.assert_called_once()
@@ -1265,15 +1277,17 @@ async def test_background_index_alt_url_fetch_timeout():
         ]
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Still uses original chunks
         server._docs_db.add_chunks.assert_called_once()
@@ -1311,15 +1325,17 @@ async def test_background_index_skip_same_netloc():
         patch("wet_mcp.server._embed_batch", new_callable=AsyncMock, return_value=None),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x/guide",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            server.IndexingTask(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x/guide",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Original chunks used (same netloc alt URL skipped)
         server._docs_db.add_chunks.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.19.0b1"
+version = "2.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Refactored the '_background_index_and_search' internal function in 'src/wet_mcp/server.py' to accept a single 'IndexingTask' dataclass instead of 9 individual parameters. This improves code readability and maintainability.

Key changes:
- Defined 'IndexingTask' dataclass in 'src/wet_mcp/server.py'.
- Updated '_background_index_and_search' signature and body to use the new dataclass.
- Updated the call site within the 'docs' tool.
- Patched 17+ relevant test cases in 'tests/test_server_comprehensive.py' and 'tests/test_server_coverage.py' to match the new signature.
- Verified all checks pass with 'ruff' and 'pytest'.

---
*PR created automatically by Jules for task [9183047875863488037](https://jules.google.com/task/9183047875863488037) started by @n24q02m*