### PR TITLE
[TEST] Missing test for Exception path in close

### DIFF
--- a/src/wet_mcp/cache.py
+++ b/src/wet_mcp/cache.py
@@ -168,5 +168,5 @@ class WebCache:
         """Close database connection."""
         try:
             self._conn.close()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to close cache database connection: {e}")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,7 +5,7 @@ deterministic cache keys and stats.
 """
 
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -246,3 +246,13 @@ class TestCacheEdgeCases:
         result = cache.get("extract", {"urls": ["big"]})
         assert result == big_content
         assert len(result) == 1024 * 1024
+
+    def test_close_exception_handling(self, tmp_path):
+        """close() silently handles exceptions."""
+        mock_conn = MagicMock()
+        mock_conn.close.side_effect = Exception("Mock close error")
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            cache = WebCache(tmp_path / "mock.db")
+            # Should not raise
+            cache.close()


### PR DESCRIPTION
This PR adds a test case for the exception path in the \`WebCache.close()\` method and improves its observability by logging the exception at the debug level instead of silently passing.

### Changes:
- **src/wet_mcp/cache.py**: Replaced \`pass\` with \`logger.debug\` in \`WebCache.close()\` to capture non-fatal connection closure errors.
- **tests/test_cache.py**: Added \`test_close_exception_handling\` to cover the exception path in \`close()\`.

---
*PR created automatically by Jules for task [12814013849710226944](https://jules.google.com/task/12814013849710226944) started by @n24q02m*