### PR TITLE
[FIX] Refactor 'media' to reduce parameters

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
 from urllib.parse import urlparse
@@ -896,6 +897,19 @@ async def extract(
                 "If you want to search for information, use the `search` tool instead."
             )
 
+@dataclass(frozen=True)
+class MediaParams:
+    """Parameters for the media tool."""
+
+    action: str
+    url: str | None = None
+    media_type: str = "all"
+    media_urls: list[str] | None = None
+    output_dir: str | None = None
+    max_items: int = 10
+    prompt: str = "Describe this image in detail."
+
+
 
 @mcp.tool(
     annotations=ToolAnnotations(
@@ -930,26 +944,44 @@ async def media(  # noqa: PLR0913
     Typical workflow: list (discover) -> download (save locally) -> analyze (LLM insights).
     Use `help` tool with tool_name="media" for full documentation.
     """
+    params = MediaParams(
+        action=action,
+        url=url,
+        media_type=media_type,
+        media_urls=media_urls,
+        output_dir=output_dir,
+        max_items=max_items,
+        prompt=prompt,
+    )
+    return await _do_media(params)
+
+
+async def _do_media(params: MediaParams) -> str:
+    """Internal implementation of the media tool."""
     from wet_mcp.sources.crawler import download_media
 
-    match action:
+    match params.action:
         case "list":
-            if not url:
+            if not params.url:
                 return 'Error: url is required for list action. Example: media(action="list", url="https://example.com/gallery", media_type="images")'
             return await _with_timeout(
-                list_media(url=url, media_type=media_type, max_items=max_items),
+                list_media(
+                    url=params.url,
+                    media_type=params.media_type,
+                    max_items=params.max_items,
+                ),
                 "media.list",
             )
 
         case "download":
-            if not media_urls:
+            if not params.media_urls:
                 return 'Error: media_urls is required for download action. Example: media(action="download", media_urls=["https://example.com/image.jpg"]). Use media(action="list", url="...") first to discover media URLs.'
 
             # Security: validate output_dir is within the configured
             # download directory to prevent arbitrary file writes.
             resolved_download_dir = Path(settings.download_dir).expanduser().resolve()
             target_dir = (
-                Path(output_dir or settings.download_dir).expanduser().resolve()
+                Path(params.output_dir or settings.download_dir).expanduser().resolve()
             )
             if not target_dir.is_relative_to(resolved_download_dir):
                 return (
@@ -959,20 +991,20 @@ async def media(  # noqa: PLR0913
 
             return await _with_timeout(
                 download_media(
-                    media_urls=media_urls,
+                    media_urls=params.media_urls,
                     output_dir=str(target_dir),
                 ),
                 "media.download",
             )
 
         case "analyze":
-            if not url:
+            if not params.url:
                 return 'Error: url (local file path) is required for analyze action. Example: media(action="analyze", url="/path/to/image.jpg", prompt="Describe this image"). Download a file first with media(action="download", ...).'
 
             from wet_mcp.llm import analyze_media
 
             return await _with_timeout(
-                analyze_media(media_path=url, prompt=prompt),
+                analyze_media(media_path=params.url, prompt=params.prompt),
                 "media.analyze",
             )
 
@@ -980,9 +1012,9 @@ async def media(  # noqa: PLR0913
             import difflib
 
             valid_actions = ["analyze", "download", "list"]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
+            closest = difflib.get_close_matches(params.action, valid_actions, n=1)
             suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return f"Error: Unknown action '{action}'.{suggestion} Valid actions: list (discover media on page), download (save to local), analyze (LLM vision analysis)."
+            return f"Error: Unknown action '{params.action}'.{suggestion} Valid actions: list (discover media on page), download (save to local), analyze (LLM vision analysis)."
 
 
 @mcp.tool(
@@ -1018,8 +1050,6 @@ async def help(tool_name: str = "search") -> str:
         return f"Error: No documentation found for tool '{tool_name}'"
     except Exception as e:
         return f"Error loading documentation: {e}"
-
-
 @mcp.tool(
     description=(
         "Server config and management. Actions: "

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.20.1"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Refactored the 'media' tool in `src/wet_mcp/server.py` to use a `MediaParams` dataclass and an internal `_do_media` helper. This improves readability and maintains a flat public signature for MCP. Verified with `uv run pytest tests/test_media_tool.py` and the full test suite. Fixed a minor import sorting issue found by `ruff`.

---
*PR created automatically by Jules for task [2677963108715044985](https://jules.google.com/task/2677963108715044985) started by @n24q02m*