### PR TITLE
[TEST] Untested process_url method in BaseCrawler

### DIFF
--- a/tests/test_crawler_document.py
+++ b/tests/test_crawler_document.py
@@ -1,0 +1,161 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wet_mcp.sources.crawler import _extract_with_markitdown, _is_document_url, extract
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://example.com/file.pdf", True),
+        ("https://example.com/file.DOCX", True),
+        ("https://example.com/file.html", False),
+        ("https://example.com/path/", False),
+        ("https://example.com/file.pptx?query=1", True),
+    ],
+)
+def test_is_document_url(url, expected):
+    assert _is_document_url(url) == expected
+
+
+@pytest.mark.asyncio
+async def test_extract_with_markitdown_success():
+    url = "https://example.com/test.pdf"
+    mock_content = b"PDF content"
+
+    mock_resp = MagicMock()
+    mock_resp.content = mock_content
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__.return_value = mock_client
+
+    mock_result = MagicMock()
+    mock_result.text_content = "Converted Markdown Content"
+
+    with (
+        patch("wet_mcp.sources.crawler._safe_httpx_client", return_value=mock_client),
+        patch("markitdown.MarkItDown"),
+        patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread,
+    ):
+        mock_thread.return_value = mock_result
+
+        result = await _extract_with_markitdown(url)
+
+        assert result["url"] == url
+        assert result["content"] == "Converted Markdown Content"
+        assert result["converter"] == "markitdown"
+        assert result["title"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_extract_with_markitdown_http_error():
+    url = "https://example.com/test.pdf"
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("HTTP Error")
+    mock_client.__aenter__.return_value = mock_client
+
+    with patch("wet_mcp.sources.crawler._safe_httpx_client", return_value=mock_client):
+        result = await _extract_with_markitdown(url)
+
+        assert "error" in result
+        assert "Document conversion failed" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_extract_with_markitdown_import_error():
+    url = "https://example.com/test.pdf"
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "markitdown":
+            raise ImportError("Mocked ImportError")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        result = await _extract_with_markitdown(url)
+        assert "error" in result
+        assert "markitdown not installed" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_extract_document_via_process_url(mock_crawler_instance):
+    """Test that extract() routes document URLs to markitdown."""
+    url = "https://example.com/document.pdf"
+    mock_doc_result = {
+        "url": url,
+        "title": "document",
+        "content": "Markitdown Content",
+        "converter": "markitdown",
+    }
+
+    with (
+        patch("wet_mcp.sources.crawler._is_document_url", return_value=True),
+        patch(
+            "wet_mcp.sources.crawler._extract_with_markitdown", new_callable=AsyncMock
+        ) as mock_md,
+        patch(
+            "wet_mcp.sources.crawler._get_crawler", return_value=mock_crawler_instance
+        ),
+    ):
+        mock_md.return_value = mock_doc_result
+
+        result_json = await extract([url])
+        results = json.loads(result_json)
+
+        assert len(results) == 1
+        assert results[0]["content"] == "Markitdown Content"
+        assert results[0]["converter"] == "markitdown"
+        mock_md.assert_called_once_with(url)
+        # Ensure browser-based crawler was NOT used for this URL
+        mock_crawler_instance.arun.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_extract_mixed_urls(mock_crawler_instance):
+    """Test extract() with a mix of web and document URLs."""
+    doc_url = "https://example.com/doc.pdf"
+    web_url = "https://example.com/page"
+
+    mock_doc_result = {
+        "url": doc_url,
+        "content": "PDF content",
+        "converter": "markitdown",
+    }
+
+    mock_web_result = MagicMock()
+    mock_web_result.success = True
+    mock_web_result.markdown = "Web content"
+    mock_web_result.metadata = {"title": "Web Title"}
+    mock_web_result.links = {"internal": [], "external": []}
+
+    mock_crawler_instance.arun = AsyncMock(return_value=mock_web_result)
+
+    with (
+        patch(
+            "wet_mcp.sources.crawler._extract_with_markitdown", new_callable=AsyncMock
+        ) as mock_md,
+        patch(
+            "wet_mcp.sources.crawler._get_crawler", return_value=mock_crawler_instance
+        ),
+    ):
+        mock_md.return_value = mock_doc_result
+
+        # We don't need to patch _is_document_url if it works correctly
+        result_json = await extract([doc_url, web_url])
+        results = json.loads(result_json)
+
+        assert len(results) == 2
+
+        doc_res = next(r for r in results if r["url"] == doc_url)
+        web_res = next(r for r in results if r["url"] == web_url)
+
+        assert doc_res["content"] == "PDF content"
+        assert web_res["content"] == "Web content"


### PR DESCRIPTION
Added comprehensive test coverage for the `process_url` inner function in `src/wet_mcp/sources/crawler.py`, specifically focusing on the document extraction routing logic.

Changes:
- Created `tests/test_crawler_document.py` with 10 test cases.
- Tested `_is_document_url` helper for various extensions and case sensitivity.
- Tested `_extract_with_markitdown` for:
    - Successful conversion (mocking `httpx` and `markitdown`).
    - HTTP errors during download.
    - `markitdown` import failures (graceful error message).
- Verified that `extract()` correctly routes document URLs to `markitdown` while sending other URLs to the browser-based crawler.
- Ensured all new and existing crawler tests pass.
- Verified linting and formatting for the new test file.

---
*PR created automatically by Jules for task [7950167076822758681](https://jules.google.com/task/7950167076822758681) started by @n24q02m*