### PR TITLE
feat(extract): support file:// URLs and concurrent local conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,4 +145,4 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 ## TODO / Backlog
 
 - [x] **markitdown integration**: Added `markitdown[pdf,docx,pptx]` as dependency. Extract tool auto-detects document URLs by extension and routes through markitdown instead of Crawl4AI.
-- [ ] **extract action for local files**: Support `file://` URLs or a new `convert` action for local document conversion via markitdown.
+- [x] **extract action for local files**: Support `file://` URLs or a new `convert` action for local document conversion via markitdown.

--- a/src/wet_mcp/setup_tool.py
+++ b/src/wet_mcp/setup_tool.py
@@ -46,7 +46,7 @@ def _validate_cloud_models(settings_obj) -> dict:
     for candidate in candidates:
         try:
             backend = init_backend("cloud", candidate)
-                dims = await backend.check_available()
+            dims = await backend.check_available()
             if dims > 0:
                 embedding_info = {"model": candidate, "dims": dims}
                 break

--- a/src/wet_mcp/setup_tool.py
+++ b/src/wet_mcp/setup_tool.py
@@ -34,7 +34,7 @@ def clear_model_cache(model_name: str) -> str | None:
     return None
 
 
-def _validate_cloud_models(settings_obj) -> dict:
+async def _validate_cloud_models(settings_obj) -> dict:
     """Check if cloud embedding and reranking models are valid."""
     from wet_mcp.embedder import init_backend
     from wet_mcp.reranker import init_reranker
@@ -196,7 +196,7 @@ async def run_warmup() -> dict:
     # 2. Check cloud models if API keys are configured
     mode = settings.setup_providers()
     if mode == "sdk":
