### PR TITLE
[TEST] Untested score_url method

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -2924,6 +2924,31 @@ def _is_i18n_url(path: str, root_path: str) -> bool:
     return f"/{lang_segment}/" not in root_path.lower()
 
 
+def _score_url_by_query(url: str, query_words: frozenset[str]) -> int:
+    """Score a URL based on query term overlap in its path."""
+    path = urlparse(url).path.lower()
+    path_words = set(
+        path.replace("-", " ")
+        .replace("_", " ")
+        .replace("/", " ")
+        .replace(".", " ")
+        .split()
+    )
+    return len(query_words & path_words)
+
+
+def _sort_urls_by_query(urls: list[str], query: str) -> list[str]:
+    """Sort URLs by query term overlap (highest first)."""
+    if not query or not urls:
+        return urls
+    query_words = frozenset(query.lower().split())
+
+    def score_url(url: str) -> int:
+        return _score_url_by_query(url, query_words)
+
+    return sorted(urls, key=score_url, reverse=True)
+
+
 async def _fetch_github_readme(repo_url: str) -> list[dict] | None:
     """Fetch just the README.md from a GitHub repository.
 
@@ -3534,25 +3559,6 @@ async def fetch_docs_pages(
             seen_urls.add(full_url)
         return urls
 
-    def _sort_by_query(urls: list[str]) -> list[str]:
-        """Sort URLs by query term overlap (highest first)."""
-        if not query or not urls:
-            return urls
-        query_words = frozenset(query.lower().split())
-
-        def score_url(url: str) -> int:
-            path = urlparse(url).path.lower()
-            path_words = set(
-                path.replace("-", " ")
-                .replace("_", " ")
-                .replace("/", " ")
-                .replace(".", " ")
-                .split()
-            )
-            return len(query_words & path_words)
-
-        return sorted(urls, key=score_url, reverse=True)
-
     # Process root page results
     blocked_count = 0
     for r in root_results:
@@ -3613,7 +3619,7 @@ async def fetch_docs_pages(
         seen_urls.add(su)
 
     # Sort by query relevance
-    pending_urls = _sort_by_query(pending_urls)
+    pending_urls = _sort_urls_by_query(pending_urls, query)
 
     # --- Fetch round 1 ---
     remaining = max_pages - len(pages)
@@ -3656,7 +3662,7 @@ async def fetch_docs_pages(
     # --- Fetch round 2 (depth-2 discovery) ---
     remaining = max_pages - len(pages)
     if remaining > 0 and pending_urls:
-        pending_urls = _sort_by_query(pending_urls)
+        pending_urls = _sort_urls_by_query(pending_urls, query)
         batch2_urls = pending_urls[:remaining]
         if batch2_urls:
             logger.info(f"Fetching {len(batch2_urls)} docs pages (round 2, depth-2)...")

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -3475,7 +3475,6 @@ def test_sort_urls_by_query_empty_cases():
 
     # Empty query returns original list
     assert _sort_urls_by_query(urls, "") == urls
-    assert _sort_urls_by_query(urls, None) == urls
 
     # Empty URLs returns empty list
     assert _sort_urls_by_query([], "query") == []

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -35,6 +35,8 @@ from wet_mcp.sources.docs import (
     _parse_objects_inv,
     _probe_docs_url,
     _safe_httpx_client,
+    _score_url_by_query,
+    _sort_urls_by_query,
     _strip_nav_blocks,
     _strip_nav_heading_blocks,
     _try_github_raw_docs,
@@ -3415,3 +3417,65 @@ def test_chunk_llms_txt_functional():
     assert chunks[0]["url"] == base_url
     assert "## Section 1" in chunks[0]["content"]
     assert "## Section 2" in chunks[1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# _score_url_by_query / _sort_urls_by_query
+# ---------------------------------------------------------------------------
+
+
+def test_score_url_by_query_matches():
+    """Score increases with query term overlap in path."""
+    query_words = frozenset(["auth", "guide"])
+
+    # 2 matches
+    assert _score_url_by_query("https://example.com/auth/guide", query_words) == 2
+    # 1 match (case insensitive)
+    assert (
+        _score_url_by_query("https://example.com/Auth/getting-started", query_words)
+        == 1
+    )
+    # 0 matches
+    assert _score_url_by_query("https://example.com/api/reference", query_words) == 0
+
+
+def test_score_url_by_query_delimiters():
+    """Score correctly handles various path delimiters."""
+    query_words = frozenset(["user", "login"])
+
+    # Hyphens
+    assert _score_url_by_query("https://example.com/user-login", query_words) == 2
+    # Underscores
+    assert _score_url_by_query("https://example.com/user_login", query_words) == 2
+    # Dots (e.g. file extensions)
+    assert _score_url_by_query("https://example.com/user.login.html", query_words) == 2
+    # Slashes
+    assert _score_url_by_query("https://example.com/user/login/", query_words) == 2
+
+
+def test_sort_urls_by_query_ordering():
+    """URLs are sorted by score descending."""
+    urls = [
+        "https://example.com/other",
+        "https://example.com/auth/login",
+        "https://example.com/auth/getting-started",
+    ]
+    query = "auth login"
+
+    sorted_urls = _sort_urls_by_query(urls, query)
+
+    assert sorted_urls[0] == "https://example.com/auth/login"  # 2 matches
+    assert sorted_urls[1] == "https://example.com/auth/getting-started"  # 1 match
+    assert sorted_urls[2] == "https://example.com/other"  # 0 matches
+
+
+def test_sort_urls_by_query_empty_cases():
+    """Handles empty inputs gracefully."""
+    urls = ["https://example.com/page"]
+
+    # Empty query returns original list
+    assert _sort_urls_by_query(urls, "") == urls
+    assert _sort_urls_by_query(urls, None) == urls
+
+    # Empty URLs returns empty list
+    assert _sort_urls_by_query([], "query") == []


### PR DESCRIPTION
Refactored nested sorting and scoring logic in fetch_docs_pages into module-level private helpers _score_url_by_query and _sort_urls_by_query. This allows for comprehensive unit testing of the URL relevance ranking logic. Added tests to tests/test_docs_coverage.py covering query term overlap scoring, path delimiter handling, and edge cases.

---
*PR created automatically by Jules for task [14764651987012626216](https://jules.google.com/task/14764651987012626216) started by @n24q02m*