### PR TITLE
[FIX] Randomize starting offset

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -44,6 +44,41 @@ def _patched_install_searxng() -> bool:
 
 _wc_runner._install_searxng = _patched_install_searxng  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
+
+def _find_available_port(start_port: int, max_tries: int = 100) -> int:
+    """Find an available port, randomizing offset to avoid collisions.
+
+    When multiple WET MCP instances start concurrently (e.g. wet, wet-nokey,
+    wet-sync), they all call this function at roughly the same time.
+    A deterministic port scan (8080, 8081, ...) can hit a TOCTOU race:
+    two instances both see port 8081 as free, then one fails to bind.
+
+    Fix: randomize the starting offset within a wider range so concurrent
+    instances are unlikely to pick the same port.
+    """
+    import random
+    import socket
+
+    # Randomize starting offset within a wider range (100) to avoid collisions
+    offsets = list(range(max_tries))
+    random.shuffle(offsets)
+
+    for offset in offsets:
+        port = start_port + offset
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("127.0.0.1", port))
+                return port
+        except OSError:
+            continue
+
+    msg = f"No available port found in range {start_port}-{start_port + max_tries - 1}"
+    raise RuntimeError(msg)
+
+
+# Monkey-patch web-core's port finder to use our randomized version
+_wc_runner._find_available_port = _find_available_port  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+
 # ---------------------------------------------------------------------------
 # Re-export internal functions from web-core for backward compatibility.
 # Tests and other modules import these from wet_mcp.searxng_runner.
@@ -56,7 +91,6 @@ from web_core.search.runner import (  # noqa: F401, E402
     _STARTUP_HEALTH_TIMEOUT,
     _cleanup_process,
     _ensure_searxng_locked,
-    _find_available_port,
     _force_kill_process,
     _get_pip_command,
     _get_process_kwargs,


### PR DESCRIPTION
I have implemented a randomized port discovery mechanism in `src/wet_mcp/searxng_runner.py` to prevent TOCTOU (Time of Check to Time of Use) race conditions when multiple WET MCP instances (e.g., wet, wet-nokey, wet-sync) start concurrently.

### Key Changes:
1. **Robust Port Discovery:** Defined a local `_find_available_port` function that:
   - Uses a wider range (100) of ports for scanning.
   - Randomizes the scan order using `random.shuffle(offsets)` to minimize collisions.
   - Uses `socket.bind` for reliable availability checking.
2. **Library Monkey-patching:** Patched `web_core.search.runner._find_available_port` with this new implementation to ensure all internal library calls use the randomized logic.
3. **Module Re-exports:** Updated the module's re-exports to use the improved local version while maintaining backward compatibility for existing consumers.
4. **Type Safety:** Added `# type: ignore` and `# ty: ignore` annotations to satisfy Ruff and Astral `ty` checks for the monkey-patch assignment.

### Verification:
- **Randomization Test:** Verified with a script that confirmed distinct ports are selected across multiple successive calls.
- **Linting & Formatting:** Passed `uv run ruff format .`, `uv run ruff check .`, and `uv run ty check`.
- **Unit Tests:** All existing tests in `tests/test_searxng_runner_comprehensive.py` passed.

This change ensures a more reliable startup process for WET MCP in multi-instance environments.

---
*PR created automatically by Jules for task [1785842337237798425](https://jules.google.com/task/1785842337237798425) started by @n24q02m*