-        cloud_result = await asyncio.to_thread(_validate_cloud_models, settings)
+        cloud_result = await _validate_cloud_models(settings)
         if cloud_result["cloud_ready"]:
             steps.append(
                 {

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -16,6 +16,7 @@ import tempfile
 from contextlib import asynccontextmanager
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
+from urllib.request import url2pathname
 
 import httpx
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
@@ -286,6 +287,14 @@ async def extract(
 
     async def process_url(url: str):
         async with sem:
+            # Handle local file URLs
+            if url.startswith("file://"):
+                try:
+                    path_str = url2pathname(urlparse(url).path)
+                    return await _extract_local_file(path_str, url=url)
+                except Exception as e:
+                    return {"url": url, "error": f"Invalid file URL: {e}"}
+
             if not is_safe_url(url):
                 logger.warning(f"Skipping unsafe URL: {url}")
                 return {"url": url, "error": "Security Alert: Unsafe URL blocked"}
@@ -774,18 +783,16 @@ async def batch_extract(
 # ---------------------------------------------------------------------------
 
 
-async def convert_local_files(paths: list[str]) -> str:
-    """Convert local files to Markdown via markitdown.
+async def _extract_local_file(path_str: str, url: str | None = None) -> dict:
+    """Validate and convert a local file to Markdown.
 
     Args:
-        paths: List of absolute file paths (max 10).
+        path_str: Local file path.
+        url: Original URL if this was a file:// URL.
 
     Returns:
-        JSON array of {path, content, title} or {path, error}.
+        Dict with result (content, title, etc.) or error.
     """
-    if len(paths) > _MAX_CONVERT_FILES:
-        return f"Error: Maximum {_MAX_CONVERT_FILES} files per call (got {len(paths)})"
-
     from wet_mcp.config import settings as _settings
     from wet_mcp.security import is_safe_local_path
 
@@ -800,28 +807,42 @@ async def convert_local_files(paths: list[str]) -> str:
         # to prevent arbitrary file read of sensitive system files.
         allowed_dirs = [Path.home().resolve(), Path("/tmp").resolve()]
 
-    results = []
-    for path_str in paths:
-        safe_path = is_safe_local_path(
-            path_str,
-            allowed_dirs=allowed_dirs,
-            max_size=_settings.convert_max_file_size,
-        )
-        if safe_path is None:
-            results.append({"path": path_str, "error": f"Path rejected: {path_str}"})
-            continue
+    safe_path = is_safe_local_path(
+        path_str,
+        allowed_dirs=allowed_dirs,
+        max_size=_settings.convert_max_file_size,
+    )
+    if safe_path is None:
+        return {"url": url or path_str, "error": f"Path rejected: {path_str}"}
 
-        try:
-            content = await asyncio.to_thread(_convert_file, safe_path)
-            results.append(
-                {
-                    "path": str(safe_path),
-                    "content": content,
-                    "title": safe_path.name,
-                }
-            )
-        except Exception as e:
-            results.append({"path": path_str, "error": str(e)})
+    try:
+        content = await asyncio.to_thread(_convert_file, safe_path)
+        res = {
+            "path": str(safe_path),
+            "content": content,
+            "title": safe_path.name,
+        }
+        if url:
+            res["url"] = url
+        return res
+    except Exception as e:
+        return {"url": url or path_str, "error": str(e)}
+
+
+async def convert_local_files(paths: list[str]) -> str:
+    """Convert local files to Markdown via markitdown.
+
+    Args:
+        paths: List of absolute file paths (max 10).
+
+    Returns:
+        JSON array of {path, content, title} or {path, error}.
+    """
+    if len(paths) > _MAX_CONVERT_FILES:
+        return f"Error: Maximum {_MAX_CONVERT_FILES} files per call (got {len(paths)})"
+
+    tasks = [_extract_local_file(path) for path in paths]
+    results = await asyncio.gather(*tasks)
 
     return json.dumps(results, ensure_ascii=False, indent=2)
 

--- a/tests/run_benchmark.py
+++ b/tests/run_benchmark.py
@@ -278,14 +278,14 @@ async def main():
                 t = text
                 if is_query and isinstance(b, Qwen3EmbedBackend):
                     t = f"Instruct: Retrieve relevant technical documentation\nQuery: {text}"
-                vec = await asyncio.to_thread(b.embed_single, t, 768)
+                vec = await b.embed_single(t, dimensions=768)
                 return vec[:768] if len(vec) > 768 else vec
 
             async def _embed_batch(texts):
                 b = get_backend()
                 if not b:
                     return None
-                vecs = await asyncio.to_thread(b.embed_texts, texts, 768)
+                vecs = await b.embed_texts(texts, dimensions=768)
                 return [v[:768] if len(v) > 768 else v for v in vecs]
 
             embed_fn = _embed

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -94,7 +94,10 @@ class TestCloudEmbeddingBackend:
         """Batch embedding returns correct vectors."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             return_value=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
         ):
             vecs = await backend.embed_texts(["hello", "world"])
@@ -113,7 +116,9 @@ class TestCloudEmbeddingBackend:
         """Dimensions parameter is passed through to _call_provider."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.1]]) as mock_call:
+        with patch.object(
+            backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.1]]
+        ) as mock_call:
             await backend.embed_texts(["test"], dimensions=256)
             mock_call.assert_called_once_with(["test"], 256)
 
@@ -121,7 +126,9 @@ class TestCloudEmbeddingBackend:
         """No dimensions parameter when not specified."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.1]]) as mock_call:
+        with patch.object(
+            backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.1]]
+        ) as mock_call:
             await backend.embed_texts(["test"])
             mock_call.assert_called_once_with(["test"], None)
 
@@ -131,7 +138,10 @@ class TestCloudEmbeddingBackend:
 
         unsupported_err = Exception("output_dimension is not supported for this model")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=[unsupported_err, [[0.1] * 1024]],
         ):
             result = await backend.embed_texts(["test"], dimensions=768)
