### PR TITLE
[CLEANUP] Broad Exception caught and silently passed

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -519,9 +519,12 @@ async def _with_timeout(coro, action: str) -> str:
     # Give the task a grace period to clean up (close browser pages, etc.)
     try:
         await asyncio.wait_for(asyncio.shield(task), timeout=_CANCEL_GRACE_PERIOD)
-    except (asyncio.CancelledError, TimeoutError, Exception):
-        # Task either cancelled cleanly, timed out again, or raised -- all OK
+    except (asyncio.CancelledError, TimeoutError):
+        # Task either cancelled cleanly or timed out again -- all OK
         pass
+    except Exception as e:
+        # Unexpected error during cleanup
+        logger.debug(f"Unexpected error during tool cleanup: {e}")
 
     logger.error(f"Tool '{action}' timed out after {timeout}s")
     return (


### PR DESCRIPTION
Modified the exception handling in `src/wet_mcp/server.py` within the `_with_timeout` function. 
Previously, the code caught all exceptions during the tool's cancellation grace period and passed silently.
Now, it explicitly catches `asyncio.CancelledError` and `TimeoutError` (passing silently as they are expected), while other exceptions are logged at the `debug` level.
This ensures that unexpected errors during resource cleanup (like browser closing or network teardown) are visible in logs for troubleshooting without affecting the user-facing timeout message.
Verified the fix with an isolated test script mocking `asyncio.shield` and `asyncio.wait_for`.

---
*PR created automatically by Jules for task [17219596501780288659](https://jules.google.com/task/17219596501780288659) started by @n24q02m*