### PR TITLE
[FIX] Remove unused import in sync.py

### DIFF
--- a/src/wet_mcp/sync.py
+++ b/src/wet_mcp/sync.py
@@ -243,7 +243,6 @@ async def _find_or_create_folder(token: dict, folder_name: str) -> str | None:
             return saved_id
 
     # 3. Search by name on Drive (retry for eventual consistency)
-    import asyncio
 
     query = (
         f"name='{folder_name}' and mimeType='application/vnd.google-apps.folder' "


### PR DESCRIPTION
Removed a redundant local `import asyncio` from the `_get_folder_id` function in `src/wet_mcp/sync.py`. `asyncio` was already imported at the top level of the module (line 23). This fix addresses the issue of unused/redundant imports in the sync module, resulting in cleaner code. Verified with `ruff check` and the full sync test suite (`tests/test_sync.py`, `tests/test_sync_comprehensive.py`, `tests/test_sync_coverage.py`).

---
*PR created automatically by Jules for task [3656906300444704879](https://jules.google.com/task/3656906300444704879) started by @n24q02m*