### PR TITLE
[TEST] Missing test for load_config_from_file in relay_setup.py

### DIFF
--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -68,6 +68,32 @@ class TestLoadConfigFromFile:
         # Should not raise, returns None if module missing or config not found
         assert result is None or isinstance(result, dict)
 
+    def test_returns_config_when_valid_keys_present(self):
+        valid_config = {"GEMINI_API_KEY": "test-key"}
+        with patch(
+            "mcp_relay_core.storage.config_file.read_config",
+            return_value=valid_config,
+        ):
+            result = load_config_from_file()
+        assert result == valid_config
+
+    def test_returns_none_when_no_cloud_keys_present(self):
+        invalid_config = {"OTHER_KEY": "some-value"}
+        with patch(
+            "mcp_relay_core.storage.config_file.read_config",
+            return_value=invalid_config,
+        ):
+            result = load_config_from_file()
+        assert result is None
+
+    def test_returns_none_when_read_config_raises(self):
+        with patch(
+            "mcp_relay_core.storage.config_file.read_config",
+            side_effect=Exception("Disk error"),
+        ):
+            result = load_config_from_file()
+        assert result is None
+
 
 class TestApplyConfig:
     """Tests for apply_config."""


### PR DESCRIPTION
This PR adds missing unit test coverage for the \`load_config_from_file\` function in \`src/wet_mcp/relay_setup.py\`. 

New tests include:
- \`test_returns_config_when_valid_keys_present\`: Verifies the function returns the configuration dictionary if at least one of the \`CLOUD_KEYS\` is present.
- \`test_returns_none_when_no_cloud_keys_present\`: Verifies the function returns \`None\` if the configuration file exists but does not contain any of the expected cloud API keys.
- \`test_returns_none_when_read_config_raises\`: Verifies the function handles generic exceptions from the underlying \`read_config\` storage helper.

Verified that all 18 tests in \`tests/test_relay_setup.py\` pass. Attempted to refactor for coverage collection (resolving Pydantic/MCP dependency conflicts), but deferred due to complex module re-import issues with C-extensions like Numpy. The current tests remain clean and correct for standard execution.

---
*PR created automatically by Jules for task [13021795699346010607](https://jules.google.com/task/13021795699346010607) started by @n24q02m*