### PR TITLE
[FIX] Missing Caching for SearXNG Quick Health Checks

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -9,6 +9,8 @@ All internal functions are re-exported from web-core for backward
 compatibility with existing tests and consumers.
 """
 
+import time
+
 import web_core.search.runner as _wc_runner
 from loguru import logger
 from web_core.search.runner import shutdown_searxng
@@ -78,6 +80,11 @@ _wc_runner._find_available_port = _find_available_port  # type: ignore[assignmen
 # Re-export internal functions from web-core for backward compatibility.
 # Tests and other modules import these from wet_mcp.searxng_runner.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Caching for SearXNG health checks (10s TTL) to reduce network overhead.
+# ---------------------------------------------------------------------------
+
 from web_core.search.runner import (  # noqa: F401, E402
     _DISCOVERY_FILE,
     _HEALTH_CHECK_TIMEOUT,
@@ -100,7 +107,6 @@ from web_core.search.runner import (  # noqa: F401, E402
     _is_searxng_installed,
     _kill_stale_port_process,
     _last_restart_time,
-    _quick_health_check,
     _read_discovery,
     _remove_discovery,
     _restart_count,
@@ -114,7 +120,26 @@ from web_core.search.runner import (  # noqa: F401, E402
     _write_discovery,
 )
 
-# ---------------------------------------------------------------------------
+_health_cache: dict[str, tuple[bool, float]] = {}  # URL -> (is_healthy, timestamp)
+
+_wc_original_health_check = _wc_runner._quick_health_check
+
+
+async def _quick_health_check(url: str, retries: int = 3) -> bool:
+    """Health check with 10s TTL cache."""
+    now = time.time()
+    if url in _health_cache:
+        result, ts = _health_cache[url]
+        if now - ts < 10:
+            return result
+
+    result = await _wc_original_health_check(url, retries)
+    _health_cache[url] = (result, now)
+    return result
+
+
+_wc_runner._quick_health_check = _quick_health_check  # type: ignore[assignment] # ty: ignore[invalid-assignment]
+
 # Public API — bridges wet-mcp settings to web-core
 # ---------------------------------------------------------------------------
 

--- a/tests/test_health_check_cache.py
+++ b/tests/test_health_check_cache.py
@@ -1,0 +1,47 @@
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import wet_mcp.searxng_runner as wet_runner
+
+
+@pytest.mark.asyncio
+async def test_health_check_caching():
+    # Clear the cache before starting
+    wet_runner._health_cache.clear()
+
+    # Patch the original health check
+    with patch(
+        "wet_mcp.searxng_runner._wc_original_health_check", new_callable=AsyncMock
+    ) as mock_original:
+        mock_original.return_value = True
+
+        url = "http://localhost:8080"
+
+        # 1. First call - should call original
+        res1 = await wet_runner._quick_health_check(url)
+        assert res1 is True
+        assert mock_original.call_count == 1
+
+        # 2. Second call - should be cached
+        res2 = await wet_runner._quick_health_check(url)
+        assert res2 is True
+        assert mock_original.call_count == 1
+
+        # 3. Third call with different URL - should call original
+        url2 = "http://localhost:8081"
+        res3 = await wet_runner._quick_health_check(url2)
+        assert res3 is True
+        assert mock_original.call_count == 2
+
+        # 4. Wait for TTL to expire (10s)
+        # Instead of mocking time.time globally which might break other things,
+        # we can manually manipulate the cache timestamp
+        now = time.time()
+        wet_runner._health_cache[url] = (True, now - 11)
+
+        res4 = await wet_runner._quick_health_check(url)
+        assert res4 is True
+        # It should have called original again because timestamp is old
+        assert mock_original.call_count == 3

--- a/tests/test_searxng_runner_comprehensive.py
+++ b/tests/test_searxng_runner_comprehensive.py
@@ -156,6 +156,9 @@ async def test_quick_health_check():
 
     with patch("httpx.AsyncClient", return_value=MockClientContextManager()):
         assert await _quick_health_check("http://localhost:8080", retries=1) is True
+        import wet_mcp.searxng_runner as wet_runner
+
+        wet_runner._health_cache.clear()
 
         mock_client.get.side_effect = httpx.RequestError("error")
         assert await _quick_health_check("http://localhost:8080", retries=1) is False

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.20.1"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR adds a 10-second TTL cache to the SearXNG health check function.

### Changes:
- Modified `src/wet_mcp/searxng_runner.py` to:
    - Define `_health_cache` (dictionary mapping URL to (result, timestamp)).
    - Implement a new `_quick_health_check` that uses this cache.
    - Monkey-patch `web_core.search.runner._quick_health_check`.
- Updated `tests/test_searxng_runner_comprehensive.py` to clear the cache during health check tests.
- Added `tests/test_health_check_cache.py` with comprehensive unit tests for the caching logic.

### Verification:
- Ran `uv run ruff check .` and `uv run ruff format .`.
- Ran `uv run pytest tests/test_health_check_cache.py tests/test_searxng_runner.py tests/test_searxng_runner_comprehensive.py`.
- All tests passed.

---
*PR created automatically by Jules for task [13402445665395490446](https://jules.google.com/task/13402445665395490446) started by @n24q02m*