### PR TITLE
[FIX] Refactor long function: import_jsonl

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -900,62 +900,66 @@ class DocsDB:
 
         return "\n".join(lines)
 
-    def import_jsonl(self, data: str, mode: str = "merge") -> dict:
-        """Import JSONL data. mode: merge (skip existing) or replace (clear first)."""
-        stats = {"libraries": 0, "versions": 0, "chunks": 0, "skipped": 0}
+    def _clear_for_import(self) -> None:
+        """Clear all tables before full import replace."""
+        if self._vec_enabled:
+            try:
+                self._conn.execute("DELETE FROM doc_chunks_vec")
+            except Exception:
+                logger.warning(
+                    "Failed to clear vector table during import replace",
+                    exc_info=True,
+                )
+        self._conn.execute("DELETE FROM doc_chunks")
+        self._conn.execute("DELETE FROM versions")
+        self._conn.execute("DELETE FROM libraries")
 
-        if mode == "replace":
-            if self._vec_enabled:
-                try:
-                    self._conn.execute("DELETE FROM doc_chunks_vec")
-                except Exception:
-                    logger.warning(
-                        "Failed to clear vector table during import replace",
-                        exc_info=True,
-                    )
-            self._conn.execute("DELETE FROM doc_chunks")
-            self._conn.execute("DELETE FROM versions")
-            self._conn.execute("DELETE FROM libraries")
-
+    def _parse_jsonl_data(self, data: str) -> tuple[list, list, list]:
+        """Parse JSONL data into libraries, versions, and chunks lists."""
         lines = data.strip().split("\n")
-
         libraries = []
         versions = []
         chunks = []
-
         for line in lines:
             if not line.strip():
                 continue
             obj = json.loads(line)
             obj_type = obj.pop("_type", None)
-
             if obj_type == "library":
                 libraries.append(obj)
             elif obj_type == "version":
                 versions.append(obj)
             elif obj_type == "chunk":
                 chunks.append(obj)
+        return libraries, versions, chunks
 
-        def _get_existing(table: str, items: list) -> set:
-            if table not in {"libraries", "versions", "doc_chunks"}:
-                raise ValueError(f"Invalid table name: {table}")
-            if not items:
-                return set()
-            ids = [obj["id"] for obj in items]
-            existing = set()
-            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
-            for i in range(0, len(ids), batch_size):
-                batch = ids[i : i + batch_size]
-                placeholders = ",".join("?" * len(batch))
-                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                res = self._conn.execute(
-                    f"SELECT id FROM {table} WHERE id IN ({placeholders})", batch
-                ).fetchall()
-                existing.update(r[0] for r in res)
-            return existing
+    def _get_existing_ids(self, table: str, items: list) -> set:
+        """Get existing IDs for a table to support merge mode."""
+        allowed_tables = {
+            "libraries": "SELECT id FROM libraries WHERE id IN ({})",
+            "versions": "SELECT id FROM versions WHERE id IN ({})",
+            "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN ({})",
+        }
+        if table not in allowed_tables:
+            raise ValueError(f"Invalid table name: {table}")
+        if not items:
+            return set()
+        ids = [obj["id"] for obj in items]
+        existing = set()
+        batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+        for i in range(0, len(ids), batch_size):
+            batch = ids[i : i + batch_size]
+            placeholders = ",".join("?" * len(batch))
+            sql = allowed_tables[table].format(placeholders)
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+            res = self._conn.execute(sql, batch).fetchall()
+            existing.update(r[0] for r in res)
+        return existing
 
+    def _import_libraries(self, libraries: list, mode: str, stats: dict) -> None:
+        """Process and insert libraries."""
         existing_libs = (
-            _get_existing("libraries", libraries) if mode == "merge" else set()
+            self._get_existing_ids("libraries", libraries) if mode == "merge" else set()
         )
         to_insert_libs = []
         for obj in libraries:
@@ -984,8 +988,10 @@ class DocsDB:
             )
             stats["libraries"] += len(to_insert_libs)
 
+    def _import_versions(self, versions: list, mode: str, stats: dict) -> None:
+        """Process and insert versions."""
         existing_vers = (
-            _get_existing("versions", versions) if mode == "merge" else set()
+            self._get_existing_ids("versions", versions) if mode == "merge" else set()
         )
         to_insert_vers = []
         for obj in versions:
@@ -1015,8 +1021,10 @@ class DocsDB:
             )
             stats["versions"] += len(to_insert_vers)
 
+    def _import_chunks(self, chunks: list, mode: str, stats: dict) -> None:
+        """Process and insert chunks."""
         existing_chunks = (
-            _get_existing("doc_chunks", chunks) if mode == "merge" else set()
+            self._get_existing_ids("doc_chunks", chunks) if mode == "merge" else set()
         )
         to_insert_chunks = []
         for obj in chunks:
@@ -1046,6 +1054,19 @@ class DocsDB:
                 to_insert_chunks,
             )
             stats["chunks"] += len(to_insert_chunks)
+
+    def import_jsonl(self, data: str, mode: str = "merge") -> dict:
+        """Import JSONL data. mode: merge (skip existing) or replace (clear first)."""
+        stats = {"libraries": 0, "versions": 0, "chunks": 0, "skipped": 0}
+
+        if mode == "replace":
+            self._clear_for_import()
+
+        libraries, versions, chunks = self._parse_jsonl_data(data)
+
+        self._import_libraries(libraries, mode, stats)
+        self._import_versions(versions, mode, stats)
+        self._import_chunks(chunks, mode, stats)
 
         self._conn.commit()
         return stats


### PR DESCRIPTION
Refactored the long `import_jsonl` function in `src/wet_mcp/db.py` into smaller, private methods for better maintainability and security.

Key changes:
- Extracted `_clear_for_import` to handle table cleanup in replace mode.
- Extracted `_parse_jsonl_data` to handle JSONL parsing into separate entity lists.
- Extracted `_get_existing_ids` to handle secure, batched ID lookups for merge mode.
- Extracted `_import_libraries`, `_import_versions`, and `_import_chunks` to handle data transformation and batch insertion for each entity type.
- Updated `import_jsonl` to orchestrate these private methods.

Verification:
- Ran `uv run pytest tests/test_db.py tests/test_db_coverage.py tests/test_db_extra.py` (All 126 tests passed).
- Ran `uv tool run ruff check src/wet_mcp/db.py` (All checks passed).
- Verified syntax with `ast.parse`.

---
*PR created automatically by Jules for task [4040670048299511814](https://jules.google.com/task/4040670048299511814) started by @n24q02m*