### PR TITLE
[CLEANUP] Broad Exception caught and silently passed in setup_tool.py

### DIFF
--- a/src/wet_mcp/setup_tool.py
+++ b/src/wet_mcp/setup_tool.py
@@ -34,7 +34,7 @@ def clear_model_cache(model_name: str) -> str | None:
     return None
 
 
-def _validate_cloud_models(settings_obj) -> dict:
+async def _validate_cloud_models(settings_obj) -> dict:
     """Check if cloud embedding and reranking models are valid."""
     from wet_mcp.embedder import init_backend
     from wet_mcp.reranker import init_reranker
@@ -46,7 +46,7 @@ def _validate_cloud_models(settings_obj) -> dict:
     for candidate in candidates:
         try:
             backend = init_backend("cloud", candidate)
-                dims = await backend.check_available()
+            dims = await backend.check_available()
             if dims > 0:
                 embedding_info = {"model": candidate, "dims": dims}
                 break
@@ -65,8 +65,7 @@ def _validate_cloud_models(settings_obj) -> dict:
             if reranker.check_available():
                 reranker_info = {"model": rerank_model}
         except Exception as exc:
-            logger.debug(f"Cloud reranker {rerank_model} failed: {exc}")
-            pass
+            logger.warning(f"Cloud reranker {rerank_model} failed: {exc}")
 
     return {
         "cloud_ready": True,
@@ -196,7 +195,7 @@ async def run_warmup() -> dict:
     # 2. Check cloud models if API keys are configured
     mode = settings.setup_providers()
     if mode == "sdk":
-        cloud_result = await asyncio.to_thread(_validate_cloud_models, settings)
+        cloud_result = await _validate_cloud_models(settings)
         if cloud_result["cloud_ready"]:
             steps.append(
                 {


### PR DESCRIPTION
This PR addresses a code quality issue where a broad exception was being caught and silently ignored in `src/wet_mcp/setup_tool.py`. 

During the cleanup, I discovered that `_validate_cloud_models` was using `await` despite being defined as a synchronous function, and had incorrect indentation for the `await` call.

Changes:
1. **Async Refactoring**: Converted `_validate_cloud_models` to `async def` and fixed the indentation of the `await` call.
2. **Call Site Update**: Updated `run_warmup` to call `_validate_cloud_models` as an async function.
3. **Improved Error Visibility**: Upgraded the exception logging for reranker validation from `debug` to `warning` and removed the silent `pass`. This ensures that if a reranker is configured but fails to initialize, it is properly surfaced in the logs.

Verification:
- Performed manual verification using a custom script that mocked dependencies and exercised both success and failure paths for cloud model validation.
- Confirmed that the reranker failure now logs a warning and correctly returns a `None` reranker info without crashing the setup process.

---
*PR created automatically by Jules for task [8844778866293326352](https://jules.google.com/task/8844778866293326352) started by @n24q02m*