### PR TITLE
fix: consolidated Jules PR review -- perf, cleanup, deps, docs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,11 +111,11 @@ jobs:
         with:
           ref: ${{ needs.release.outputs.tag }}
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -153,11 +153,11 @@ jobs:
           pattern: digest-*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
 
   dependency-review:
     name: Dependency Review

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Configure env vars in `~/.claude/settings.local.json` or your shell profile. See
 | `extract` | `extract`, `batch`, `crawl`, `map`, `convert`, `extract_structured` | Content extraction, batch processing (up to 50 URLs), deep crawling, site mapping, local file conversion, structured data extraction (JSON Schema) |
 | `media` | `list`, `download`, `analyze` | Media discovery, download, and analysis |
 | `config` | `status`, `set`, `cache_clear`, `docs_reindex` | Server configuration and cache management |
-| `setup` | `warmup`, `setup_sync` | Pre-download models, configure cloud sync |
+| `setup` | `warmup`, `setup_sync`, `setup_relay` | Pre-download models, configure cloud sync, relay setup |
 | `help` | -- | Full documentation for any tool |
 
 ### MCP Prompts
@@ -117,7 +117,6 @@ Configure env vars in `~/.claude/settings.local.json` or your shell profile. See
 | Prompt | Parameters | Description |
 |:-------|:-----------|:------------|
 | `research_topic` | `topic` | Research a topic using academic search |
-| `library_docs` | `library`, `question` | Find library documentation |
 
 ## Zero-Config Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = "==3.13.*"
 dependencies = [
     # Shared web infrastructure (SSRF, SearXNG, URL utils)
-    "n24q02m-web-core>=1.0.0",
+    "n24q02m-web-core>=1.0.1",
     # MCP Server
     "mcp[cli]",
     # Web Crawling
@@ -40,7 +40,7 @@ dependencies = [
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
-    "qwen3-embed>=1.5.1",
+    "qwen3-embed>=1.6.0",
 
     "pillow>=12.1.1",
     "diskcache>=5.6.3",
@@ -52,7 +52,7 @@ dependencies = [
     # Per-domain rate limiting for batch operations
     "aiolimiter>=1.2.1",
     # Relay setup (zero-env-config)
-    "mcp-relay-core>=1.0.5",
+    "mcp-relay-core>=1.2.0",
     # Google Drive sync
     "google-api-python-client>=2.193.0",
     "google-auth>=2.49.1",

--- a/src/wet_mcp/__main__.py
+++ b/src/wet_mcp/__main__.py
@@ -8,5 +8,5 @@ def _cli() -> None:
     main()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     _cli()

--- a/src/wet_mcp/cache.py
+++ b/src/wet_mcp/cache.py
@@ -49,6 +49,9 @@ class WebCache:
         self._conn.execute("PRAGMA journal_mode = WAL")
         self._conn.execute("PRAGMA synchronous = NORMAL")
         self._conn.execute("PRAGMA busy_timeout = 5000")
+        self._conn.execute("PRAGMA mmap_size = 268435456")  # 256MB mmap
+        self._conn.execute("PRAGMA temp_store = MEMORY")
+        self._conn.execute("PRAGMA cache_size = -64000")  # 64MB cache (KB)
 
         self._create_tables()
         logger.debug(f"WebCache initialized at {db_path}")
@@ -115,25 +118,6 @@ class WebCache:
         if self._op_count >= _PURGE_INTERVAL:
             self._purge_expired()
             self._op_count = 0
-
-    def get_extract(self, url: str) -> str | None:
-        """Get cached extract result for a single URL.
-
-        This enables docs action to reuse already-extracted content
-        without re-crawling.
-        """
-        row = self._conn.execute(
-            """SELECT content FROM web_cache
-               WHERE action IN ('extract', 'crawl') AND expires_at > ?
-               AND params LIKE ?
-               ORDER BY CASE action WHEN 'extract' THEN 0 ELSE 1 END
-               LIMIT 1""",
-            (time.time(), f'%"{url}"%'),
-        ).fetchone()
-        if row:
-            logger.debug(f"Extract cache HIT for URL: {url[:60]}...")
-            return row["content"]
-        return None
 
     def _purge_expired(self) -> None:
         """Remove expired cache entries."""

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -152,6 +152,9 @@ class DocsDB:
         self._conn.execute("PRAGMA journal_mode = WAL")
         self._conn.execute("PRAGMA synchronous = NORMAL")
         self._conn.execute("PRAGMA busy_timeout = 5000")
+        self._conn.execute("PRAGMA mmap_size = 268435456")  # 256MB mmap
+        self._conn.execute("PRAGMA temp_store = MEMORY")
+        self._conn.execute("PRAGMA cache_size = -64000")  # 64MB cache (KB)
 
         # Try loading sqlite-vec extension
         if embedding_dims > 0:
@@ -397,47 +400,6 @@ class DocsDB:
             "SELECT * FROM libraries WHERE name = ?", (name.lower().strip(),)
         ).fetchone()
         return dict(row) if row else None
-
-    def list_libraries(self) -> list[dict]:
-        """List all libraries with chunk counts."""
-        rows = self._conn.execute("""
-            SELECT l.*,
-                   COALESCE(SUM(v.chunk_count), 0) as total_chunks,
-                   COUNT(v.id) as version_count
-            FROM libraries l
-            LEFT JOIN versions v ON v.library_id = l.id AND v.status = 'indexed'
-            GROUP BY l.id
-            ORDER BY l.name
-        """).fetchall()
-        return [dict(r) for r in rows]
-
-    def remove_library(self, name: str) -> bool:
-        """Remove a library and all its chunks."""
-        lib = self.get_library(name)
-        if not lib:
-            return False
-
-        lib_id = lib["id"]
-
-        # Remove vector entries in a single bulk query
-        if self._vec_enabled:
-            try:
-                self._conn.execute(
-                    "DELETE FROM doc_chunks_vec WHERE id IN "
-                    "(SELECT id FROM doc_chunks WHERE library_id = ?)",
-                    (lib_id,),
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to delete vector chunks: {e}",
-                )
-
-        # Cascade deletes chunks and versions
-        self._conn.execute("DELETE FROM doc_chunks WHERE library_id = ?", (lib_id,))
-        self._conn.execute("DELETE FROM versions WHERE library_id = ?", (lib_id,))
-        self._conn.execute("DELETE FROM libraries WHERE id = ?", (lib_id,))
-        self._conn.commit()
-        return True
 
     # -----------------------------------------------------------------------
     # Version management
@@ -807,10 +769,11 @@ class DocsDB:
             for _url, _ver, _idx in _adj_keys:
                 _groups.setdefault((_url, _ver), set()).add(_idx)
 
+            _batch_size = 32764 if sqlite3.sqlite_version_info >= (3, 32, 0) else 900
             for (_url, _ver), _indices in _groups.items():
                 _indices_list = list(_indices)
-                for i in range(0, len(_indices_list), 900):
-                    _chunk_indices = _indices_list[i : i + 900]
+                for i in range(0, len(_indices_list), _batch_size):
+                    _chunk_indices = _indices_list[i : i + _batch_size]
                     _placeholders = ",".join(["?"] * len(_chunk_indices))
 
                     # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
@@ -956,8 +919,9 @@ class DocsDB:
                 return set()
             ids = [obj["id"] for obj in items]
             existing = set()
-            for i in range(0, len(ids), 999):
-                batch = ids[i : i + 999]
+            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+            for i in range(0, len(ids), batch_size):
+                batch = ids[i : i + batch_size]
                 placeholders = ",".join("?" * len(batch))
                 # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 res = self._conn.execute(

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -84,7 +84,7 @@ class EmbeddingBackend(Protocol):
         dimensions: int | None = None,
     ) -> list[list[float]]:
         """Embed a batch of texts. Returns list of embedding vectors."""
-        ...
+        ...  # pragma: no cover
 
     def embed_single(
         self,
@@ -92,7 +92,7 @@ class EmbeddingBackend(Protocol):
         dimensions: int | None = None,
     ) -> list[float]:
         """Embed a single text. Returns embedding vector."""
-        ...
+        ...  # pragma: no cover
 
     def check_available(self) -> int:
         """Check if backend is available.
@@ -100,7 +100,7 @@ class EmbeddingBackend(Protocol):
         Returns:
             Embedding dimensions if available, 0 if not.
         """
-        ...
+        ...  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -345,16 +345,26 @@ def get_model_capabilities(model: str) -> dict:
     }
 
 
