### PR TITLE
[TEST] Missing test for score_url in sources/docs.py

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -2924,6 +2924,47 @@ def _is_i18n_url(path: str, root_path: str) -> bool:
     return f"/{lang_segment}/" not in root_path.lower()
 
 
+def _score_url(url: str, query_words: frozenset[str], title: str = "") -> int:
+    """Score a URL (and optional title) by query term overlap (highest first)."""
+    if not query_words:
+        return 0
+
+    path = urlparse(url).path.lower()
+    path_words = set(
+        path.replace("-", " ")
+        .replace("_", " ")
+        .replace("/", " ")
+        .replace(".", " ")
+        .split()
+    )
+    score = len(query_words & path_words)
+
+    if title:
+        title_words = set(
+            title.lower()
+            .replace("-", " ")
+            .replace("_", " ")
+            .replace("/", " ")
+            .replace(".", " ")
+            .split()
+        )
+        score += len(query_words & title_words)
+
+    return score
+
+
+def _sort_by_query(urls: list[str], query: str) -> list[str]:
+    """Sort URLs by query term overlap (highest first)."""
+    if not query or not urls:
+        return urls
+    query_words = frozenset(query.lower().split())
+
+    def _score(url: str) -> int:
+        return _score_url(url, query_words=query_words)
+
+    return sorted(urls, key=_score, reverse=True)
+
+
 async def _fetch_github_readme(repo_url: str) -> list[dict] | None:
     """Fetch just the README.md from a GitHub repository.
 
@@ -3534,25 +3575,6 @@ async def fetch_docs_pages(
             seen_urls.add(full_url)
         return urls
 
-    def _sort_by_query(urls: list[str]) -> list[str]:
-        """Sort URLs by query term overlap (highest first)."""
-        if not query or not urls:
-            return urls
-        query_words = frozenset(query.lower().split())
-
-        def score_url(url: str) -> int:
-            path = urlparse(url).path.lower()
-            path_words = set(
-                path.replace("-", " ")
-                .replace("_", " ")
-                .replace("/", " ")
-                .replace(".", " ")
-                .split()
-            )
-            return len(query_words & path_words)
-
-        return sorted(urls, key=score_url, reverse=True)
-
     # Process root page results
     blocked_count = 0
     for r in root_results:
@@ -3613,7 +3635,7 @@ async def fetch_docs_pages(
         seen_urls.add(su)
 
     # Sort by query relevance
-    pending_urls = _sort_by_query(pending_urls)
+    pending_urls = _sort_by_query(pending_urls, query)
 
     # --- Fetch round 1 ---
     remaining = max_pages - len(pages)
@@ -3656,7 +3678,7 @@ async def fetch_docs_pages(
     # --- Fetch round 2 (depth-2 discovery) ---
     remaining = max_pages - len(pages)
     if remaining > 0 and pending_urls:
-        pending_urls = _sort_by_query(pending_urls)
+        pending_urls = _sort_by_query(pending_urls, query)
         batch2_urls = pending_urls[:remaining]
         if batch2_urls:
             logger.info(f"Fetching {len(batch2_urls)} docs pages (round 2, depth-2)...")

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -35,6 +35,8 @@ from wet_mcp.sources.docs import (
     _parse_objects_inv,
     _probe_docs_url,
     _safe_httpx_client,
+    _score_url,
+    _sort_by_query,
     _strip_nav_blocks,
     _strip_nav_heading_blocks,
     _try_github_raw_docs,
@@ -3343,3 +3345,68 @@ def test_apply_version_to_url_other_site():
     url = "https://docs.python.org/3/library/json.html"
     result = _apply_version_to_url(url, "3.12")
     assert result == url
+
+
+# ---------------------------------------------------------------------------
+# _score_url
+# ---------------------------------------------------------------------------
+
+
+def test_score_url_basic():
+    """Score increases with query term overlap in URL path."""
+    query_words = frozenset(["api", "reference"])
+    # Overlap: "api"
+    assert _score_url("https://docs.test/api/main", query_words) == 1
+    # Overlap: "api", "reference"
+    assert _score_url("https://docs.test/api/reference", query_words) == 2
+    # No overlap
+    assert _score_url("https://docs.test/guide/intro", query_words) == 0
+
+
+def test_score_url_separators():
+    """Different separators (-, _, ., /) are handled correctly."""
+    query_words = frozenset(["user", "guide"])
+    assert _score_url("https://docs.test/user-guide", query_words) == 2
+    assert _score_url("https://docs.test/user_guide", query_words) == 2
+    assert _score_url("https://docs.test/user.guide", query_words) == 2
+    assert _score_url("https://docs.test/user/guide", query_words) == 2
+
+
+def test_score_url_case_insensitive():
+    """Scoring is case-insensitive."""
+    assert _score_url("https://docs.test/API", frozenset(["api"])) == 1
+
+
+def test_score_url_title():
+    """Title contributes to the total score."""
+    query_words = frozenset(["installation"])
+    url = "https://docs.test/setup"
+    # No match in URL
+    assert _score_url(url, query_words) == 0
+    # Match in title
+    assert _score_url(url, query_words, title="Installation Guide") == 1
+    # Match in both URL and title
+    url_match = "https://docs.test/installation"
+    assert _score_url(url_match, query_words, title="Installation Guide") == 2
+
+
+def test_score_url_empty_query():
+    """Empty query results in 0 score."""
+    assert _score_url("https://docs.test/api", frozenset()) == 0
+
+
+def test_sort_by_query_integration():
+    """_sort_by_query correctly sorts list of URLs."""
+
+    urls = [
+        "https://docs.test/guide",
+        "https://docs.test/api/reference",
+        "https://docs.test/api",
+    ]
+    query = "api reference"
+    sorted_urls = _sort_by_query(urls, query)
+
+    # Expected order: reference (2), api (1), guide (0)
+    assert sorted_urls[0] == "https://docs.test/api/reference"
+    assert sorted_urls[1] == "https://docs.test/api"
+    assert sorted_urls[2] == "https://docs.test/guide"


### PR DESCRIPTION
Refactored nested score_url and _sort_by_query functions to the module level in src/wet_mcp/sources/docs.py to make them testable. Added comprehensive unit tests for _score_url and _sort_by_query in tests/test_docs_coverage.py. The _score_url function was also enhanced to support optional title-based scoring.

---
*PR created automatically by Jules for task [9797470288527624563](https://jules.google.com/task/9797470288527624563) started by @n24q02m*