### PR TITLE
[TEST] Missing test for credential config read failure

### DIFF
--- a/check_cov.py
+++ b/check_cov.py
@@ -1,0 +1,60 @@
+import sys
+import os
+import coverage
+from unittest.mock import patch, MagicMock
+
+# Force clean state for the module if it was already imported
+if "wet_mcp.credential_state" in sys.modules:
+    del sys.modules["wet_mcp.credential_state"]
+
+# Mock dependencies to avoid Pydantic/other issues
+sys.modules["mcp"] = MagicMock()
+sys.modules["mcp.server"] = MagicMock()
+sys.modules["mcp.server.fastmcp"] = MagicMock()
+sys.modules["mcp.types"] = MagicMock()
+
+cov = coverage.Coverage(include="src/wet_mcp/credential_state.py")
+cov.start()
+
+from wet_mcp.credential_state import resolve_credential_state, CredentialState, CLOUD_KEYS
+
+def run_tests():
+    print("Running tests...")
+    # 1. Env vars
+    with patch.dict(os.environ, {"GEMINI_API_KEY": "test"}):
+        print("Test 1: Env vars")
+        resolve_credential_state()
+
+    # 2. Config file success
+    with patch.dict(os.environ, {k: "" for k in CLOUD_KEYS}):
+        with patch("mcp_core.storage.config_file.read_config", return_value={"GEMINI_API_KEY": "test"}):
+            with patch("mcp_core.get_mode", return_value=None):
+                print("Test 2: Config file success")
+                resolve_credential_state()
+
+    # 3. Config file read error
+    with patch.dict(os.environ, {k: "" for k in CLOUD_KEYS}):
+        with patch("mcp_core.storage.config_file.read_config", side_effect=Exception("BOOM")):
+             with patch("mcp_core.get_mode", return_value=None):
+                print("Test 3: Config file read error")
+                resolve_credential_state()
+
+    # 4. Local mode
+    with patch.dict(os.environ, {k: "" for k in CLOUD_KEYS}):
+        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+            with patch("mcp_core.get_mode", return_value="local"):
+                print("Test 4: Local mode")
+                resolve_credential_state()
+
+    # 5. Local mode error
+    with patch.dict(os.environ, {k: "" for k in CLOUD_KEYS}):
+        with patch("mcp_core.storage.config_file.read_config", return_value=None):
+            with patch("mcp_core.get_mode", side_effect=Exception("BOOM")):
+                print("Test 5: Local mode error")
+                resolve_credential_state()
+
+run_tests()
+
+cov.stop()
+cov.save()
+cov.report(show_missing=True)

--- a/check_cov_v2.py
+++ b/check_cov_v2.py
@@ -1,0 +1,36 @@
+import sys
+import os
+import coverage
+from unittest.mock import patch, MagicMock
+
+# Force clean state for the module
+if "wet_mcp.credential_state" in sys.modules:
+    del sys.modules["wet_mcp.credential_state"]
+
+# Mock dependencies to avoid Pydantic/other issues
+sys.modules["mcp"] = MagicMock()
+sys.modules["mcp.server"] = MagicMock()
+sys.modules["mcp.server.fastmcp"] = MagicMock()
+sys.modules["mcp.types"] = MagicMock()
+
+cov = coverage.Coverage(source=["src/wet_mcp/credential_state.py"])
+cov.start()
+
+from wet_mcp.credential_state import resolve_credential_state, CredentialState, CLOUD_KEYS
+
+# 3. Config file read error (as in test_config_file_read_error)
+with patch.dict(os.environ, {k: "" for k in CLOUD_KEYS}):
+    with patch("mcp_core.storage.config_file.read_config", side_effect=Exception("BOOM")):
+            with patch("mcp_core.get_mode", return_value=None):
+                print("Test: Config file read error")
+                resolve_credential_state()
+
+cov.stop()
+cov.save()
+
+# Find lines 89-90
+data = cov.get_data()
+lines = data.lines(os.path.abspath("src/wet_mcp/credential_state.py"))
+print(f"Lines hit in 85-95 range: {[l for l in lines if 85 <= l <= 95]}")
+
+cov.report(show_missing=True)

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -128,6 +128,74 @@ class TestResolveCredentialState:
             result = resolve_credential_state()
             assert result == CredentialState.AWAITING_SETUP
 
+    def test_config_file_invalid_type(self, monkeypatch):
+        """Invalid type from read_config triggers exception and falls through."""
+        for k in CLOUD_KEYS:
+            monkeypatch.delenv(k, raising=False)
+
+        with (
+            patch(
+                "mcp_core.storage.config_file.read_config",
+                return_value=["not", "a", "dict"],
+            ),
+            patch(
+                "mcp_core.get_mode",
+                return_value=None,
+            ),
+        ):
+            result = resolve_credential_state()
+            assert result == CredentialState.AWAITING_SETUP
+
+    def test_config_file_share_keys_failure_falls_through(self, monkeypatch):
+        """Failure in _share_cloud_keys_to_peers is caught and falls through."""
+        for k in CLOUD_KEYS:
+            monkeypatch.delenv(k, raising=False)
+
+        saved = {"GEMINI_API_KEY": "from-file"}
+        with (
+            patch(
+                "mcp_core.storage.config_file.read_config",
+                return_value=saved,
+            ),
+            patch(
+                "wet_mcp.credential_state._share_cloud_keys_to_peers",
+                side_effect=RuntimeError("share failed"),
+            ),
+            patch(
+                "mcp_core.get_mode",
+                return_value=None,
+            ),
+        ):
+            result = resolve_credential_state()
+            # Since _share_cloud_keys_to_peers is called inside the try block,
+            # its failure will trigger the except Exception and fallback to next step
+            # (which is local mode check, then AWAITING_SETUP)
+            assert result == CredentialState.AWAITING_SETUP
+
+    def test_config_file_import_error(self, monkeypatch):
+        """Import error for read_config is caught and falls through."""
+        for k in CLOUD_KEYS:
+            monkeypatch.delenv(k, raising=False)
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "mcp_core.storage.config_file":
+                raise ImportError("mock import error")
+            return real_import(name, *args, **kwargs)
+
+        with (
+            patch.object(builtins, "__import__", side_effect=fake_import),
+            patch(
+                "mcp_core.get_mode",
+                return_value=None,
+            ),
+        ):
+            result = resolve_credential_state()
+            assert result == CredentialState.AWAITING_SETUP
+
     def test_local_mode_marker(self, monkeypatch):
         """When local mode marker is set, state = LOCAL."""
         for k in CLOUD_KEYS:


### PR DESCRIPTION
Add comprehensive test coverage for exception paths in `resolve_credential_state`.
The `except Exception` block at line 89 is now exercised by new tests covering:
- `ImportError` during dynamic module loading for `read_config`.
- `AttributeError` caused by invalid configuration data types.
- Runtime failures within the successful config-load block (e.g., in `_share_cloud_keys_to_peers`).

These additions ensure the fallback to `AWAITING_SETUP` mode is robust and remains
intact during credential discovery failures.

---
*PR created automatically by Jules for task [130790782965053327](https://jules.google.com/task/130790782965053327) started by @n24q02m*