-def encode_image(image_path: str) -> str:
-    """Encode image to base64."""
-    with open(image_path, "rb") as image_file:
-        return base64.b64encode(image_file.read()).decode("utf-8")
+async def encode_image(image_path: str) -> str:
+    """Encode image to base64.
+
+    Offload blocking I/O to thread pool to prevent event loop lag.
+    """
+    data = await asyncio.to_thread(Path(image_path).read_bytes)
+    return base64.b64encode(data).decode("utf-8")
 
 
-def _read_and_truncate(path: str) -> str:
-    """Read file and truncate if too long."""
-    with open(path, encoding="utf-8") as f:
-        text = f.read()
+async def _read_and_truncate(path: str) -> str:
+    """Read file and truncate if too long.
+
+    Uses asyncio.to_thread for non-blocking file I/O.
+    """
+
+    def _read():
+        with open(path, encoding="utf-8") as f:
+            return f.read(100001)
+
+    text = await asyncio.to_thread(_read)
     if len(text) > 100000:
         text = text[:100000] + "\n...[truncated]"
     return text
@@ -387,7 +397,7 @@ async def analyze_media(
         "application/xml",
     ]:
         try:
-            content = await asyncio.to_thread(_read_and_truncate, media_path)
+            content = await _read_and_truncate(media_path)
             logger.info(f"Analyzing text file with model: {config['model']}")
 
             messages = [
@@ -425,7 +435,7 @@ async def analyze_media(
     try:
         logger.info(f"Analyzing media with model: {config['model']}")
 
-        base64_image = await asyncio.to_thread(encode_image, media_path)
+        base64_image = await encode_image(media_path)
         data_url = f"data:{mime_type};base64,{base64_image}"
 
         messages = [

--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -44,6 +44,36 @@ def _patched_install_searxng() -> bool:
 
 _wc_runner._install_searxng = _patched_install_searxng  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
+
+# ---------------------------------------------------------------------------
+# Randomize port discovery to avoid TOCTOU race when multiple instances
+# start concurrently (e.g. wet, wet-nokey, wet-sync).
+# ---------------------------------------------------------------------------
+
+
+def _find_available_port(start_port: int, max_tries: int = 100) -> int:
+    """Find an available port, randomizing offset to avoid collisions."""
+    import random
+    import socket
+
+    offsets = list(range(max_tries))
+    random.shuffle(offsets)
+
+    for offset in offsets:
+        port = start_port + offset
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("127.0.0.1", port))
+                return port
+        except OSError:
+            continue
+
+    msg = f"No available port found in range {start_port}-{start_port + max_tries - 1}"
+    raise RuntimeError(msg)
+
+
+_wc_runner._find_available_port = _find_available_port  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+
 # ---------------------------------------------------------------------------
 # Re-export internal functions from web-core for backward compatibility.
 # Tests and other modules import these from wet_mcp.searxng_runner.

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -589,40 +589,52 @@ async def search(  # noqa: PLR0913
                 ),
                 "search",
             )
-            # Rerank by semantic relevance (same as research/docs)
             if not result.startswith("Error"):
                 try:
                     data = json.loads(result)
-                    results_list = data.get("results", [])
-                    if results_list:
-                        # Map snippet -> content for reranker (fallback to title)
-                        for r in results_list:
-                            if "content" not in r:
-                                r["content"] = r.get("snippet", r.get("title", ""))
-                        reranked = await _rerank_results(
-                            query, results_list, top_n=max_results
-                        )
-                        if reranked:
-                            data["results"] = [
-                                r for r in reranked if r.get("score", 1.0) > 0.2
-                            ]
-                            data["total"] = len(data["results"])
-                            result = json.dumps(data, ensure_ascii=False, indent=2)
-                except Exception as e:
-                    logger.debug(f"Search reranking failed, using original: {e}")
-            # Optional snippet enrichment
-            if enrich and not result.startswith("Error"):
-                try:
-                    data = json.loads(result)
-                    results_list = data.get("results", [])
-                    if results_list:
-                        from wet_mcp.sources.search_strategies import enrich_snippets
+                    modified = False
 
-                        enriched = await enrich_snippets(results_list, query, top_n=5)
-                        data["results"] = enriched
+                    # Rerank by semantic relevance (same as research/docs)
+                    try:
+                        results_list = data.get("results", [])
+                        if results_list:
+                            # Map snippet -> content for reranker (fallback to title)
+                            for r in results_list:
+                                if "content" not in r:
+                                    r["content"] = r.get("snippet", r.get("title", ""))
+                            reranked = await _rerank_results(
+                                query, results_list, top_n=max_results
+                            )
+                            if reranked:
+                                data["results"] = [
+                                    r for r in reranked if r.get("score", 1.0) > 0.2
+                                ]
+                                data["total"] = len(data["results"])
+                                modified = True
+                    except Exception as e:
+                        logger.debug(f"Search reranking failed, using original: {e}")
+
+                    # Optional snippet enrichment
+                    if enrich:
+                        try:
+                            results_list = data.get("results", [])
+                            if results_list:
+                                from wet_mcp.sources.search_strategies import (
+                                    enrich_snippets,
+                                )
+
+                                enriched = await enrich_snippets(
+                                    results_list, query, top_n=5
+                                )
+                                data["results"] = enriched
+                                modified = True
+                        except Exception as e:
+                            logger.debug(f"Snippet enrichment failed: {e}")
+
+                    if modified:
                         result = json.dumps(data, ensure_ascii=False, indent=2)
-                except Exception as e:
-                    logger.debug(f"Snippet enrichment failed: {e}")
+                except json.JSONDecodeError:
+                    pass
             if _web_cache and not result.startswith("Error"):
                 await asyncio.to_thread(_web_cache.set, "search", cache_params, result)
             return result
@@ -1262,17 +1274,19 @@ async def _do_research(
     )
     try:
         data = json.loads(result_str)
-        if "results" in data and data["results"]:
-            reranked = await _rerank_results(query, data["results"], top_n=max_results)
-            data["results"] = [r for r in reranked if r.get("score", 1.0) > 0.3]
-            data["total"] = len(data["results"])
-            result_str = json.dumps(data, ensure_ascii=False, indent=2)
-    except Exception as e:
-        logger.error(f"Reranking failed: {e}")
 
-    # Re-format results for academic context
-    try:
-        data = json.loads(result_str)
+        # Rerank
+        try:
+            if "results" in data and data["results"]:
+                reranked = await _rerank_results(
+                    query, data["results"], top_n=max_results
+                )
+                data["results"] = [r for r in reranked if r.get("score", 1.0) > 0.3]
+                data["total"] = len(data["results"])
+        except Exception as e:
+            logger.error(f"Reranking failed: {e}")
+
+        # Re-format results for academic context
         results = data.get("results", [])
 
         # Enrich with academic metadata hints
@@ -1497,6 +1511,8 @@ async def _background_index_and_search(
                 import json
 
                 fallback_data = json.loads(fallback_result)
+                tasks = []
+                alt_urls = []
                 for fr in fallback_data.get("results", []):
                     alt_url = fr.get("url", "")
                     if not alt_url or not alt_url.startswith("http"):
@@ -1505,18 +1521,25 @@ async def _background_index_and_search(
                     orig_parsed = urlparse(docs_url)
                     if alt_parsed.netloc == orig_parsed.netloc:
                         continue
-                    try:
-                        alt_chunks, alt_pages = await asyncio.wait_for(
+                    alt_urls.append(alt_url)
+                    tasks.append(
+                        asyncio.wait_for(
                             _fetch_and_chunk_docs(alt_url, "", query),
                             timeout=_FALLBACK_TIMEOUT,
                         )
-                    except TimeoutError:
-                        continue
-                    if alt_pages > page_count and len(alt_chunks) > len(all_chunks):
-                        docs_url = alt_url
-                        all_chunks = alt_chunks
-                        page_count = alt_pages
-                        break
+                    )
+
+                if tasks:
+                    results = await asyncio.gather(*tasks, return_exceptions=True)
+                    for i, res in enumerate(results):
+                        if isinstance(res, BaseException):
+                            continue
+                        alt_chunks, alt_pages = res
+                        if alt_pages > page_count and len(alt_chunks) > len(all_chunks):
+                            docs_url = alt_urls[i]
+                            all_chunks = alt_chunks
+                            page_count = alt_pages
+                            break
             except Exception as e:
                 logger.debug(f"SearXNG fallback failed: {e}")
 
@@ -1881,21 +1904,10 @@ def research_topic(topic: str) -> str:
     )
 
 
-@mcp.prompt()
-def library_docs(library: str, question: str) -> str:
-    """Generate a prompt to find library documentation."""
-    return (
-        f"Find documentation for '{library}' to answer: {question}\n\n"
-        f"Use the search tool with action='docs', library='{library}', "
-        f"query='{question}'. If results are insufficient, use extract tool "
-        "to get more content from the documentation URLs."
-    )
-
-
 def main() -> None:
     """Entry point for the MCP server."""
     mcp.run()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/wet_mcp/setup.py
+++ b/src/wet_mcp/setup.py
@@ -145,13 +145,9 @@ def _install_searxng() -> bool:
     Returns:
         True if installation succeeded or already installed.
     """
-    try:
-        import searx  # noqa: F401
-
+    if _find_searx_package_dir():
         logger.debug("SearXNG already installed")
         return True
-    except ImportError:
-        pass
 
     logger.info("Installing SearXNG from GitHub...")
     try:
@@ -295,10 +291,3 @@ def run_auto_setup() -> bool:
         logger.info("Auto-setup complete!")
 
     return success
-
-
-def reset_setup() -> None:
-    """Reset setup marker to force re-run on next start."""
-    if SETUP_MARKER.exists():
-        SETUP_MARKER.unlink()
-        logger.info("Setup marker removed, will re-run on next start")

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -3209,16 +3209,23 @@ async def _try_sitemap(base_url: str, max_urls: int = 50) -> list[str]:
                 if "<sitemapindex" in text:
                     sub_urls = re.findall(r"<loc>\s*(.*?)\s*</loc>", text)
                     all_page_urls: list[str] = []
-                    for sub_url in sub_urls[:5]:
+
+                    async def _fetch_sub(sub_url: str) -> list[str]:
                         try:
                             sub_resp = await client.get(sub_url)
                             if sub_resp.status_code == 200:
-                                sub_locs = re.findall(
+                                return re.findall(
                                     r"<loc>\s*(.*?)\s*</loc>", sub_resp.text
                                 )
-                                all_page_urls.extend(sub_locs)
                         except Exception:
-                            continue
+                            pass
+                        return []
+
+                    sub_results = await asyncio.gather(
+                        *[_fetch_sub(u) for u in sub_urls[:5]]
+                    )
+                    for sub_locs in sub_results:
+                        all_page_urls.extend(sub_locs)
                     urls = all_page_urls
                 else:
                     urls = re.findall(r"<loc>\s*(.*?)\s*</loc>", text)

--- a/src/wet_mcp/token_store.py
+++ b/src/wet_mcp/token_store.py
@@ -62,7 +62,7 @@ def save_token(provider: str, token: dict) -> None:
     token_dir.mkdir(parents=True, exist_ok=True)
 
     # Secure directory permissions (Unix only)
-    if os.name != "nt":
+    if os.name != "nt":  # pragma: no cover
         try:
             token_dir.chmod(stat.S_IRWXU)  # 0700
         except OSError:
@@ -72,20 +72,10 @@ def save_token(provider: str, token: dict) -> None:
     path.write_text(json.dumps(token, indent=2), encoding="utf-8")
 
     # Secure file permissions (Unix only)
-    if os.name != "nt":
+    if os.name != "nt":  # pragma: no cover
         try:
             path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
         except OSError:
             pass
 
     logger.info(f"Token saved: {path}")
-
-
-def delete_token(provider: str) -> bool:
-    """Delete a stored token. Returns True if deleted."""
-    path = get_token_path(provider)
-    if path.exists():
-        path.unlink()
-        logger.info(f"Token deleted: {path}")
-        return True
-    return False

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -2634,17 +2634,6 @@ class TestSetup:
         assert setup.needs_setup() is True
         setup.SETUP_MARKER = old
 
-    def test_reset_setup(self, tmp_path):
-        """reset_setup removes marker."""
-        from wet_mcp import setup
-
-        old = setup.SETUP_MARKER
-        setup.SETUP_MARKER = tmp_path / ".setup-complete"
-        setup.SETUP_MARKER.touch()
-        setup.reset_setup()
-        assert not setup.SETUP_MARKER.exists()
-        setup.SETUP_MARKER = old
-
     def test_find_searx_package_dir_found(self):
         """Returns path when searx found."""
         from wet_mcp.setup import _find_searx_package_dir
@@ -2704,3 +2693,27 @@ class TestSetup:
 
         with patch("wet_mcp.setup._find_searx_package_dir", return_value=None):
             patch_searxng_version()  # Should not raise
+
+
+class TestRandomizedPortFinder:
+    """Tests for the randomized port finder in searxng_runner."""
+
+    def test_finds_available_port(self):
+        """Should find an available port in range."""
+        from wet_mcp.searxng_runner import _find_available_port
+
+        port = _find_available_port(40000, max_tries=100)
+        assert 40000 <= port < 40100
+
+    def test_raises_when_no_port_available(self):
+        """Raises RuntimeError when all ports are occupied."""
+        from wet_mcp.searxng_runner import _find_available_port
+
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+            mock_sock.__exit__ = MagicMock(return_value=False)
+            mock_sock.bind.side_effect = OSError("Address in use")
+            mock_socket.return_value = mock_sock
+            with pytest.raises(RuntimeError, match="No available port"):
+                _find_available_port(40000, max_tries=3)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,7 @@
 """Tests for src/wet_mcp/cache.py — WebCache with TTL-based expiry.
 
 Covers cache hit/miss, TTL expiry, hit counting, purge mechanics,
-deterministic cache keys, get_extract cross-action lookup, and stats.
+deterministic cache keys and stats.
 """
 
 import time
@@ -185,42 +185,6 @@ class TestPurge:
         # Even without time mock, the entry should be gone from DB
         stats = short_ttl_cache.stats()
         assert stats.get("search", {}).get("total", 0) == 0
-
-
-# -----------------------------------------------------------------------
-# get_extract cross-action lookup
-# -----------------------------------------------------------------------
-
-
-class TestGetExtract:
-    def test_get_extract_from_extract_cache(self, cache):
-        """get_extract finds URL in extract cache."""
-        cache.set(
-            "extract",
-            {
-                "urls": ["https://example.com/docs"],
-                "format": "markdown",
-                "stealth": True,
-            },
-            '[{"url": "https://example.com/docs", "content": "doc content"}]',
-        )
-        result = cache.get_extract("https://example.com/docs")
-        assert result is not None
-        assert "doc content" in result
-
-    def test_get_extract_from_crawl_cache(self, cache):
-        """get_extract also searches crawl cache."""
-        cache.set(
-            "crawl",
-            {"urls": ["https://example.com"], "depth": 2, "max_pages": 20},
-            '[{"url": "https://example.com", "content": "crawled"}]',
-        )
-        result = cache.get_extract("https://example.com")
-        assert result is not None
-
-    def test_get_extract_miss(self, cache):
-        """get_extract returns None when URL not in any cache."""
-        assert cache.get_extract("https://nowhere.com") is None
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -142,25 +142,6 @@ class TestLibraryCRUD:
     def test_get_nonexistent_library(self, db):
         assert db.get_library("nonexistent") is None
 
-    def test_list_libraries_empty(self, db):
-        assert db.list_libraries() == []
-
-    def test_list_libraries_with_data(self, db_with_data):
-        db = db_with_data[0]
-        libs = db.list_libraries()
-        assert len(libs) == 1
-        assert libs[0]["name"] == "fastapi"
-        assert libs[0]["total_chunks"] == 4
-
-    def test_remove_library(self, db_with_data):
-        db = db_with_data[0]
-        assert db.remove_library("fastapi") is True
-        assert db.get_library("fastapi") is None
-        assert db.list_libraries() == []
-
-    def test_remove_nonexistent(self, db):
-        assert db.remove_library("ghost") is False
-
     def test_library_name_normalization(self, db):
         """Names are lowercased and stripped."""
         db.upsert_library(name="  PyTorch  ")
@@ -640,25 +621,6 @@ class TestEdgeCases:
         assert all(r["library"] == "lib-a" for r in results_a)
         assert all(r["library"] == "lib-b" for r in results_b)
 
-    def test_remove_library_cascades(self, db):
-        """Removing a library deletes all versions and chunks."""
-        lib_id = db.upsert_library(name="cascade")
-        ver_id = db.upsert_version(lib_id)
-        db.add_chunks(
-            ver_id,
-            lib_id,
-            [
-                {"content": "cascade test chunk"},
-            ],
-        )
-        db.mark_version_indexed(ver_id, 1, 1)
-
-        db.remove_library("cascade")
-
-        # Chunks should be gone
-        results = db.search(query="cascade", library_name="cascade")
-        assert results == []
-
 
 # -----------------------------------------------------------------------
 # sqlite-vec extension loading and vector table creation (lines 141-151, 266-271)
@@ -783,60 +745,6 @@ class TestUpsertLibraryPaths:
         assert lib["docs_url"] == "https://new.dev"
         assert lib["registry"] == "crates"
         assert lib["description"] == "A Rust library"
-
-
-# -----------------------------------------------------------------------
-# remove_library() bulk vector deletion (lines 396-403)
-# -----------------------------------------------------------------------
-
-
-class TestRemoveLibraryVec:
-    def test_remove_library_with_vec_enabled(self, tmp_path):
-        """remove_library deletes vector entries when vec is enabled."""
-        db = DocsDB(tmp_path / "rm_vec.db", embedding_dims=4)
-        try:
-            lib_id = db.upsert_library(name="veclib")
-            ver_id = db.upsert_version(lib_id)
-            embeddings = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
-            db.add_chunks(
-                ver_id,
-                lib_id,
-                [{"content": "vec chunk 1"}, {"content": "vec chunk 2"}],
-                embeddings=embeddings,
-            )
-            # Verify vec entries exist
-            vec_count = db._conn.execute(
-                "SELECT COUNT(*) FROM doc_chunks_vec"
-            ).fetchone()[0]
-            assert vec_count == 2
-
-            db.remove_library("veclib")
-
-            # Vec entries should be gone
-            vec_count = db._conn.execute(
-                "SELECT COUNT(*) FROM doc_chunks_vec"
-            ).fetchone()[0]
-            assert vec_count == 0
-        finally:
-            db.close()
-
-    def test_remove_library_vec_error_handled(self, tmp_path):
-        """remove_library handles vec deletion errors gracefully."""
-        db = DocsDB(tmp_path / "rm_vec_err.db", embedding_dims=4)
-        try:
-            lib_id = db.upsert_library(name="veclib2")
-            ver_id = db.upsert_version(lib_id)
-            db.add_chunks(ver_id, lib_id, [{"content": "test chunk"}])
-
-            # Simulate vec table error by dropping it
-            db._conn.execute("DROP TABLE doc_chunks_vec")
-            db._conn.commit()
-
-            # Should not raise
-            result = db.remove_library("veclib2")
-            assert result is True
-        finally:
-            db.close()
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -273,30 +273,6 @@ class TestUpsertVersionUpdate:
 
 
 # ---------------------------------------------------------------------------
-# remove_library with vec enabled (lines 396-403)
-# ---------------------------------------------------------------------------
-
-
-class TestRemoveLibraryVec:
-    def test_remove_library_vec_path(self, tmp_path):
-        """remove_library deletes vec entries when vec is enabled (lines 396-403)."""
-        # Simulate vec-enabled DB by monkey-patching
-        d = DocsDB(tmp_path / "rvec.db", embedding_dims=0)
-        lib_id = d.upsert_library(name="veclib")
-        ver_id = d.upsert_version(lib_id)
-        d.add_chunks(ver_id, lib_id, [{"content": "test chunk"}])
-
-        # Force vec_enabled to trigger the DELETE path
-        d._vec_enabled = True
-        # The DELETE will fail silently because doc_chunks_vec table doesn't exist
-        # but the code path is exercised (lines 396-403)
-        result = d.remove_library("veclib")
-        assert result is True
-        assert d.get_library("veclib") is None
-        d.close()
-
-
-# ---------------------------------------------------------------------------
 # clear_version_chunks with vec (lines 550-557)
 # ---------------------------------------------------------------------------
 
@@ -608,20 +584,11 @@ class TestCombineScoresRRF:
 
 
 # ---------------------------------------------------------------------------
-# list_libraries and stats
+# stats
 # ---------------------------------------------------------------------------
 
 
-class TestListLibrariesAndStats:
-    def test_list_libraries(self, populated_db):
-        """list_libraries returns all libs with chunk counts."""
-        db, _, _ = populated_db
-        libs = db.list_libraries()
-        assert len(libs) >= 1
-        lib = libs[0]
-        assert "total_chunks" in lib
-        assert "version_count" in lib
-
+class TestStats:
     def test_stats(self, populated_db):
         """stats returns correct counts."""
         db, _, _ = populated_db
@@ -650,14 +617,3 @@ class TestExportJsonlRoundtrip:
         assert "library" in types_found
         assert "version" in types_found
         assert "chunk" in types_found
-
-
-# ---------------------------------------------------------------------------
-# remove_library for nonexistent
-# ---------------------------------------------------------------------------
-
-
-class TestRemoveNonexistent:
-    def test_remove_nonexistent_returns_false(self, db):
-        """remove_library returns False for unknown library."""
-        assert db.remove_library("no_such_lib") is False

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -219,13 +219,13 @@ def test_analyze_media_path_traversal(mock_settings, tmp_path):
     assert "download directory" in result
 
 
-def test_encode_image_valid(tmp_path):
+async def test_encode_image_valid(tmp_path):
     """Test encode_image with a valid image file."""
     from wet_mcp.llm import encode_image
 
     img_path = tmp_path / "test.png"
     img_path.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00")
-    result = encode_image(str(img_path))
+    result = await encode_image(str(img_path))
     # base64 of above bytes
     import base64
 
@@ -233,38 +233,38 @@ def test_encode_image_valid(tmp_path):
     assert result == expected
 
 
-def test_encode_image_not_found(tmp_path):
+async def test_encode_image_not_found(tmp_path):
     """Test encode_image with a non-existent file raises FileNotFoundError."""
     from wet_mcp.llm import encode_image
 
     with pytest.raises(FileNotFoundError):
-        encode_image(str(tmp_path / "nonexistent.png"))
+        await encode_image(str(tmp_path / "nonexistent.png"))
 
 
-def test_encode_image_empty(tmp_path):
+async def test_encode_image_empty(tmp_path):
     """Test encode_image with an empty file."""
     from wet_mcp.llm import encode_image
 
     img_path = tmp_path / "empty.png"
     img_path.write_bytes(b"")
-    result = encode_image(str(img_path))
+    result = await encode_image(str(img_path))
     assert result == ""
 
 
-def test_read_and_truncate(tmp_path):
+async def test_read_and_truncate(tmp_path):
     """Test _read_and_truncate reads and truncates properly."""
     from wet_mcp.llm import _read_and_truncate
 
     # Test small file
     txt_path = tmp_path / "small.txt"
     txt_path.write_text("hello", encoding="utf-8")
-    assert _read_and_truncate(str(txt_path)) == "hello"
+    assert await _read_and_truncate(str(txt_path)) == "hello"
 
     # Test large file
     txt_path = tmp_path / "large.txt"
     large_content = "a" * 100005
     txt_path.write_text(large_content, encoding="utf-8")
-    result = _read_and_truncate(str(txt_path))
+    result = await _read_and_truncate(str(txt_path))
     assert len(result) == 100000 + len("\n...[truncated]")
     assert result.endswith("\n...[truncated]")
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -315,3 +315,18 @@ def test_safe_local_path_symlink_escape(tmp_path):
     link = allowed / "link.txt"
     link.symlink_to(secret)
     assert is_safe_local_path(str(link), allowed_dirs=[allowed]) is None
+
+
+def test_safe_local_path_dotdot_traversal(tmp_path):
+    """Paths containing '..' components are blocked before resolution."""
+    f = tmp_path / "test.txt"
+    f.write_text("hello")
+    evil_path = str(tmp_path / "sub" / ".." / "test.txt")
+    assert is_safe_local_path(evil_path) is None
+
+
+def test_safe_local_path_oversized_file(tmp_path):
+    """Returns None when file exceeds max_size."""
+    f = tmp_path / "big.txt"
+    f.write_text("x" * 200)
+    assert is_safe_local_path(str(f), max_size=100) is None

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -546,15 +546,6 @@ async def test_with_timeout_expired():
 
 def test_prompts():
     assert "Research" in server.research_topic("topic")
-    assert "Find documentation" in server.library_docs("lib", "question")
-
-
-def test_library_docs_prompt():
-    """Test library_docs prompt formatting."""
-    result = server.library_docs("react", "how to use hooks")
-    assert "Find documentation for 'react' to answer: how to use hooks" in result
-    assert "library='react'" in result
-    assert "query='how to use hooks'" in result
 
 
 def test_research_topic_prompt():

--- a/tests/test_setup_comprehensive.py
+++ b/tests/test_setup_comprehensive.py
@@ -10,7 +10,6 @@ from wet_mcp.setup import (
     needs_setup,
     patch_searxng_version,
     patch_searxng_windows,
-    reset_setup,
     run_auto_setup,
 )
 
@@ -235,19 +234,19 @@ def test_get_pip_command_sys_executable(mock_which):
 # Test _install_searxng
 
 
-@patch.dict("sys.modules", {"searx": MagicMock()})
-def test_install_searxng_already_installed():
-    # If import searx succeeds, should return True immediately
+@patch("wet_mcp.setup._find_searx_package_dir", return_value=Path("/mock/searx"))
+def test_install_searxng_already_installed(_mock_find):
+    # If _find_searx_package_dir returns a path, should return True immediately
     assert _install_searxng() is True
 
 
-@patch.dict("sys.modules", {"searx": None})
+@patch("wet_mcp.setup._find_searx_package_dir", return_value=None)
 @patch("wet_mcp.setup._get_pip_command", return_value=["pip", "install"])
 @patch("subprocess.run")
 @patch("wet_mcp.setup.patch_searxng_version")
 @patch("wet_mcp.setup.patch_searxng_windows")
 def test_install_searxng_success(
-    mock_patch_win, mock_patch_ver, mock_run, mock_get_pip
+    mock_patch_win, mock_patch_ver, mock_run, mock_get_pip, _mock_find
 ):
     # Simulate both subprocesses returning 0
     mock_run.return_value = MagicMock(returncode=0)
@@ -258,20 +257,20 @@ def test_install_searxng_success(
     mock_patch_win.assert_called_once()
 
 
-@patch.dict("sys.modules", {"searx": None})
+@patch("wet_mcp.setup._find_searx_package_dir", return_value=None)
 @patch("wet_mcp.setup._get_pip_command", return_value=["pip", "install"])
 @patch("subprocess.run")
-def test_install_searxng_deps_fail(mock_run, mock_get_pip):
+def test_install_searxng_deps_fail(mock_run, mock_get_pip, _mock_find):
     mock_run.return_value = MagicMock(returncode=1, stderr="deps failed")
 
     assert _install_searxng() is False
     assert mock_run.call_count == 1
 
 
-@patch.dict("sys.modules", {"searx": None})
+@patch("wet_mcp.setup._find_searx_package_dir", return_value=None)
 @patch("wet_mcp.setup._get_pip_command", return_value=["pip", "install"])
 @patch("subprocess.run")
-def test_install_searxng_main_fail(mock_run, mock_get_pip):
+def test_install_searxng_main_fail(mock_run, mock_get_pip, _mock_find):
     # First call (deps) succeeds, second call (main) fails
     mock_run.side_effect = [
         MagicMock(returncode=0),
@@ -282,16 +281,16 @@ def test_install_searxng_main_fail(mock_run, mock_get_pip):
     assert mock_run.call_count == 2
 
 
-@patch.dict("sys.modules", {"searx": None})
+@patch("wet_mcp.setup._find_searx_package_dir", return_value=None)
 @patch("wet_mcp.setup._get_pip_command", return_value=["pip", "install"])
 @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="pip", timeout=120))
-def test_install_searxng_timeout(mock_run, mock_get_pip):
+def test_install_searxng_timeout(mock_run, mock_get_pip, _mock_find):
     assert _install_searxng() is False
 
 
-@patch.dict("sys.modules", {"searx": None})
+@patch("wet_mcp.setup._find_searx_package_dir", return_value=None)
 @patch("wet_mcp.setup._get_pip_command", side_effect=Exception("Test error"))
-def test_install_searxng_exception(mock_get_pip):
+def test_install_searxng_exception(mock_get_pip, _mock_find):
     assert _install_searxng() is False
 
 
@@ -355,20 +354,3 @@ def test_run_auto_setup_crawl4ai_fail(
 ):
     assert run_auto_setup() is False
     mock_marker.touch.assert_not_called()
-
-
-# Test reset_setup
-
-
-@patch("wet_mcp.setup.SETUP_MARKER")
-def test_reset_setup_exists(mock_marker):
-    mock_marker.exists.return_value = True
-    reset_setup()
-    mock_marker.unlink.assert_called_once()
-
-
-@patch("wet_mcp.setup.SETUP_MARKER")
-def test_reset_setup_not_exists(mock_marker):
-    mock_marker.exists.return_value = False
-    reset_setup()
-    mock_marker.unlink.assert_not_called()

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 import pytest
 
 from wet_mcp.token_store import (
-    delete_token,
     get_token_path,
     load_token,
     save_token,
@@ -72,20 +71,6 @@ def test_load_oserror(token_dir):
         mock_settings.get_data_dir.return_value = token_dir.parent
         with patch.object(Path, "exists", side_effect=OSError("disk error")):
             assert load_token("drive") is None
-
-
-def test_delete_existing(token_dir):
-    with patch("wet_mcp.token_store.settings") as mock_settings:
-        mock_settings.get_data_dir.return_value = token_dir.parent
-        save_token("drive", {"access_token": "test"})
-        assert delete_token("drive") is True
-        assert not get_token_path("drive").exists()
-
-
-def test_delete_nonexistent(token_dir):
-    with patch("wet_mcp.token_store.settings") as mock_settings:
-        mock_settings.get_data_dir.return_value = token_dir.parent
-        assert delete_token("drive") is False
 
 
 def test_save_token_creates_dir(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1387,16 +1387,16 @@ cli = [
 
 [[package]]
 name = "mcp-relay-core"
-version = "1.1.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/ce/3560665d55accbc6c02c70156bf8cf140da2ce402acdb0d23d79650bf84e/mcp_relay_core-1.1.0.tar.gz", hash = "sha256:e1f9e7c22ccf1e1bbb631c3d685341899a7269f2c8cab1115815e024761b9982", size = 61250, upload-time = "2026-03-28T12:18:38.025Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/8b/809647e6b3d9ae65ced9dedccf9ffb70c6d0be379b9996143e740e31cf8d/mcp_relay_core-1.3.0.tar.gz", hash = "sha256:90a10119711ee878023a8e64f87b22348619a76963630cb05341af2bd1508014", size = 61721, upload-time = "2026-04-03T08:31:05.909Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/d4/1cb487b43940467cc1028f645329dc440f01539ed069bce740a9d09f44a5/mcp_relay_core-1.1.0-py3-none-any.whl", hash = "sha256:4030111cabb04ce65463bc1a16acd73cc04263b6196fae1e97b7d057944e4744", size = 41300, upload-time = "2026-03-28T12:18:39.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/91/61525f30ef3fdc5db1e15754182997eb33d51674b187fb56d7bd5c70afe8/mcp_relay_core-1.3.0-py3-none-any.whl", hash = "sha256:6c8ea16152b1021a02457445cb9f2910ca0b4837f923d9c50df07070cbc199d1", size = 41302, upload-time = "2026-04-03T08:31:04.611Z" },
 ]
 
 [[package]]
@@ -2237,7 +2237,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.5.1"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2248,9 +2248,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/7d/879642e9655500799b6ed78c5815fcfd3a5795d79c0ed24251639b7df35b/qwen3_embed-1.5.1.tar.gz", hash = "sha256:77239cd9848f2e2c4b7c71fef7272d662c200dc01ed785e51903f1d9275f3613", size = 176046, upload-time = "2026-03-20T11:45:51.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/7b/95d2bc68ab50c89899d6d525b5cdbea6efddbdb8d27870c03c30b98e4124/qwen3_embed-1.7.0.tar.gz", hash = "sha256:f805a1a6c72f3e4b790b910086a4f8c3bfd6693870dd7f79a68c3fd315bfe625", size = 180327, upload-time = "2026-04-03T08:07:24.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/a9/164090150d35a1db9dfd9784f19b377564578be325de3d195da5ed6dfa5a/qwen3_embed-1.5.1-py3-none-any.whl", hash = "sha256:778cacbfe2a6c37dc8ee76b059dd1494f62f71f317543d1ce07494017e1e7afe", size = 55232, upload-time = "2026-03-20T11:45:52.793Z" },
+    { url = "https://files.pythonhosted.org/packages/54/48/bba811776f53a5ef4c26d8fd55d3f8e2c8b6b54a97949593b16af2c891ed/qwen3_embed-1.7.0-py3-none-any.whl", hash = "sha256:23f4a95e61b85409dfdd03018dc1f945a814a42a230be3c9a935dd54fbc39de2", size = 56221, upload-time = "2026-04-03T08:07:23.409Z" },
 ]
 
 [[package]]
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.19.0"
+version = "2.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -2942,13 +2942,13 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "mcp-relay-core", specifier = ">=1.0.5" },
-    { name = "n24q02m-web-core", specifier = ">=1.0.0" },
+    { name = "mcp-relay-core", specifier = ">=1.2.0" },
+    { name = "n24q02m-web-core", specifier = ">=1.0.1" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "qwen3-embed", specifier = ">=1.5.1" },
+    { name = "qwen3-embed", specifier = ">=1.6.0" },
     { name = "sqlite-vec" },
     { name = "waitress", marker = "sys_platform == 'win32'", specifier = ">=3.0.0" },
 ]


### PR DESCRIPTION
## Summary

Reviewed all 48 open Jules PRs. Accepted 16, rejected 32 (API-breaking refactors, mock-heavy tests, false-positive SQL injection, used-function removals).

### Accepted PRs (16)

**Performance (7):**
- #657: Eliminate redundant `json.loads`/`json.dumps` in search post-processing
- #644: Make `encode_image`/`_read_and_truncate` async with `asyncio.to_thread`
- #617: Parallelize N+1 fallback docs extraction with `asyncio.gather`
- #638: Parallelize N+1 sitemap sub-fetches with `asyncio.gather`
- #613: Increase SQLite IN clause batch size (32K+ for modern SQLite)
- #611: Add SQLite PRAGMA optimizations (mmap 256MB, temp_store MEMORY, cache 64MB)
- #614: Replace `import searx` with `_find_searx_package_dir()` check

**Cleanup -- unused code removal (6):**
- #618: Remove `library_docs` prompt (0 callers)
- #622: Remove `reset_setup` (0 callers)
- #619: Remove `delete_token` (0 callers)
- #615: Remove `get_extract` (0 callers)
- #629: Remove `list_libraries` (0 callers)
- #636: Remove `remove_library` (0 callers)

**Infrastructure (3):**
- #639: Randomize SearXNG port scan to avoid TOCTOU race
- #656: Update docker/login-action digest
- #609: Update CodeQL action to v4

### Rejected PRs (32)

- #650, #641, #630, #626: SQL injection -- false positive (already parameterized, hardcoded column names)
- #655, #653: API-breaking refactors (extract/media param grouping)
- #633, #632: Cosmetic refactors
- #625: Remove `research_topic` -- it IS a `@mcp.prompt()`, not unused
- #634: Remove `trigger_relay_setup` -- it IS used in server.py
- #654, #652, #651, #649, #648, #647, #646, #645, #643, #642, #640, #637, #635, #631, #628, #627, #624, #623, #621, #620, #616: Test PRs -- mock-heavy, test trivial paths, or modify source code to be testable

### Dependencies (closes #668, #667, #666)

- `mcp-relay-core` >= 1.2.0
- `n24q02m-web-core` >= 1.0.1
- `qwen3-embed` >= 1.6.0

### Docs

- Removed stale `library_docs` prompt from README
- Added `setup_relay` action to setup tool documentation

## Test plan

- [x] All 1390 tests pass (`uv run pytest --tb=short -q`)
- [x] Ruff lint + format clean
- [x] ty type check passes
- [x] Pre-commit hooks pass (gitleaks, ruff, ty, pytest, commit msg)
- [ ] CI pipeline (lint, test, coverage, CodeQL v4)

Closes #668 #667 #666

Generated with [Claude Code](https://claude.com/claude-code)