### PR TITLE
[FIX] Refactor 'media' to reduce parameters

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
 from urllib.parse import urlparse
@@ -885,6 +886,80 @@ async def extract(
             )
 
 
+@dataclass
+class MediaParams:
+    """Parameters for media tool."""
+
+    action: str
+    url: str | None = None
+    media_type: str = "all"
+    media_urls: list[str] | None = None
+    output_dir: str | None = None
+    max_items: int = 10
+    prompt: str = "Describe this image in detail."
+
+
+async def _media_impl(params: MediaParams) -> str:
+    """Implementation of media tool logic."""
+    from wet_mcp.sources.crawler import download_media
+
+    match params.action:
+        case "list":
+            if not params.url:
+                return 'Error: url is required for list action. Example: media(action="list", url="https://example.com/gallery", media_type="images")'
+            return await _with_timeout(
+                list_media(
+                    url=params.url,
+                    media_type=params.media_type,
+                    max_items=params.max_items,
+                ),
+                "media.list",
+            )
+
+        case "download":
+            if not params.media_urls:
+                return 'Error: media_urls is required for download action. Example: media(action="download", media_urls=["https://example.com/image.jpg"]). Use media(action="list", url="...") first to discover media URLs.'
+
+            # Security: validate output_dir is within the configured
+            # download directory to prevent arbitrary file writes.
+            resolved_download_dir = Path(settings.download_dir).expanduser().resolve()
+            target_dir = (
+                Path(params.output_dir or settings.download_dir).expanduser().resolve()
+            )
+            if not target_dir.is_relative_to(resolved_download_dir):
+                return (
+                    "Error: Security Alert — output_dir must be within "
+                    f"the configured download directory ({resolved_download_dir})"
+                )
+
+            return await _with_timeout(
+                download_media(
+                    media_urls=params.media_urls,
+                    output_dir=str(target_dir),
+                ),
+                "media.download",
+            )
+
+        case "analyze":
+            if not params.url:
+                return 'Error: url (local file path) is required for analyze action. Example: media(action="analyze", url="/path/to/image.jpg", prompt="Describe this image"). Download a file first with media(action="download", ...).'
+
+            from wet_mcp.llm import analyze_media
+
+            return await _with_timeout(
+                analyze_media(media_path=params.url, prompt=params.prompt),
+                "media.analyze",
+            )
+
+        case _:
+            import difflib
+
+            valid_actions = ["analyze", "download", "list"]
+            closest = difflib.get_close_matches(params.action, valid_actions, n=1)
+            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
+            return f"Error: Unknown action '{params.action}'.{suggestion} Valid actions: list (discover media on page), download (save to local), analyze (LLM vision analysis)."
+
+
 @mcp.tool(
     annotations=ToolAnnotations(
         readOnlyHint=False,
@@ -918,59 +993,16 @@ async def media(  # noqa: PLR0913
     Typical workflow: list (discover) -> download (save locally) -> analyze (LLM insights).
     Use `help` tool with tool_name="media" for full documentation.
     """
-    from wet_mcp.sources.crawler import download_media
-
-    match action:
-        case "list":
-            if not url:
-                return 'Error: url is required for list action. Example: media(action="list", url="https://example.com/gallery", media_type="images")'
-            return await _with_timeout(
-                list_media(url=url, media_type=media_type, max_items=max_items),
-                "media.list",
-            )
-
-        case "download":
-            if not media_urls:
-                return 'Error: media_urls is required for download action. Example: media(action="download", media_urls=["https://example.com/image.jpg"]). Use media(action="list", url="...") first to discover media URLs.'
-
-            # Security: validate output_dir is within the configured
-            # download directory to prevent arbitrary file writes.
-            resolved_download_dir = Path(settings.download_dir).expanduser().resolve()
-            target_dir = (
-                Path(output_dir or settings.download_dir).expanduser().resolve()
-            )
-            if not target_dir.is_relative_to(resolved_download_dir):
-                return (
-                    "Error: Security Alert — output_dir must be within "
-                    f"the configured download directory ({resolved_download_dir})"
-                )
-
-            return await _with_timeout(
-                download_media(
-                    media_urls=media_urls,
-                    output_dir=str(target_dir),
-                ),
-                "media.download",
-            )
-
-        case "analyze":
-            if not url:
-                return 'Error: url (local file path) is required for analyze action. Example: media(action="analyze", url="/path/to/image.jpg", prompt="Describe this image"). Download a file first with media(action="download", ...).'
-
-            from wet_mcp.llm import analyze_media
-
-            return await _with_timeout(
-                analyze_media(media_path=url, prompt=prompt),
-                "media.analyze",
-            )
-
-        case _:
-            import difflib
-
-            valid_actions = ["analyze", "download", "list"]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
-            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return f"Error: Unknown action '{action}'.{suggestion} Valid actions: list (discover media on page), download (save to local), analyze (LLM vision analysis)."
+    params = MediaParams(
+        action=action,
+        url=url,
+        media_type=media_type,
+        media_urls=media_urls,
+        output_dir=output_dir,
+        max_items=max_items,
+        prompt=prompt,
+    )
+    return await _media_impl(params)
 
 
 @mcp.tool(


### PR DESCRIPTION
Refactored the `media` tool in `src/wet_mcp/server.py` to improve internal code organization and readability.

The `media` tool had 7 parameters, leading to linting warnings (PLR0913). While the public-facing signature must remain flat to ensure MCP JSON schema stability and compatible LLM interactions, the internal implementation has been refactored to use a `MediaParams` dataclass.

Key changes:
- Added `MediaParams` dataclass to group the tool's parameters internally.
- Extracted the core logic into a private `_media_impl` helper function.
- Updated the `@mcp.tool` handler to delegate to the helper, maintaining its original signature.
- Fixed an unintended `uv.lock` modification during testing.
- Verified that all media-related tests pass and linting is clean.

---
*PR created automatically by Jules for task [16517503544986023950](https://jules.google.com/task/16517503544986023950) started by @n24q02m*