@@ -142,7 +152,12 @@ class TestCloudEmbeddingBackend:
         """Truncates locally when server returns more dims than requested."""
         backend = CloudEmbeddingBackend("gemini/gemini-embedding-001")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.1] * 3072]):
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 3072],
+        ):
             result = await backend.embed_texts(["test"], dimensions=768)
             assert len(result[0]) == 768
 
@@ -150,7 +165,11 @@ class TestCloudEmbeddingBackend:
         """Non-retryable API errors are raised to caller."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, side_effect=Exception("Invalid model"),
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            side_effect=Exception("Invalid model"),
         ):
             with pytest.raises(Exception, match="Invalid model"):
                 await backend.embed_texts(["test"])
@@ -159,7 +178,12 @@ class TestCloudEmbeddingBackend:
         """Single text embedding returns one vector."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.1, 0.2, 0.3]]):
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            return_value=[[0.1, 0.2, 0.3]],
+        ):
             vec = await backend.embed_single("hello")
 
         assert vec == [0.1, 0.2, 0.3]
@@ -168,7 +192,12 @@ class TestCloudEmbeddingBackend:
         """Returns dimension count when model is available."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.0] * 768]):
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            return_value=[[0.0] * 768],
+        ):
             dims = await backend.check_available()
 
         assert dims == 768
@@ -177,7 +206,11 @@ class TestCloudEmbeddingBackend:
         """Returns 0 when model is not available."""
         backend = CloudEmbeddingBackend("nonexistent")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, side_effect=Exception("Invalid API key")
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            side_effect=Exception("Invalid API key"),
         ):
             dims = await backend.check_available()
 
@@ -389,7 +422,9 @@ class TestBatchSplitting:
         def mock_call(texts, dimensions=None):
             return [[float(j)] for j in range(len(texts))]
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, side_effect=mock_call):
+        with patch.object(
+            backend, "_call_provider", new_callable=AsyncMock, side_effect=mock_call
+        ):
             vecs = await backend.embed_texts([f"text_{i}" for i in range(n)])
 
         assert len(vecs) == n
@@ -402,7 +437,9 @@ class TestBatchSplitting:
         def mock_call(texts, dimensions=None):
             return [[0.0] for _ in range(len(texts))]
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, side_effect=mock_call) as mock:
+        with patch.object(
+            backend, "_call_provider", new_callable=AsyncMock, side_effect=mock_call
+        ) as mock:
             await backend.embed_texts([f"t{i}" for i in range(n)])
 
         assert mock.call_count == 3
@@ -415,7 +452,9 @@ class TestBatchSplitting:
         def mock_call(texts, dimensions=None):
             return [[0.0] for _ in range(len(texts))]
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, side_effect=mock_call) as mock:
+        with patch.object(
+            backend, "_call_provider", new_callable=AsyncMock, side_effect=mock_call
+        ) as mock:
             await backend.embed_texts([f"text_{i}" for i in range(n)])
 
         assert mock.call_count == 1
@@ -432,7 +471,10 @@ class TestRetryLogic:
         """Retries on rate limit errors with exponential backoff."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=[
                 Exception("429 rate limit exceeded"),
                 [[0.1]],
@@ -448,7 +490,10 @@ class TestRetryLogic:
         """Retries on 5xx server errors."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=[
                 Exception("503 service temporarily unavailable"),
                 [[0.2]],
@@ -463,7 +508,10 @@ class TestRetryLogic:
         """Non-retryable errors fail immediately without retry."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=Exception("Invalid API key"),
         ):
             with pytest.raises(Exception, match="Invalid API key"):
@@ -476,7 +524,10 @@ class TestRetryLogic:
         """Retry delays use exponential backoff."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=[
                 Exception("429 rate limit"),
                 Exception("429 rate limit"),
@@ -492,7 +543,10 @@ class TestRetryLogic:
         """Raises after all retries are exhausted."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=Exception("429 rate limit"),
         ):
             with pytest.raises(Exception, match="429 rate limit"):
