### PR TITLE
[TEST] Missing test for is_safe_local_path in security.py

### DIFF
--- a/src/wet_mcp/security.py
+++ b/src/wet_mcp/security.py
@@ -90,7 +90,10 @@ def is_safe_local_path(
         return None
 
     # 3. Must be a regular file
-    if not p.is_file():
+    try:
+        if not p.is_file():
+            return None
+    except OSError:
         return None
 
     # 4. Check against allowed directories

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -308,3 +308,35 @@ def test_safe_local_path_symlink_escape(tmp_path):
     link = allowed / "link.txt"
     link.symlink_to(secret)
     assert is_safe_local_path(str(link), allowed_dirs=[allowed]) is None
+
+
+def test_safe_local_path_stat_oserror(tmp_path):
+    """Test that is_safe_local_path returns None if stat() raises OSError."""
+    f = tmp_path / "error.txt"
+    f.write_text("hello")
+    with patch("pathlib.Path.stat", side_effect=OSError("Permission denied")):
+        assert is_safe_local_path(str(f)) is None
+
+
+def test_safe_local_path_accepts_path_object(tmp_path):
+    """Test that is_safe_local_path correctly handles Path objects as input."""
+    f = tmp_path / "test.txt"
+    f.write_text("hello")
+    # type: ignore (testing runtime support for Path even if hint says str)
+    assert is_safe_local_path(f) == f.resolve()
+
+
+def test_safe_local_path_resolve_value_error():
+    """Test that is_safe_local_path returns None if resolve() raises ValueError."""
+    with patch("pathlib.Path.resolve", side_effect=ValueError("Invalid path")):
+        assert is_safe_local_path("/invalid/path") is None
+
+
+def test_safe_local_path_size_stat_oserror(tmp_path):
+    """Test that is_safe_local_path returns None if stat() for size check raises OSError."""
+    f = tmp_path / "error_size.txt"
+    f.write_text("hello")
+    # Mock is_file to succeed so we reach the size check
+    with patch("pathlib.Path.is_file", return_value=True):
+        with patch("pathlib.Path.stat", side_effect=OSError("Permission denied")):
+            assert is_safe_local_path(str(f)) is None


### PR DESCRIPTION
Identified missing test coverage for `is_safe_local_path` in `src/wet_mcp/security.py`.
Fixed a bug where `OSError` during `is_file()` check was unhandled.
Added 4 new test cases to `tests/test_security.py`:
- `test_safe_local_path_stat_oserror`: Verifies handling of `OSError` during file type check.
- `test_safe_local_path_accepts_path_object`: Verifies runtime support for `pathlib.Path` input.
- `test_safe_local_path_resolve_value_error`: Verifies handling of `ValueError` during resolution.
- `test_safe_local_path_size_stat_oserror`: Verifies handling of `OSError` during file size check.
Achieved 100% coverage for `src/wet_mcp/security.py`.
Verified all 1427 tests pass.

---
*PR created automatically by Jules for task [9046687636334468083](https://jules.google.com/task/9046687636334468083) started by @n24q02m*