### PR TITLE
🛡️ Sentinel: [MEDIUM] Add allowlist validation for dynamic SQL updates

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -36,13 +36,15 @@ def _now_ts() -> float:
 # Patterns for chunk quality scoring
 _CODE_BLOCK_RE = re.compile(r"```")
 _LINK_LINE_RE = re.compile(r"^\s*[-*]?\s*\[.+?\]\(.+?\)\s*$|^\s*https?://\S+\s*$")
-_ALLOWED_UPDATES = frozenset({
-    "docs_url = ?",
-    "registry = ?",
-    "description = ?",
-    "discovery_version = ?",
-    "updated_at = ?"
-})
+_ALLOWED_UPDATES = frozenset(
+    {
+        "docs_url = ?",
+        "registry = ?",
+        "description = ?",
+        "discovery_version = ?",
+        "updated_at = ?",
+    }
+)
 
 # Function/class/type definitions (common across languages)
 _DEF_RE = re.compile(

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -36,6 +36,14 @@ def _now_ts() -> float:
 # Patterns for chunk quality scoring
 _CODE_BLOCK_RE = re.compile(r"```")
 _LINK_LINE_RE = re.compile(r"^\s*[-*]?\s*\[.+?\]\(.+?\)\s*$|^\s*https?://\S+\s*$")
+_ALLOWED_UPDATES = frozenset({
+    "docs_url = ?",
+    "registry = ?",
+    "description = ?",
+    "discovery_version = ?",
+    "updated_at = ?"
+})
+
 # Function/class/type definitions (common across languages)
 _DEF_RE = re.compile(
     r"^\s*(?:def |class |fn |func |function |interface |type |struct |enum |const |let |var |export )",
@@ -366,6 +374,9 @@ class DocsDB:
             params.append(now)
             params.append(lib_id)
             if updates:
+                for u in updates:
+                    if u not in _ALLOWED_UPDATES:
+                        raise ValueError(f"Invalid column update: {u}")
                 # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 self._conn.execute(
                     f"UPDATE libraries SET {', '.join(updates)} WHERE id = ?",

--- a/tests/test_security_db.py
+++ b/tests/test_security_db.py
@@ -1,9 +1,9 @@
-import sqlite3
 from unittest.mock import patch
 
 import pytest
 
 from wet_mcp.db import DocsDB
+
 
 def test_upsert_library_security_allowlist(tmp_path):
     """Test that upsert_library validates dynamic UPDATE column names against the allowlist."""

--- a/tests/test_security_db.py
+++ b/tests/test_security_db.py
@@ -15,9 +15,10 @@ def test_upsert_library_security_allowlist(tmp_path):
 
     # By mocking the _ALLOWED_UPDATES allowlist to be empty, any update
     # will simulate a non-permitted string being in the internal list accumulator.
-    with patch('wet_mcp.db._ALLOWED_UPDATES', frozenset()):
+    with patch("wet_mcp.db._ALLOWED_UPDATES", frozenset()):
         with pytest.raises(ValueError, match="Invalid column update"):
             db.upsert_library("testlib", docs_url="http://example.com")
+
 
 def test_upsert_library_allowlist_enforcement_with_mocked_accumulator(tmp_path):
     """Verify whitelist enforcement by using unittest.mock.patch to simulate non-permitted strings."""
@@ -28,7 +29,12 @@ def test_upsert_library_allowlist_enforcement_with_mocked_accumulator(tmp_path):
     # To strictly follow the instruction of inserting non-permitted strings into internal list accumulators:
     # We patch the allowlist to simulate what would happen if a malicious string made it into `updates`.
     # Alternatively, we can use patch on the allowed updates.
-    with patch('wet_mcp.db._ALLOWED_UPDATES', frozenset({"docs_url = ?", "registry = ?", "description = ?", "discovery_version = ?"})):
+    with patch(
+        "wet_mcp.db._ALLOWED_UPDATES",
+        frozenset(
+            {"docs_url = ?", "registry = ?", "description = ?", "discovery_version = ?"}
+        ),
+    ):
         # We omitted "updated_at = ?" from the mocked allowlist.
         # upsert_library always appends "updated_at = ?" to the updates list.
         # This will cause the validation to fail, simulating a non-permitted string in the accumulator.

--- a/tests/test_security_db.py
+++ b/tests/test_security_db.py
@@ -1,0 +1,36 @@
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from wet_mcp.db import DocsDB
+
+def test_upsert_library_security_allowlist(tmp_path):
+    """Test that upsert_library validates dynamic UPDATE column names against the allowlist."""
+    db_path = tmp_path / "test.db"
+    db = DocsDB(db_path)
+
+    # Insert a library to trigger the UPDATE block in upsert_library on the next call
+    db.upsert_library("testlib")
+
+    # By mocking the _ALLOWED_UPDATES allowlist to be empty, any update
+    # will simulate a non-permitted string being in the internal list accumulator.
+    with patch('wet_mcp.db._ALLOWED_UPDATES', frozenset()):
+        with pytest.raises(ValueError, match="Invalid column update"):
+            db.upsert_library("testlib", docs_url="http://example.com")
+
+def test_upsert_library_allowlist_enforcement_with_mocked_accumulator(tmp_path):
+    """Verify whitelist enforcement by using unittest.mock.patch to simulate non-permitted strings."""
+    db_path = tmp_path / "test.db"
+    db = DocsDB(db_path)
+    db.upsert_library("testlib")
+
+    # To strictly follow the instruction of inserting non-permitted strings into internal list accumulators:
+    # We patch the allowlist to simulate what would happen if a malicious string made it into `updates`.
+    # Alternatively, we can use patch on the allowed updates.
+    with patch('wet_mcp.db._ALLOWED_UPDATES', frozenset({"docs_url = ?", "registry = ?", "description = ?", "discovery_version = ?"})):
+        # We omitted "updated_at = ?" from the mocked allowlist.
+        # upsert_library always appends "updated_at = ?" to the updates list.
+        # This will cause the validation to fail, simulating a non-permitted string in the accumulator.
+        with pytest.raises(ValueError, match="Invalid column update: updated_at = \\?"):
+            db.upsert_library("testlib", docs_url="http://example.com")

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.20.1"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix SQL injection risk via dynamic queries

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The `upsert_library` function dynamically constructed a SQL `UPDATE` string by accumulating column assignment strings (like `"docs_url = ?"`) in a list and joining them using an f-string in the `.execute()` method. While the current usage safely appended hardcoded strings, this pattern was technically insecure and flagged by static analysis (`# nosemgrep`), introducing a potential path for SQL injection if future developers unwittingly passed dynamic values or non-hardcoded strings into this block.
**🎯 Impact:** If user input could somehow influence the entries appended to the `updates` list, an attacker could inject arbitrary SQL into the `UPDATE` statement.
**🔧 Fix:** I implemented defense-in-depth by enforcing a strict allowlist (`_ALLOWED_UPDATES = frozenset({...})`) of permitted column assignments. Before the query is generated, the code loops over the items in `updates` and raises a `ValueError` if any string is not found in the allowlist.
**✅ Verification:** I have written a regression test inside the new file `tests/test_security_db.py` which mocks the `_ALLOWED_UPDATES` to simulate a malicious or unpermitted payload in the list and validates that the `ValueError` triggers correctly. I've also executed `uv run pytest` successfully across the codebase to ensure nothing broke.

---
*PR created automatically by Jules for task [9996885921513195735](https://jules.google.com/task/9996885921513195735) started by @n24q02m*