@@ -631,21 +685,32 @@ class TestCheckAvailableApiKeyValidation:
     async def test_api_key_401_returns_zero(self):
         """401 errors are caught and return 0."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, side_effect=Exception("401 Unauthorized")
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            side_effect=Exception("401 Unauthorized"),
         ):
             assert await backend.check_available() == 0
 
     async def test_api_key_403_returns_zero(self):
         """403 forbidden returns 0."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, side_effect=Exception("403 Forbidden")
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            side_effect=Exception("403 Forbidden"),
         ):
             assert await backend.check_available() == 0
 
     async def test_invalid_key_detected(self):
         """'invalid' keyword in error is caught."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=Exception("Invalid API key provided"),
         ):
             assert await backend.check_available() == 0
@@ -653,7 +718,10 @@ class TestCheckAvailableApiKeyValidation:
     async def test_unauthorized_detected(self):
         """'unauthorized' keyword in error is caught."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=Exception("Unauthorized access"),
         ):
             assert await backend.check_available() == 0
@@ -661,7 +729,10 @@ class TestCheckAvailableApiKeyValidation:
     async def test_non_auth_error_returns_zero(self):
         """Non-auth errors (e.g. model not found) also return 0."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock,
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
             side_effect=Exception("Model not found"),
         ):
             assert await backend.check_available() == 0
@@ -669,13 +740,20 @@ class TestCheckAvailableApiKeyValidation:
     async def test_success_returns_dims(self):
         """Successful check returns embedding dimensions."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, return_value=[[0.1, 0.2, 0.3]]):
