### PR TITLE
[CLEANUP] Broad Exception caught and silently passed

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -123,8 +123,8 @@ def _detect_gh_token() -> str | None:
             token = result.stdout.strip()
             if token:
                 return token
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Failed to detect GitHub token from gh CLI: {e}")
     return None
 
 
@@ -313,7 +313,8 @@ async def _init_embedding_backend(mode: str) -> None:
                         f"(native={native_dims}, stored={_embedding_dims})"
                     )
                     return
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Embedding candidate {candidate} failed: {e}")
                 continue
 
     logger.error("Cloud embedding not available and local fallback is disabled")


### PR DESCRIPTION
This PR addresses the issue of broad exceptions being caught and silently passed in `src/wet_mcp/server.py`.

Specifically:
- In `_detect_gh_token`, the silent `except Exception: pass` has been replaced with `logger.debug` logging. This provides visibility when the GitHub CLI token detection fails, which is helpful for troubleshooting.
- In `_init_embedding_backend`, the silent `except Exception: continue` has been replaced with `logger.debug` logging. This helps identify which specific embedding candidates are failing and why.
- Consistency was checked across other tool action JSON formatting blocks to ensure they follow best practices.

These changes improve the maintainability and observability of the server startup and tool execution paths without changing the functional behavior (fallbacks still occur as intended).

---
*PR created automatically by Jules for task [4291678448085146147](https://jules.google.com/task/4291678448085146147) started by @n24q02m*