### PR TITLE
[TEST] Missing test for process_url in sources/crawler.py

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -284,54 +284,64 @@ async def extract(
         run_config_kwargs["page_timeout"] = page_timeout
     run_config = CrawlerRunConfig(**run_config_kwargs)
 
-    async def process_url(url: str):
-        async with sem:
-            if not is_safe_url(url):
-                logger.warning(f"Skipping unsafe URL: {url}")
-                return {"url": url, "error": "Security Alert: Unsafe URL blocked"}
-
-            # Route document URLs (PDF, DOCX, etc.) through markitdown
-            if _is_document_url(url):
-                logger.info(f"Document URL detected, using markitdown: {url}")
-                return await _extract_with_markitdown(url)
-
-            try:
-                result = await crawler.arun(  # ty: ignore[missing-argument]
-                    url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
-                    config=run_config,
-                )
-
-                if result.success:
-                    content = (
-                        result.markdown if format == "markdown" else result.cleaned_html
-                    )
-                    return {
-                        "url": url,
-                        "title": result.metadata.get("title", ""),
-                        "content": content,
-                        "links": {
-                            "internal": result.links.get("internal", [])[:20],
-                            "external": result.links.get("external", [])[:20],
-                        },
-                    }
-                else:
-                    return {
-                        "url": url,
-                        "error": result.error_message or "Failed to extract",
-                    }
-
-            except Exception as e:
-                logger.error(f"Error extracting {url}: {e}")
-                return {
-                    "url": url,
-                    "error": str(e),
-                }
-
-    tasks = [process_url(url) for url in urls]
+    tasks = [_process_url(url, crawler, run_config, sem, format) for url in urls]
     results = await asyncio.gather(*tasks)
 
     logger.info(f"Extracted {len(results)} pages")
     return json.dumps(results, ensure_ascii=False, indent=2)
+
+
+async def _process_url(
+    url: str,
+    crawler: AsyncWebCrawler,
+    run_config: CrawlerRunConfig,
+    sem: asyncio.Semaphore,
+    format: str = "markdown",
+    depth: int = 0,
+) -> dict:
+    """Process a single URL for extraction."""
+    async with sem:
+        if not is_safe_url(url):
+            logger.warning(f"Skipping unsafe URL: {url}")
+            return {"url": url, "error": "Security Alert: Unsafe URL blocked"}
+
+        # Route document URLs (PDF, DOCX, etc.) through markitdown
+        if _is_document_url(url):
+            logger.info(f"Document URL detected, using markitdown: {url}")
+            return await _extract_with_markitdown(url)
+
+        try:
+            result = await crawler.arun(  # ty: ignore[missing-argument]
+                url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
+                config=run_config,
+            )
+
+            if result.success:
+                content = (
+                    result.markdown if format == "markdown" else result.cleaned_html
+                )
+                return {
+                    "url": url,
+                    "depth": depth,
+                    "title": result.metadata.get("title", ""),
+                    "content": content,
+                    "links": {
+                        "internal": result.links.get("internal", [])[:20],
+                        "external": result.links.get("external", [])[:20],
+                    },
+                }
+            else:
+                return {
+                    "url": url,
+                    "error": result.error_message or "Failed to extract",
+                }
+
+        except Exception as e:
+            logger.error(f"Error extracting {url}: {e}")
+            return {
+                "url": url,
+                "error": str(e),
+            }
 
 
 async def crawl(

--- a/tests/test_crawler_unit.py
+++ b/tests/test_crawler_unit.py
@@ -1,11 +1,109 @@
 """Unit tests for crawl functionality with singleton browser pool."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from crawl4ai import CrawlerRunConfig
 
-from wet_mcp.sources.crawler import crawl
+from wet_mcp.sources.crawler import _process_url, crawl
+
+
+@pytest.mark.asyncio
+async def test_process_url_success(mock_crawler_instance):
+    """Test successful _process_url."""
+    mock_result = MagicMock()
+    mock_result.success = True
+    mock_result.markdown = "Content"
+    mock_result.cleaned_html = "<p>Content</p>"
+    mock_result.metadata = {"title": "Title"}
+    mock_result.links = {"internal": [], "external": []}
+
+    mock_crawler_instance.arun = AsyncMock(return_value=mock_result)
+    run_config = CrawlerRunConfig()
+    sem = asyncio.Semaphore(1)
+
+    result = await _process_url(
+        "https://example.com",
+        mock_crawler_instance,
+        run_config,
+        sem,
+        format="markdown",
+        depth=1,
+    )
+
+    assert result["url"] == "https://example.com"
+    assert result["depth"] == 1
+    assert result["title"] == "Title"
+    assert result["content"] == "Content"
+
+
+@pytest.mark.asyncio
+async def test_process_url_unsafe(mock_crawler_instance):
+    """Test _process_url with unsafe URL."""
+    run_config = CrawlerRunConfig()
+    sem = asyncio.Semaphore(1)
+
+    with patch("wet_mcp.sources.crawler.is_safe_url", return_value=False):
+        result = await _process_url(
+            "http://127.0.0.1", mock_crawler_instance, run_config, sem
+        )
+
+    assert "Security Alert" in result["error"]
+    mock_crawler_instance.arun.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_url_document(mock_crawler_instance):
+    """Test _process_url with a document URL."""
+    run_config = CrawlerRunConfig()
+    sem = asyncio.Semaphore(1)
+    mock_doc_result = {"url": "https://example.com/test.pdf", "content": "PDF Content"}
+
+    with patch(
+        "wet_mcp.sources.crawler._extract_with_markitdown",
+        new_callable=AsyncMock,
+        return_value=mock_doc_result,
+    ):
+        result = await _process_url(
+            "https://example.com/test.pdf", mock_crawler_instance, run_config, sem
+        )
+
+    assert result["content"] == "PDF Content"
+    mock_crawler_instance.arun.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_url_failure_result(mock_crawler_instance):
+    """Test _process_url when crawler returns success=False."""
+    mock_result = MagicMock()
+    mock_result.success = False
+    mock_result.error_message = "404 Not Found"
+
+    mock_crawler_instance.arun = AsyncMock(return_value=mock_result)
+    run_config = CrawlerRunConfig()
+    sem = asyncio.Semaphore(1)
+
+    result = await _process_url(
+        "https://example.com", mock_crawler_instance, run_config, sem
+    )
+
+    assert result["error"] == "404 Not Found"
+
+
+@pytest.mark.asyncio
+async def test_process_url_exception(mock_crawler_instance):
+    """Test _process_url when crawler raises an exception."""
+    mock_crawler_instance.arun = AsyncMock(side_effect=Exception("Network error"))
+    run_config = CrawlerRunConfig()
+    sem = asyncio.Semaphore(1)
+
+    result = await _process_url(
+        "https://example.com", mock_crawler_instance, run_config, sem
+    )
+
+    assert result["error"] == "Network error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR refactors the nested `process_url` function within `extract` in `src/wet_mcp/sources/crawler.py` into a standalone, module-level function `_process_url`. This change was made to facilitate unit testing as requested.

Key changes:
- Extracted `process_url` logic to `_process_url` with explicit dependencies.
- Added a `depth` parameter to `_process_url` as per the task requirements.
- Updated the `extract` function to call `_process_url`.
- Added five comprehensive unit tests in `tests/test_crawler_unit.py` covering:
    - Successful extraction.
    - Unsafe URL handling.
    - Document URL routing (markitdown).
    - Failed extraction results.
    - Exception handling.

Verification:
- Ran `uv run pytest` (27 tests passed).
- Verified coverage with `uv run coverage`.
- Applied `ruff` for formatting and linting.

---
*PR created automatically by Jules for task [7635323030114595360](https://jules.google.com/task/7635323030114595360) started by @n24q02m*