+        with patch.object(
+            backend,
+            "_call_provider",
+            new_callable=AsyncMock,
+            return_value=[[0.1, 0.2, 0.3]],
+        ):
             assert await backend.check_available() == 3
 
     async def test_empty_embeddings_returns_zero(self):
         """Returns 0 when provider returns empty embeddings."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")
-        with patch.object(backend, "_call_provider", new_callable=AsyncMock, return_value=[]):
+        with patch.object(
+            backend, "_call_provider", new_callable=AsyncMock, return_value=[]
+        ):
             assert await backend.check_available() == 0
 
 

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -271,7 +271,7 @@ class TestProviderSDKs:
         mock_openai_mod = MagicMock(OpenAI=mock_openai_cls)
 
         with patch.dict("sys.modules", {"openai": mock_openai_mod}):
-            backend._embed_openai(["test"], dimensions=256)
+            await backend._embed_openai(["test"], dimensions=256)
             mock_client.embeddings.create.assert_called_once_with(
                 model="text-embedding-3-small", input=["test"], dimensions=256
             )
@@ -298,7 +298,7 @@ class TestProviderSDKs:
         mock_openai_mod = MagicMock(OpenAI=mock_openai_cls)
 
         with patch.dict("sys.modules", {"openai": mock_openai_mod}):
-            backend._embed_openai(["test"])
+            await backend._embed_openai(["test"])
             mock_openai_cls.assert_called_once_with(
                 api_key="test-key", base_url="https://custom.api/v1"
             )
@@ -349,7 +349,7 @@ class TestProviderSDKs:
         mock_cohere_mod.ClientV2.return_value = mock_client
 
         with patch.dict("sys.modules", {"cohere": mock_cohere_mod}):
-            result = backend._embed_cohere(["test"], dimensions=768)
+            result = await backend._embed_cohere(["test"], dimensions=768)
 
         assert len(result[0]) == 768
 

--- a/tests/test_file_url.py
+++ b/tests/test_file_url.py
@@ -1,22 +1,23 @@
-import asyncio
-import json
-import os
-import sys
 import importlib.util
+import json
+import sys
 from pathlib import Path
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock
+
 import pytest
+
 
 # This test uses isolated loading because of the complex dependency environment
 @pytest.mark.asyncio
 async def test_extract_file_url_and_convert_concurrent(tmp_path):
     # Setup Mocks
-    with MagicMock() as mock_loguru, \
-         MagicMock() as mock_httpx, \
-         MagicMock() as mock_crawl4ai, \
-         MagicMock() as mock_aiolimiter, \
-         MagicMock() as mock_markitdown:
-
+    with (
+        MagicMock() as mock_loguru,
+        MagicMock() as mock_httpx,
+        MagicMock() as mock_crawl4ai,
+        MagicMock() as mock_aiolimiter,
+        MagicMock() as mock_markitdown,
+    ):
         sys.modules["loguru"] = mock_loguru
         sys.modules["httpx"] = mock_httpx
         sys.modules["crawl4ai"] = mock_crawl4ai
@@ -41,7 +42,9 @@ async def test_extract_file_url_and_convert_concurrent(tmp_path):
         mock_markitdown.MarkItDown.return_value = mock_mid
 
         # Load module
-        spec = importlib.util.spec_from_file_location("wet_mcp.sources.crawler", "src/wet_mcp/sources/crawler.py")
+        spec = importlib.util.spec_from_file_location(
+            "wet_mcp.sources.crawler", "src/wet_mcp/sources/crawler.py"
+        )
         crawler = importlib.util.module_from_spec(spec)
         sys.modules["wet_mcp.sources.crawler"] = crawler
         spec.loader.exec_module(crawler)

--- a/tests/test_file_url.py
+++ b/tests/test_file_url.py
@@ -45,31 +45,32 @@ async def test_extract_file_url_and_convert_concurrent(tmp_path):
         spec = importlib.util.spec_from_file_location(
             "wet_mcp.sources.crawler", "src/wet_mcp/sources/crawler.py"
         )
-        crawler = importlib.util.module_from_spec(spec)
-        sys.modules["wet_mcp.sources.crawler"] = crawler
-        spec.loader.exec_module(crawler)
+        if spec and spec.loader:
+            crawler = importlib.util.module_from_spec(spec)
+            sys.modules["wet_mcp.sources.crawler"] = crawler
+            spec.loader.exec_module(crawler)
 
-        # Test file:// URL
-        test_file = tmp_path / "test.txt"
-        test_file.write_text("Hello")
-        file_url = f"file://{test_file.absolute()}"
+            # Test file:// URL
+            test_file = tmp_path / "test.txt"
+            test_file.write_text("Hello")
+            file_url = f"file://{test_file.absolute()}"
 
-        mock_security.is_safe_local_path.side_effect = lambda p, **kwargs: Path(p)
+            mock_security.is_safe_local_path.side_effect = lambda p, **kwargs: Path(p)
 
-        result_json = await crawler.extract([file_url])
-        results = json.loads(result_json)
-        assert len(results) == 1
-        assert results[0]["url"] == file_url
-        assert results[0]["content"] == "Converted Content"
+            result_json = await crawler.extract([file_url])
+            results = json.loads(result_json)
+            assert len(results) == 1
+            assert results[0]["url"] == file_url
+            assert results[0]["content"] == "Converted Content"
 
-        # Test concurrent convert
-        test_file2 = tmp_path / "test2.txt"
-        test_file2.write_text("Hello 2")
+            # Test concurrent convert
+            test_file2 = tmp_path / "test2.txt"
+            test_file2.write_text("Hello 2")
 
-        result_json = await crawler.convert_local_files(
-            [str(test_file), str(test_file2)]
-        )
-        results = json.loads(result_json)
-        assert len(results) == 2
-        assert results[0]["content"] == "Converted Content"
-        assert results[1]["content"] == "Converted Content"
+            result_json = await crawler.convert_local_files(
+                [str(test_file), str(test_file2)]
+            )
+            results = json.loads(result_json)
+            assert len(results) == 2
+            assert results[0]["content"] == "Converted Content"
+            assert results[1]["content"] == "Converted Content"

--- a/tests/test_file_url.py
+++ b/tests/test_file_url.py
@@ -1,0 +1,70 @@
+import asyncio
+import json
+import os
+import sys
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, AsyncMock
+import pytest
+
+# This test uses isolated loading because of the complex dependency environment
+@pytest.mark.asyncio
+async def test_extract_file_url_and_convert_concurrent(tmp_path):
+    # Setup Mocks
+    with MagicMock() as mock_loguru, \
+         MagicMock() as mock_httpx, \
+         MagicMock() as mock_crawl4ai, \
+         MagicMock() as mock_aiolimiter, \
+         MagicMock() as mock_markitdown:
+
+        sys.modules["loguru"] = mock_loguru
+        sys.modules["httpx"] = mock_httpx
+        sys.modules["crawl4ai"] = mock_crawl4ai
+        sys.modules["aiolimiter"] = mock_aiolimiter
+        sys.modules["markitdown"] = mock_markitdown
+
+        mock_config = MagicMock()
+        mock_security = MagicMock()
+        sys.modules["wet_mcp"] = MagicMock()
+        sys.modules["wet_mcp.config"] = mock_config
+        sys.modules["wet_mcp.security"] = mock_security
+
+        class MockSettings:
+            convert_allowed_dirs = ""
+            convert_max_file_size = 100 * 1024 * 1024
+            crawler_timeout = 60
+
+        mock_config.settings = MockSettings()
+
+        mock_mid = MagicMock()
+        mock_mid.convert.return_value.text_content = "Converted Content"
+        mock_markitdown.MarkItDown.return_value = mock_mid
+
+        # Load module
+        spec = importlib.util.spec_from_file_location("wet_mcp.sources.crawler", "src/wet_mcp/sources/crawler.py")
+        crawler = importlib.util.module_from_spec(spec)
+        sys.modules["wet_mcp.sources.crawler"] = crawler
+        spec.loader.exec_module(crawler)
+
+        # Test file:// URL
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello")
+        file_url = f"file://{test_file.absolute()}"
+
+        mock_security.is_safe_local_path.side_effect = lambda p, **kwargs: Path(p)
+
+        result_json = await crawler.extract([file_url])
+        results = json.loads(result_json)
+        assert len(results) == 1
+        assert results[0]["url"] == file_url
+        assert results[0]["content"] == "Converted Content"
+
+        # Test concurrent convert
+        test_file2 = tmp_path / "test2.txt"
+        test_file2.write_text("Hello 2")
+
+        result_json = await crawler.convert_local_files([str(test_file), str(test_file2)])
+        results = json.loads(result_json)
+        assert len(results) == 2
+        assert results[0]["content"] == "Converted Content"
+        assert results[1]["content"] == "Converted Content"

--- a/tests/test_file_url.py
+++ b/tests/test_file_url.py
@@ -66,7 +66,9 @@ async def test_extract_file_url_and_convert_concurrent(tmp_path):
         test_file2 = tmp_path / "test2.txt"
         test_file2.write_text("Hello 2")
 
-        result_json = await crawler.convert_local_files([str(test_file), str(test_file2)])
+        result_json = await crawler.convert_local_files(
+            [str(test_file), str(test_file2)]
+        )
         results = json.loads(result_json)
         assert len(results) == 2
         assert results[0]["content"] == "Converted Content"

--- a/tests/test_real_comprehensive.py
+++ b/tests/test_real_comprehensive.py
@@ -12,7 +12,6 @@ Tests all configuration combinations:
 Run with: uv run pytest tests/test_real_comprehensive.py -v -m integration --timeout=120
 """
 
-import asyncio
 import json
 import os
 


### PR DESCRIPTION
- Added support for `file://` URLs in `extract` tool.
- Refactored `convert_local_files` for concurrency using `asyncio.gather`.
- Centralized local file validation and conversion in `_extract_local_file` helper.
- Added tests for `file://` extraction and concurrent conversion.
- Updated AGENTS.md backlog.

---
*PR created automatically by Jules for task [3365490881182174098](https://jules.google.com/task/3365490881182174098) started by @n24q02m*