### PR TITLE
[CLEANUP] Remove unused function 'remove_library'

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -411,34 +411,6 @@ class DocsDB:
         """).fetchall()
         return [dict(r) for r in rows]
 
-    def remove_library(self, name: str) -> bool:
-        """Remove a library and all its chunks."""
-        lib = self.get_library(name)
-        if not lib:
-            return False
-
-        lib_id = lib["id"]
-
-        # Remove vector entries in a single bulk query
-        if self._vec_enabled:
-            try:
-                self._conn.execute(
-                    "DELETE FROM doc_chunks_vec WHERE id IN "
-                    "(SELECT id FROM doc_chunks WHERE library_id = ?)",
-                    (lib_id,),
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to delete vector chunks: {e}",
-                )
-
-        # Cascade deletes chunks and versions
-        self._conn.execute("DELETE FROM doc_chunks WHERE library_id = ?", (lib_id,))
-        self._conn.execute("DELETE FROM versions WHERE library_id = ?", (lib_id,))
-        self._conn.execute("DELETE FROM libraries WHERE id = ?", (lib_id,))
-        self._conn.commit()
-        return True
-
     # -----------------------------------------------------------------------
     # Version management
     # -----------------------------------------------------------------------

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -152,15 +152,6 @@ class TestLibraryCRUD:
         assert libs[0]["name"] == "fastapi"
         assert libs[0]["total_chunks"] == 4
 
-    def test_remove_library(self, db_with_data):
-        db = db_with_data[0]
-        assert db.remove_library("fastapi") is True
-        assert db.get_library("fastapi") is None
-        assert db.list_libraries() == []
-
-    def test_remove_nonexistent(self, db):
-        assert db.remove_library("ghost") is False
-
     def test_library_name_normalization(self, db):
         """Names are lowercased and stripped."""
         db.upsert_library(name="  PyTorch  ")
@@ -640,25 +631,6 @@ class TestEdgeCases:
         assert all(r["library"] == "lib-a" for r in results_a)
         assert all(r["library"] == "lib-b" for r in results_b)
 
-    def test_remove_library_cascades(self, db):
-        """Removing a library deletes all versions and chunks."""
-        lib_id = db.upsert_library(name="cascade")
-        ver_id = db.upsert_version(lib_id)
-        db.add_chunks(
-            ver_id,
-            lib_id,
-            [
-                {"content": "cascade test chunk"},
-            ],
-        )
-        db.mark_version_indexed(ver_id, 1, 1)
-
-        db.remove_library("cascade")
-
-        # Chunks should be gone
-        results = db.search(query="cascade", library_name="cascade")
-        assert results == []
-
 
 # -----------------------------------------------------------------------
 # sqlite-vec extension loading and vector table creation (lines 141-151, 266-271)
@@ -783,60 +755,6 @@ class TestUpsertLibraryPaths:
         assert lib["docs_url"] == "https://new.dev"
         assert lib["registry"] == "crates"
         assert lib["description"] == "A Rust library"
-
-
-# -----------------------------------------------------------------------
-# remove_library() bulk vector deletion (lines 396-403)
-# -----------------------------------------------------------------------
-
-
-class TestRemoveLibraryVec:
-    def test_remove_library_with_vec_enabled(self, tmp_path):
-        """remove_library deletes vector entries when vec is enabled."""
-        db = DocsDB(tmp_path / "rm_vec.db", embedding_dims=4)
-        try:
-            lib_id = db.upsert_library(name="veclib")
-            ver_id = db.upsert_version(lib_id)
-            embeddings = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
-            db.add_chunks(
-                ver_id,
-                lib_id,
-                [{"content": "vec chunk 1"}, {"content": "vec chunk 2"}],
-                embeddings=embeddings,
-            )
-            # Verify vec entries exist
-            vec_count = db._conn.execute(
-                "SELECT COUNT(*) FROM doc_chunks_vec"
-            ).fetchone()[0]
-            assert vec_count == 2
-
-            db.remove_library("veclib")
-
-            # Vec entries should be gone
-            vec_count = db._conn.execute(
-                "SELECT COUNT(*) FROM doc_chunks_vec"
-            ).fetchone()[0]
-            assert vec_count == 0
-        finally:
-            db.close()
-
-    def test_remove_library_vec_error_handled(self, tmp_path):
-        """remove_library handles vec deletion errors gracefully."""
-        db = DocsDB(tmp_path / "rm_vec_err.db", embedding_dims=4)
-        try:
-            lib_id = db.upsert_library(name="veclib2")
-            ver_id = db.upsert_version(lib_id)
-            db.add_chunks(ver_id, lib_id, [{"content": "test chunk"}])
-
-            # Simulate vec table error by dropping it
-            db._conn.execute("DROP TABLE doc_chunks_vec")
-            db._conn.commit()
-
-            # Should not raise
-            result = db.remove_library("veclib2")
-            assert result is True
-        finally:
-            db.close()
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -273,30 +273,6 @@ class TestUpsertVersionUpdate:
 
 
 # ---------------------------------------------------------------------------
-# remove_library with vec enabled (lines 396-403)
-# ---------------------------------------------------------------------------
-
-
-class TestRemoveLibraryVec:
-    def test_remove_library_vec_path(self, tmp_path):
-        """remove_library deletes vec entries when vec is enabled (lines 396-403)."""
-        # Simulate vec-enabled DB by monkey-patching
-        d = DocsDB(tmp_path / "rvec.db", embedding_dims=0)
-        lib_id = d.upsert_library(name="veclib")
-        ver_id = d.upsert_version(lib_id)
-        d.add_chunks(ver_id, lib_id, [{"content": "test chunk"}])
-
-        # Force vec_enabled to trigger the DELETE path
-        d._vec_enabled = True
-        # The DELETE will fail silently because doc_chunks_vec table doesn't exist
-        # but the code path is exercised (lines 396-403)
-        result = d.remove_library("veclib")
-        assert result is True
-        assert d.get_library("veclib") is None
-        d.close()
-
-
-# ---------------------------------------------------------------------------
 # clear_version_chunks with vec (lines 550-557)
 # ---------------------------------------------------------------------------
 
@@ -650,14 +626,3 @@ class TestExportJsonlRoundtrip:
         assert "library" in types_found
         assert "version" in types_found
         assert "chunk" in types_found
-
-
-# ---------------------------------------------------------------------------
-# remove_library for nonexistent
-# ---------------------------------------------------------------------------
-
-
-class TestRemoveNonexistent:
-    def test_remove_nonexistent_returns_false(self, db):
-        """remove_library returns False for unknown library."""
-        assert db.remove_library("no_such_lib") is False


### PR DESCRIPTION
This PR removes the unused 'remove_library' method from the DocsDB class in src/wet_mcp/db.py. It also removes all corresponding unit tests and test classes from tests/test_db.py and tests/test_db_coverage.py to maintain a clean and relevant test suite.

---
*PR created automatically by Jules for task [4875222606359823724](https://jules.google.com/task/4875222606359823724) started by @n24q02m*