### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in local file access

### DIFF
--- a/src/wet_mcp/security.py
+++ b/src/wet_mcp/security.py
@@ -94,7 +94,7 @@ def is_safe_local_path(
         return None
 
     # 4. Check against allowed directories
-    if allowed_dirs:
+    if allowed_dirs is not None:
         if not any(p.is_relative_to(d.resolve()) for d in allowed_dirs):
             logger.warning(f"Blocked path outside allowed dirs: {p}")
             return None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -330,3 +330,10 @@ def test_safe_local_path_oversized_file(tmp_path):
     f = tmp_path / "big.txt"
     f.write_text("x" * 200)
     assert is_safe_local_path(str(f), max_size=100) is None
+
+
+def test_safe_local_path_empty_allowed_dirs(tmp_path):
+    """Returns None when allowed_dirs is an empty list."""
+    f = tmp_path / "test.txt"
+    f.write_text("hello")
+    assert is_safe_local_path(str(f), allowed_dirs=[]) is None


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `is_safe_local_path` function had a logic flaw where it checked `if allowed_dirs:`. When `allowed_dirs` was intentionally set to an empty list `[]` to explicitly block all access, the condition evaluated to False and bypassed the allowlist check completely.
🎯 **Impact:** An attacker could potentially bypass intended restrictions and access unauthorized local files if an empty allowlist was utilized for defense.
🔧 **Fix:** Updated the condition to `if allowed_dirs is not None:`. This correctly differentiates between `None` (no restrictions) and `[]` (restrict all access).
✅ **Verification:** Verified via isolated unit tests that passing an empty list `[]` now correctly returns `None` (blocking the path) instead of returning the canonicalized path. Ran project linting rules with `ruff`.

---
*PR created automatically by Jules for task [16071891552642273472](https://jules.google.com/task/16071891552642273472) started by @n24q02m*