### PR TITLE
fix: remove dead code (research_topic, trigger_relay_setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ mcp-name: io.github.n24q02m/wet-mcp
 | `setup` | `warmup`, `setup_sync`, `setup_relay` | Pre-download models, configure cloud sync, relay setup |
 | `help` | -- | Full documentation for any tool |
 
-### MCP Prompts
-
-| Prompt | Parameters | Description |
-|:-------|:-----------|:------------|
-| `research_topic` | `topic` | Research a topic using academic search |
-
 ## Security
 
 - **SSRF prevention** -- URL validation on crawl targets

--- a/src/wet_mcp/relay_setup.py
+++ b/src/wet_mcp/relay_setup.py
@@ -50,28 +50,34 @@ def apply_config(config: dict[str, str]) -> None:
             logger.debug("Applied relay config: {}", key)
 
 
-async def ensure_config() -> dict[str, str] | None:
+async def ensure_config(
+    *, force: bool = False, timeout: float | None = RELAY_TIMEOUT_S
+) -> dict[str, str] | None:
     """Resolve config: env vars -> config file -> relay setup -> local fallback.
 
-    Relay is ONLY triggered when steps 1-2 are ALL empty.
-    Uses 120s timeout since wet-mcp works locally without credentials.
+    Args:
+        force: Skip env-var and config-file checks, go straight to relay.
+        timeout: Relay poll timeout in seconds. None = no timeout (manual setup).
+
+    Relay is ONLY triggered when steps 1-2 are ALL empty (unless ``force=True``).
 
     Returns:
         Config dict with API keys, or None if skipped/failed (local mode).
     """
-    # 1. Check if env vars already provide cloud keys (highest priority)
-    if any(os.environ.get(k) for k in CLOUD_KEYS):
-        logger.info("Cloud API keys found in environment, skipping relay")
-        return None  # env vars take priority, no relay needed
+    if not force:
+        # 1. Check if env vars already provide cloud keys (highest priority)
+        if any(os.environ.get(k) for k in CLOUD_KEYS):
+            logger.info("Cloud API keys found in environment, skipping relay")
+            return None  # env vars take priority, no relay needed
 
-    # 2. Check saved relay config file
-    config = load_config_from_file()
-    if config is not None:
-        apply_config(config)
-        return config
+        # 2. Check saved relay config file
+        config = load_config_from_file()
+        if config is not None:
+            apply_config(config)
+            return config
 
-    # 3. No local credentials found -- trigger relay setup
-    logger.info("No cloud credentials found. Starting relay setup...")
+    # 3. No local credentials found (or forced) -- trigger relay setup
+    logger.info("Starting relay setup...")
     try:
         from mcp_relay_core.relay.client import create_session, poll_for_result
 
@@ -80,15 +86,16 @@ async def ensure_config() -> dict[str, str] | None:
         relay_url = os.environ.get("MCP_RELAY_URL", DEFAULT_RELAY_URL)
         session = await create_session(relay_url, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
 
+        timeout_msg = f", {int(timeout)}s timeout" if timeout else ""
         print(
-            f"\nConfigure cloud providers (optional, 120s timeout):"
+            f"\nConfigure cloud providers (optional{timeout_msg}):"
             f"\n{session.relay_url}"
             f"\nSkip to use local mode (ONNX embedding + SearXNG).\n",
             file=sys.stderr,
             flush=True,
         )
 
-        config = await poll_for_result(relay_url, session, timeout_s=RELAY_TIMEOUT_S)
+        config = await poll_for_result(relay_url, session, timeout_s=timeout)  # ty: ignore[invalid-argument-type]
 
         # Save to config file for future use
         from mcp_relay_core.storage.config_file import write_config
@@ -156,55 +163,4 @@ async def ensure_config() -> dict[str, str] | None:
         return None
     except Exception as e:
         logger.debug("Relay setup unavailable: {}. Using local mode.", e)
-        return None
-
-
-async def trigger_relay_setup() -> dict[str, str] | None:
-    """Manually trigger relay setup (from MCP setup tool). No timeout limit."""
-    try:
-        from mcp_relay_core.relay.client import create_session, poll_for_result
-
-        from .relay_schema import RELAY_SCHEMA
-
-        relay_url = os.environ.get("MCP_RELAY_URL", DEFAULT_RELAY_URL)
-        session = await create_session(relay_url, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
-
-        session_url: str = session.relay_url
-        print(
-            f"\nSetup: Open this URL to configure:\n{session_url}\n",
-            file=sys.stderr,
-            flush=True,
-        )
-
-        config = await poll_for_result(relay_url, session)
-
-        from mcp_relay_core.storage.config_file import write_config
-
-        write_config(SERVER_NAME, config)
-
-        # Notify relay page that setup is complete
-        try:
-            import httpx
-
-            async with httpx.AsyncClient() as http:
-                await http.post(
-                    f"{relay_url}/api/sessions/{session.session_id}/messages",
-                    json={
-                        "type": "complete",
-                        "text": "wet-mcp config saved. Setup complete!",
-                    },
-                )
-        except Exception:
-            pass
-
-        return config
-
-    except RuntimeError as e:
-        if "RELAY_SKIPPED" in str(e):
-            logger.info("Relay setup skipped by user")
-            return None
-        logger.warning("Relay setup failed: {}", e)
-        return None
-    except Exception as e:
-        logger.warning("Relay setup failed: {}", e)
         return None

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1216,11 +1216,10 @@ async def setup(
             return json.dumps(result, indent=2, default=str)
 
         case "setup_relay":
-            from wet_mcp.relay_setup import apply_config, trigger_relay_setup
+            from wet_mcp.relay_setup import ensure_config
 
-            config = await trigger_relay_setup()
+            config = await ensure_config(force=True, timeout=None)
             if config:
-                apply_config(config)
                 settings.setup_providers()
                 return json.dumps({"status": "ok", "message": "Relay config applied."})
             return json.dumps(
@@ -1886,22 +1885,6 @@ async def _do_immediate_fallback_search(
     except Exception as e:
         logger.debug(f"Immediate fallback search failed: {e}")
     return fallback_data
-
-
-# ---------------------------------------------------------------------------
-# Prompts (aligned with mnemo-mcp pattern)
-# ---------------------------------------------------------------------------
-
-
-@mcp.prompt()
-def research_topic(topic: str) -> str:
-    """Generate a prompt to research a topic using academic search."""
-    return (
-        f"Research the following topic thoroughly: {topic}\n\n"
-        "1. Use the search tool with action='research' to find academic papers.\n"
-        "2. Use the extract tool with action='extract' on the most relevant URLs.\n"
-        "3. Synthesize findings into a comprehensive summary with citations."
-    )
 
 
 def main() -> None:

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -347,43 +347,43 @@ class TestLoadConfigFromFile:
             assert result is None
 
 
-class TestTriggerRelaySetup:
-    """Additional coverage for trigger_relay_setup."""
+class TestEnsureConfigForced:
+    """Coverage for ensure_config(force=True) -- manual relay setup."""
 
     async def test_relay_skipped_returns_none(self):
         """When user skips, returns None."""
-        from wet_mcp.relay_setup import trigger_relay_setup
+        from wet_mcp.relay_setup import ensure_config
 
         with patch(
             "mcp_relay_core.relay.client.create_session",
             new_callable=AsyncMock,
             side_effect=RuntimeError("RELAY_SKIPPED by user"),
         ):
-            result = await trigger_relay_setup()
+            result = await ensure_config(force=True, timeout=None)
             assert result is None
 
     async def test_generic_runtime_error(self):
         """Generic RuntimeError returns None."""
-        from wet_mcp.relay_setup import trigger_relay_setup
+        from wet_mcp.relay_setup import ensure_config
 
         with patch(
             "mcp_relay_core.relay.client.create_session",
             new_callable=AsyncMock,
             side_effect=RuntimeError("network error"),
         ):
-            result = await trigger_relay_setup()
+            result = await ensure_config(force=True, timeout=None)
             assert result is None
 
     async def test_generic_exception(self):
         """Generic Exception returns None."""
-        from wet_mcp.relay_setup import trigger_relay_setup
+        from wet_mcp.relay_setup import ensure_config
 
         with patch(
             "mcp_relay_core.relay.client.create_session",
             new_callable=AsyncMock,
             side_effect=Exception("unexpected"),
         ):
-            result = await trigger_relay_setup()
+            result = await ensure_config(force=True, timeout=None)
             assert result is None
 
 
@@ -1800,17 +1800,16 @@ class TestServerSetupTool:
             assert data["status"] == "ok"
 
     async def test_setup_relay(self):
-        """setup_relay action delegates to trigger_relay_setup."""
+        """setup_relay action delegates to ensure_config(force=True)."""
         from wet_mcp.server import setup
 
         mock_config = {"GEMINI_API_KEY": "AIza_test"}
         with (
             patch(
-                "wet_mcp.relay_setup.trigger_relay_setup",
+                "wet_mcp.relay_setup.ensure_config",
                 new_callable=AsyncMock,
                 return_value=mock_config,
             ),
-            patch("wet_mcp.relay_setup.apply_config"),
             patch("wet_mcp.server.settings") as mock_settings,
         ):
             mock_settings.setup_providers = MagicMock()
@@ -1823,7 +1822,7 @@ class TestServerSetupTool:
         from wet_mcp.server import setup
 
         with patch(
-            "wet_mcp.relay_setup.trigger_relay_setup",
+            "wet_mcp.relay_setup.ensure_config",
             new_callable=AsyncMock,
             return_value=None,
         ):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -381,7 +381,7 @@ class TestErrorHandling:
 async def test_relay_all_tools(request, tmp_path):
     """Relay mode: start server without API keys, trigger relay via setup tool.
 
-    wet-mcp relay is MANUAL (trigger_relay_setup), not auto like mnemo/telegram.
+    wet-mcp relay is MANUAL (ensure_config(force=True)), not auto like mnemo/telegram.
     Flow: initialize (local mode) -> call setup_relay -> browser opens -> user enters
     credentials -> poll config status -> run all tools with cloud credentials.
 

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -7,8 +7,8 @@ from wet_mcp.relay_schema import RELAY_SCHEMA
 from wet_mcp.relay_setup import (
     DEFAULT_RELAY_URL,
     apply_config,
+    ensure_config,
     load_config_from_file,
-    trigger_relay_setup,
 )
 
 
@@ -98,8 +98,8 @@ class TestApplyConfig:
         monkeypatch.delenv("TEST_RELAY_B")
 
 
-class TestTriggerRelaySetup:
-    """Tests for trigger_relay_setup."""
+class TestEnsureConfigForced:
+    """Tests for ensure_config(force=True) -- manual relay setup."""
 
     async def test_calls_create_session(self):
         mock_session = MagicMock(
@@ -122,11 +122,14 @@ class TestTriggerRelaySetup:
             patch(
                 "mcp_relay_core.storage.config_file.write_config",
             ),
+            patch("wet_mcp.relay_setup.apply_config"),
             patch("httpx.AsyncClient") as mock_httpx,
+            patch("wet_mcp.config.settings") as mock_settings,
         ):
-            mock_httpx.return_value.__aenter__ = AsyncMock()
+            mock_settings.google_drive_client_id = None
+            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
             mock_httpx.return_value.__aexit__ = AsyncMock()
-            result = await trigger_relay_setup()
+            result = await ensure_config(force=True, timeout=None)
             mock_create.assert_called_once_with(
                 DEFAULT_RELAY_URL, "wet-mcp", RELAY_SCHEMA
             )
@@ -139,5 +142,5 @@ class TestTriggerRelaySetup:
             new_callable=AsyncMock,
             side_effect=ConnectionError("unreachable"),
         ):
-            result = await trigger_relay_setup()
+            result = await ensure_config(force=True, timeout=None)
             assert result is None

--- a/tests/test_searxng_runner_comprehensive.py
+++ b/tests/test_searxng_runner_comprehensive.py
@@ -201,7 +201,7 @@ def test_find_available_port():
         # Success on first try
         mock_sock_instance.bind.return_value = None
         port = _find_available_port(8080)
-        assert 8080 <= port < 8080 + 50
+        assert 8080 <= port < 8080 + 100
 
         # Bind fails — web-core raises RuntimeError
         mock_sock_instance.bind.side_effect = OSError()

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -544,16 +544,6 @@ async def test_with_timeout_expired():
         assert "timed out" in res
 
 
-def test_prompts():
-    assert "Research" in server.research_topic("topic")
-
-
-def test_research_topic_prompt():
-    """Test research_topic prompt formatting."""
-    result = server.research_topic("quantum computing")
-    assert "Research the following topic thoroughly: quantum computing" in result
-
-
 def test_main():
     with patch("wet_mcp.server.mcp.run") as mock_run:
         server.main()

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.20.0"
+version = "2.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## Summary
- **Jules Round 2 review**: read diffs of all 39 open PRs (#671-#709), closed all with specific reject reasons
- Remove `research_topic` MCP prompt -- unused dead code, not called by any client
- Remove `trigger_relay_setup` -- refactor `ensure_config(force, timeout)` to handle both auto-startup and manual `setup_relay` use cases in a single function
- Fix `test_find_available_port` assertion range to match `max_tries=100` from PR #670

## PR rejection summary (39 PRs)
| Category | PRs | Reason |
|:---------|:----|:-------|
| Cleanup (already removed in #670) | #704, #693, #686, #685 | Functions no longer exist |
| Security SQL injection (false positives) | #698, #684, #683, #676 | Already parameterized queries |
| FIX (API-breaking refactors) | #703, #701 | Unnecessary parameter object wrappers |
| PERF (already fixed or invasive) | #706, #702, #695, #689 | Already done in #670 or monkey-patches web-core |
| Test PRs (low quality) | #705, #697, #692, #691, #690, #688, #687, #678, #677, #675, #674, #673, #672, #671 | Mock-heavy, fragmented files, spurious CI changes |
| Cleanup (valid but mixed) | #696, #680 | Valid ideas but mixed with unrelated changes -- implemented here cleanly |
| Renovate | #708, #707 | Handled separately |
| Misc (no-op / reverting) | #699, #682, #681, #679, #694, #709 | Trivial/no-op/reverting intentional removals |

## Test plan
- [x] All pre-commit hooks pass (ruff, ty, pytest, gitleaks)
- [x] 1387 tests pass, 34 skipped
- [x] `ensure_config()` default behavior unchanged (auto-startup)
- [x] `ensure_config(force=True, timeout=None)` replaces `trigger_relay_setup()`
- [x] `setup_relay` action in server.py updated to use new API

Generated with [Claude Code](https://claude.com/claude-code)