### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix potential SQL injection in upsert_library

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -32,6 +32,7 @@ _ALLOWED_UPDATES = frozenset(
     }
 )
 
+
 def _serialize_f32(vec: list[float]) -> bytes:
     """Serialize float vector for sqlite-vec."""
     return struct.pack(f"{len(vec)}f", *vec)

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -22,6 +22,15 @@ from loguru import logger
 # Bump this when discovery scoring changes to invalidate stale caches.
 from wet_mcp.sources.docs import DISCOVERY_VERSION
 
+_ALLOWED_UPDATES = frozenset(
+    {
+        "docs_url = ?",
+        "registry = ?",
+        "description = ?",
+        "discovery_version = ?",
+        "updated_at = ?",
+    }
+)
 
 def _serialize_f32(vec: list[float]) -> bytes:
     """Serialize float vector for sqlite-vec."""
@@ -366,6 +375,10 @@ class DocsDB:
             params.append(now)
             params.append(lib_id)
             if updates:
+                for update in updates:
+                    if update not in _ALLOWED_UPDATES:
+                        raise ValueError(f"Invalid update field: {update}")
+
                 # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
                 self._conn.execute(
                     f"UPDATE libraries SET {', '.join(updates)} WHERE id = ?",

--- a/tests/test_security_db.py
+++ b/tests/test_security_db.py
@@ -13,7 +13,7 @@ def test_db_update_allowlist(tmp_path):
         name="test-lib",
         docs_url="https://test.com/docs",
         registry="pypi",
-        description="test desc"
+        description="test desc",
     )
     assert lib_id is not None
 

--- a/tests/test_security_db.py
+++ b/tests/test_security_db.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import patch
+from wet_mcp.db import DocsDB
+
+def test_db_update_allowlist(tmp_path):
+    db = DocsDB(tmp_path / "test.db")
+
+    # Valid update should not raise
+    lib_id = db.upsert_library(
+        name="test-lib",
+        docs_url="https://test.com/docs",
+        registry="pypi",
+        description="test desc"
+    )
+    assert lib_id is not None
+
+    # Mock allowlist to be empty, so any update should raise ValueError
+    with patch("wet_mcp.db._ALLOWED_UPDATES", frozenset()):
+        with pytest.raises(ValueError, match="Invalid update field"):
+            db.upsert_library(
+                name="test-lib",
+                docs_url="https://test.com/new-docs",
+            )

--- a/tests/test_security_db.py
+++ b/tests/test_security_db.py
@@ -1,6 +1,9 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 from wet_mcp.db import DocsDB
+
 
 def test_db_update_allowlist(tmp_path):
     db = DocsDB(tmp_path / "test.db")

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.20.1"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR fixes a potential SQL injection vulnerability in `src/wet_mcp/db.py` where dynamic `UPDATE` column fields in `upsert_library` were concatenated directly into the executed query without validation.

A strict module-level `frozenset` (`_ALLOWED_UPDATES`) was introduced to validate each dynamically built update string before it gets interpolated into the query block. A dedicated regression test was also added (`tests/test_security_db.py`).

---
*PR created automatically by Jules for task [15653256251666313914](https://jules.google.com/task/15653256251666313914) started by @n24q02m*