### PR TITLE
[FIX] Refactor '_background_index_and_search' to reduce parameters

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
 from urllib.parse import urlparse
@@ -1448,51 +1449,59 @@ async def _fetch_and_chunk_docs(
 
 # ---------------------------------------------------------------------------
 # Docs search (library documentation with auto-indexing)
+
+
+@dataclass
+class IndexingContext:
+    library: str
+    lib_key: str
+    language: str | None
+    docs_url: str
+    repo_url: str
+    query: str
+    version: str | None
+    lib_id: str
+    ver_id: str
+
+
 # ---------------------------------------------------------------------------
 
 
-async def _background_index_and_search(
-    library: str,
-    lib_key: str,
-    language: str | None,
-    docs_url: str,
-    repo_url: str,
-    query: str,
-    version: str | None,
-    lib_id: str,
-    ver_id: str,
-):
+async def _background_index_and_search(ctx: IndexingContext):
     """Background task to fetch, chunk, embed, and store docs."""
+    docs_url = ctx.docs_url
     try:
         from urllib.parse import urlparse
 
         from wet_mcp.sources.docs import _normalize_docs_url
 
         docs_url = _normalize_docs_url(docs_url)
-        logger.info(f"Background indexing started for '{library}' from {docs_url}...")
+        logger.info(
+            f"Background indexing started for '{ctx.library}' from {docs_url}..."
+        )
 
         try:
             all_chunks, page_count = await asyncio.wait_for(
                 _fetch_and_chunk_docs(
                     docs_url=docs_url,
-                    repo_url=repo_url,
-                    query=query,
-                    library_hint=library,
+                    repo_url=ctx.repo_url,
+                    query=ctx.query,
+                    library_hint=ctx.library,
                 ),
                 timeout=_FETCH_TIMEOUT,
             )
         except TimeoutError:
             logger.warning(
-                f"Docs fetch timed out after {_FETCH_TIMEOUT}s for '{library}'"
+                f"Docs fetch timed out after {_FETCH_TIMEOUT}s for '{ctx.library}'"
             )
             all_chunks, page_count = [], 0
 
         # Fallback SearXNG
         if page_count <= 2 and len(all_chunks) < 100:
             fallback_query = (
-                f"{library} {language} documentation"
-                if language
-                else f"{library} documentation"
+                f"{ctx.library} {ctx.language} documentation"
+                if ctx.language
+                else f"{ctx.library} documentation"
             )
             try:
                 searxng_url = await asyncio.wait_for(
@@ -1523,7 +1532,7 @@ async def _background_index_and_search(
                     alt_urls.append(alt_url)
                     tasks.append(
                         asyncio.wait_for(
-                            _fetch_and_chunk_docs(alt_url, "", query),
+                            _fetch_and_chunk_docs(alt_url, "", ctx.query),
                             timeout=_FALLBACK_TIMEOUT,
                         )
                     )
@@ -1574,18 +1583,18 @@ async def _background_index_and_search(
 
         # Store chunks
         _docs_db.add_chunks(
-            version_id=ver_id,
-            library_id=lib_id,
+            version_id=ctx.ver_id,
+            library_id=ctx.lib_id,
             chunks=all_chunks,
             embeddings=embeddings,
         )
-        _docs_db.mark_version_indexed(ver_id, page_count, len(all_chunks))
+        _docs_db.mark_version_indexed(ctx.ver_id, page_count, len(all_chunks))
         logger.info(
-            f"Background indexing complete for '{library}'. Pages: {page_count}, Chunks: {len(all_chunks)}"
+            f"Background indexing complete for '{ctx.library}'. Pages: {page_count}, Chunks: {len(all_chunks)}"
         )
 
     except Exception as e:
-        logger.error(f"Background indexing failed for {library}: {e}")
+        logger.error(f"Background indexing failed for {ctx.library}: {e}")
 
 
 async def _search_cached_index(
@@ -1819,15 +1828,17 @@ async def _do_docs_search(
     # Step 3: Launch background indexer
     asyncio.create_task(
         _background_index_and_search(
-            library=library,
-            lib_key=lib_key,
-            language=language,
-            docs_url=docs_url,
-            repo_url=repo_url,
-            query=query,
-            version=version,
-            lib_id=lib_id,
-            ver_id=ver_id,
+            IndexingContext(
+                library=library,
+                lib_key=lib_key,
+                language=language,
+                docs_url=docs_url,
+                repo_url=repo_url,
+                query=query,
+                version=version,
+                lib_id=lib_id,
+                ver_id=ver_id,
+            )
         )
     )
 

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from wet_mcp import server
+from wet_mcp.server import IndexingContext
 
 # Windows IOCP event loop hangs on fire-and-forget asyncio.create_task
 # teardown in _do_docs_search and _background_index_and_search tests.
@@ -1498,15 +1499,17 @@ async def test_background_index_fetch_timeout():
         ),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -1544,15 +1547,17 @@ async def test_background_index_with_searxng_fallback():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         server._docs_db.mark_version_indexed.assert_called_once()
@@ -1586,15 +1591,17 @@ async def test_background_index_with_language():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="redis",
-            lib_key="redis:python",
-            language="python",
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="redis",
+                lib_key="redis:python",
+                language="python",
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -1623,15 +1630,17 @@ async def test_background_index_embeddings_and_store():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         call_args = server._docs_db.add_chunks.call_args
@@ -1661,15 +1670,17 @@ async def test_background_index_embed_timeout():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Should still store chunks even without embeddings
         server._docs_db.add_chunks.assert_called_once()
@@ -1687,15 +1698,17 @@ async def test_background_index_exception():
     ):
         # Should not raise
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -1719,15 +1732,17 @@ async def test_background_index_no_chunks():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_not_called()
 
@@ -1769,15 +1784,17 @@ async def test_background_index_fallback_alt_timeout():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.example.com",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.example.com",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Should still use original chunks
         server._docs_db.add_chunks.assert_called_once()
@@ -1821,15 +1838,17 @@ async def test_background_index_fallback_same_netloc():
         server._docs_db = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.example.com",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.example.com",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from wet_mcp import server
+from wet_mcp.server import IndexingContext
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -804,15 +805,17 @@ async def test_background_index_fetch_timeout():
         ),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # No chunks -> returns early, no add_chunks call
         server._docs_db.add_chunks.assert_not_called()
@@ -858,15 +861,17 @@ async def test_background_index_with_fallback_alt_url():
         patch("wet_mcp.server._embed_batch", new_callable=AsyncMock, return_value=None),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://original.com/docs",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://original.com/docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         # Alt URL was used (30 chunks > 1 chunk)
@@ -904,15 +909,17 @@ async def test_background_index_with_embeddings():
         mock_embed.return_value = [[0.1], [0.2], [0.3]]
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         server._docs_db.add_chunks.assert_called_once()
         call_kwargs = server._docs_db.add_chunks.call_args
@@ -932,15 +939,17 @@ async def test_background_index_exception():
     ):
         # Should not raise
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
 
 
@@ -966,15 +975,17 @@ async def test_background_index_with_language_fallback():
         mock_search.return_value = json.dumps({"results": []})
 
         await server._background_index_and_search(
-            library="redis",
-            lib_key="redis:python",
-            language="python",
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="redis",
+                lib_key="redis:python",
+                language="python",
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Verify fallback query includes language
         call_args = mock_search.call_args
@@ -1007,15 +1018,17 @@ async def test_background_index_embed_timeout():
         mock_get_backend.return_value = MagicMock()
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Should still add chunks with embeddings=None
         server._docs_db.add_chunks.assert_called_once()
@@ -1285,15 +1298,17 @@ async def test_background_index_alt_url_fetch_timeout():
         ]
 
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Still uses original chunks
         server._docs_db.add_chunks.assert_called_once()
@@ -1331,15 +1346,17 @@ async def test_background_index_skip_same_netloc():
         patch("wet_mcp.server._embed_batch", new_callable=AsyncMock, return_value=None),
     ):
         await server._background_index_and_search(
-            library="testlib",
-            lib_key="testlib",
-            language=None,
-            docs_url="http://docs.x/guide",
-            repo_url="",
-            query="test",
-            version=None,
-            lib_id="1",
-            ver_id="1",
+            IndexingContext(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.x/guide",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
         )
         # Original chunks used (same netloc alt URL skipped)
         server._docs_db.add_chunks.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.20.1"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR refactors the internal `_background_index_and_search` function in `src/wet_mcp/server.py` to reduce its parameter count by grouping context variables into a new `IndexingContext` dataclass.

Key changes:
- Introduced `IndexingContext` dataclass to hold library, version, and search context.
- Modified `_background_index_and_search` to accept `ctx: IndexingContext`.
- Updated the task creation logic in `_do_docs_search` to instantiate and pass the dataclass.
- Updated comprehensive and coverage test suites to match the new function signature.

This refactoring makes the function signature cleaner and easier to maintain.

---
*PR created automatically by Jules for task [12623167606873497727](https://jules.google.com/task/12623167606873497727) started by @n24q02m*