### PR TITLE
[TEST] Missing test for `chunk_markdown` in `docs.py`

### DIFF
--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -1485,6 +1485,38 @@ class TestChunkMarkdownCoverage:
         result = chunk_markdown(content)
         assert result == []
 
+    def test_h3_h4_flushing_logic(self):
+        """H3/H4 headings trigger flush only if buffer is large enough."""
+        content = """# Title\n## Section\n### Sub1\nSmall content here.\n### Sub2\nMore content here."""
+        # max_chunk_size=40, so threshold is 20.
+        # "## Section\n### Sub1\nSmall content here." is ~40 chars, should flush before Sub2
+        result = chunk_markdown(content, max_chunk_size=40, min_chunk_size=5)
+        # Should have at least 2 chunks: one starting at # Title, one starting at ### Sub2
+        assert len(result) >= 2
+        assert "Sub2" in result[-1]["title"]
+
+    def test_h1_resets_h2_state(self):
+        """Level 1 heading resets the internal Level 2 state."""
+        content = """# H1-A\n## H2-A\nContent A is long enough to be a chunk.\n# H1-B\n## H2-B\nContent B is also long enough to be a chunk."""
+        result = chunk_markdown(content, min_chunk_size=10)
+        # Find chunk for Content B
+        chunk_b = [c for c in result if "Content B" in c["content"]][0]
+        assert chunk_b["heading_path"] == "H1-B > H2-B"
+
+    def test_h4_heading_path(self):
+        """Level 4 headings are correctly included in the heading path."""
+        content = """# H1\n## H2\n### H3\n#### H4\nDeeply nested content that meets min size."""
+        result = chunk_markdown(content, min_chunk_size=10)
+        chunk = [c for c in result if "Deeply nested" in c["content"]][0]
+        assert "H4" in chunk["heading_path"]
+        assert "H1 > H2 > H4" == chunk["heading_path"]
+
+    def test_h2_without_h1_path(self):
+        """Heading path handles missing H1 gracefully."""
+        content = """## Only H2\nContent for H2 only section."""
+        result = chunk_markdown(content, min_chunk_size=5)
+        assert result[0]["heading_path"] == " > Only H2"
+
 
 # ---------------------------------------------------------------------------
 # _parse_objects_inv


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `chunk_markdown` function in `src/wet_mcp/sources/docs.py`.

The new tests in `tests/test_docs_coverage.py` cover several previously untested or under-tested logic paths:
- **H3/H4 Flushing:** Verifies that Level 3 and 4 headings only trigger a chunk flush if the current buffer exceeds half of `max_chunk_size`.
- **H1 State Reset:** Ensures that a Level 1 heading correctly resets the internal state for Level 2 headings, preventing incorrect `heading_path` construction.
- **H4 Path Construction:** Confirms that Level 4 headings are correctly incorporated into the semantic hierarchy path.
- **Missing H1 Handling:** Tests how the `heading_path` is constructed when a document starts with a Level 2 heading.

The logic was verified using a standalone script that isolated `chunk_markdown` from its complex environment dependencies. Linting and formatting were performed using `ruff`.

---
*PR created automatically by Jules for task [18294453362609162573](https://jules.google.com/task/18294453362609162573) started by @n24q02m*