### PR TITLE
[FIX] Refactor overly long function: _probe_docs_url

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -30,6 +30,54 @@ from wet_mcp.security import safe_httpx_client as _safe_httpx_client
 # Bump this whenever discovery scoring or crawl logic changes.
 # Libraries cached with an older version are automatically re-indexed.
 DISCOVERY_VERSION = 27
+# Generic package names that collide with unrelated RTD projects
+_GENERIC_NAMES = frozenset(
+    {
+        "core",
+        "react",
+        "cli",
+        "common",
+        "utils",
+        "types",
+        "client",
+        "server",
+        "api",
+        "app",
+        "config",
+        "test",
+        "ui",
+        "web",
+    }
+)
+
+# Hostnames where we should skip probing the docs. subdomain
+_SKIP_DOCS_SUBDOMAINS = frozenset(
+    {
+        "github.com",
+        "github.io",
+        "gitlab.com",
+        "bitbucket.org",
+        "pypi.org",
+        "npmjs.com",
+        "npmjs.org",
+        "crates.io",
+    }
+)
+
+# Registries where ReadTheDocs is unlikely to be the primary docs host
+_RTD_SKIP_REGISTRIES = frozenset({"npm", "crates", "go"})
+
+# URL path segments that indicate an auth/account page (false positives)
+_AUTH_PATH_SEGMENTS = frozenset(
+    {
+        "/login",
+        "/signin",
+        "/signup",
+        "/account",
+        "/auth",
+        "/register",
+    }
+)
 
 
 def _github_headers() -> dict[str, str]:
@@ -807,6 +855,161 @@ async def _get_github_homepage(url: str) -> str | None:
     return None
 
 
+def _normalize_lib_name(lib_name: str) -> tuple[str, str, str]:
+    """Normalize library name for probing.
+
+    Example: "@nestjs/core" → scope="nestjs", pkg="core", clean_name_norm="core"
+    """
+    pkg_part = lib_name.lower().lstrip("@")
+    scope_part = ""
+    if "/" in pkg_part:
+        scope_part = pkg_part.split("/")[0]
+        pkg_part = pkg_part.split("/")[-1]
+
+    clean_name = pkg_part
+    clean_name_norm = clean_name.replace("-", "").replace("_", "")
+    return scope_part, clean_name, clean_name_norm
+
+
+def _get_probe_candidates(
+    homepage: str, lib_name: str, registry: str = ""
+) -> list[tuple[str, str]]:
+    """Generate potential documentation URL candidates."""
+    parsed = urlparse(homepage)
+    netloc = parsed.netloc
+    base_domain = netloc.removeprefix("www.") if netloc.startswith("www.") else netloc
+    scope_part, clean_name, _ = _normalize_lib_name(lib_name)
+
+    candidates: list[tuple[str, str]] = []
+
+    # 1. docs.{domain} subdomain
+    if not base_domain.startswith("docs.") and base_domain not in _SKIP_DOCS_SUBDOMAINS:
+        candidates.append(("docs_subdomain", f"https://docs.{base_domain}/"))
+
+    # 2. ReadTheDocs: probe {name}.readthedocs.io
+    if (
+        "readthedocs" not in base_domain
+        and clean_name not in _GENERIC_NAMES
+        and registry not in _RTD_SKIP_REGISTRIES
+    ):
+        rtd_name = scope_part or clean_name
+        if len(rtd_name) > 4:
+            candidates.append(
+                ("readthedocs", f"https://{rtd_name}.readthedocs.io/en/latest/")
+            )
+
+    # 3. {homepage}/docs/ path
+    if len(parsed.path.strip("/")) <= 1:
+        docs_path_url = f"{parsed.scheme}://{parsed.netloc}/docs/"
+        candidates.append(("docs_path", docs_path_url))
+
+    return candidates
+
+
+def _validate_sphinx_inventory(
+    inv_content: bytes, label: str, lib_name: str, clean_name_norm: str
+) -> bool:
+    """Validate a Sphinx objects.inv file."""
+    if not inv_content[:30].startswith(b"# Sphinx inventory version"):
+        return False
+
+    if label != "readthedocs":
+        return True
+
+    # For ReadTheDocs: validate project name matches lib
+    # and has enough objects (>= 50) to be real docs,
+    # not a squatter/placeholder project.
+    inv_text = inv_content[:500].decode("utf-8", errors="replace")
+    proj_match = re.search(r"^# Project:\s*(.+)$", inv_text, re.MULTILINE)
+    if proj_match:
+        proj_name = (
+            proj_match.group(1)
+            .strip()
+            .lower()
+            .replace("-", "")
+            .replace("_", "")
+            .replace(" ", "")
+        )
+        if clean_name_norm not in proj_name:
+            logger.debug(
+                f"RTD project '{proj_match.group(1).strip()}'"
+                f" doesn't match '{lib_name}', skipping"
+            )
+            return False
+
+    # Count objects: real docs have 50+, squatters < 30
+    try:
+        # Find end of header (4 lines starting with #)
+        hdr_pos = 0
+        for _ in range(4):
+            hdr_pos = inv_content.index(b"\n", hdr_pos) + 1
+        decompressed = zlib.decompress(inv_content[hdr_pos:])
+        obj_count = len(decompressed.split(b"\n")) - 1
+        if obj_count < 50:
+            logger.debug(
+                f"RTD {lib_name}: only {obj_count} objects, likely squatter — skipping"
+            )
+            return False
+    except Exception:
+        # Can't count objects — reject for safety
+        return False
+
+    return True
+
+
+async def _check_candidate_url(
+    client: httpx.AsyncClient,
+    label: str,
+    url: str,
+    homepage_netloc: str,
+    lib_name: str,
+    clean_name_norm: str,
+) -> tuple[str, str, int, bool] | None:
+    """Check a candidate documentation URL."""
+    try:
+        resp = await client.get(url)
+        if resp.status_code != 200:
+            return None
+        content = resp.text
+        content_len = len(content)
+        # Must be substantial HTML/text, not an error page
+        if content_len < 500:
+            return None
+        final_url = str(resp.url)
+        # Reject login/auth/account pages (false positive redirects)
+        final_path = urlparse(final_url).path.lower()
+        if any(seg in final_path for seg in _AUTH_PATH_SEGMENTS):
+            return None
+        # Avoid redirect loops back to the original homepage
+        if urlparse(final_url).netloc == homepage_netloc and label not in (
+            "docs_path",
+            "original",
+        ):
+            final_parsed = urlparse(final_url)
+            if not final_parsed.path.startswith("/docs"):
+                if "docs" not in final_parsed.netloc:
+                    return None
+
+        # Check for objects.inv (Sphinx docs indicator)
+        has_inv = False
+        inv_url = final_url.rstrip("/") + "/objects.inv"
+        try:
+            inv_resp = await client.get(inv_url)
+            if inv_resp.status_code == 200:
+                has_inv = _validate_sphinx_inventory(
+                    inv_resp.content, label, lib_name, clean_name_norm
+                )
+        except Exception:
+            pass
+
+        # ReadTheDocs without objects.inv is unreliable — skip
+        if label == "readthedocs" and not has_inv:
+            return None
+        return (label, final_url, content_len, has_inv)
+    except Exception:
+        return None
+
+
 async def _probe_docs_url(homepage: str, lib_name: str, registry: str = "") -> str:
     """Probe for a better documentation URL than the project homepage.
 
@@ -820,191 +1023,30 @@ async def _probe_docs_url(homepage: str, lib_name: str, registry: str = "") -> s
     Probes these alternatives in parallel. Returns the best URL found,
     preferring URLs with Sphinx ``objects.inv`` (guaranteed rich docs).
     Falls back to ``homepage`` if no better alternative exists.
-
-    ReadTheDocs results are validated by parsing the ``objects.inv`` header
-    project name — must match the library name to prevent false positives
-    (e.g., ``chi.readthedocs.io`` being an unrelated Python project).
     """
-    parsed = urlparse(homepage)
-    netloc = parsed.netloc
-    base_domain = netloc.removeprefix("www.") if netloc.startswith("www.") else netloc
-    # Normalize lib name for probing:
-    # "@nestjs/core" → scope="nestjs", pkg="core"
-    # "solid-js" → scope="", pkg="solid-js"
-    scope_part = ""
-    pkg_part = lib_name.lower().lstrip("@")
-    if "/" in pkg_part:
-        scope_part = pkg_part.split("/")[0]
-        pkg_part = pkg_part.split("/")[-1]
-    clean_name = pkg_part
-    # Normalized for matching (no hyphens/underscores)
-    clean_name_norm = clean_name.replace("-", "").replace("_", "")
-    # Generic package names that collide with unrelated RTD projects
-    _GENERIC_NAMES = frozenset(
-        {
-            "core",
-            "react",
-            "cli",
-            "common",
-            "utils",
-            "types",
-            "client",
-            "server",
-            "api",
-            "app",
-            "config",
-            "test",
-            "ui",
-            "web",
-        }
-    )
-
-    candidates: list[tuple[str, str]] = []
-
-    # 1. docs.{domain} subdomain — skip for generic hosting domains
-    # (docs.github.com is GitHub's own docs, not project docs)
-    # (docs.pypi.org is PyPI's own API docs, not project docs)
-    _skip_docs_subdomain = {
-        "github.com",
-        "github.io",
-        "gitlab.com",
-        "bitbucket.org",
-        "pypi.org",
-        "npmjs.com",
-        "npmjs.org",
-        "crates.io",
-    }
-    if not base_domain.startswith("docs.") and base_domain not in _skip_docs_subdomain:
-        candidates.append(("docs_subdomain", f"https://docs.{base_domain}/"))
-
-    # 2. ReadTheDocs: probe {name}.readthedocs.io when not already on RTD.
-    # Skip for generic package names and very short names (<=4 chars).
-    # Skip for non-Python registries (npm, crates, go) — RTD is almost
-    # exclusively used by Python projects, so probing for React/Rust/Go
-    # libs would match unrelated Python packages with the same name.
-    # Validated via objects.inv: project name must match + object count >= 50
-    # to reject squatter/placeholder projects (real docs have 50+ objects).
-    _rtd_skip_registries = {"npm", "crates", "go"}
-    if (
-        "readthedocs" not in base_domain
-        and clean_name not in _GENERIC_NAMES
-        and registry not in _rtd_skip_registries
-    ):
-        rtd_name = scope_part or clean_name
-        if len(rtd_name) > 4:
-            candidates.append(
-                ("readthedocs", f"https://{rtd_name}.readthedocs.io/en/latest/")
-            )
-
-    # 3. {homepage}/docs/ path (only if homepage has no path or short path)
-    if len(parsed.path.strip("/")) <= 1:
-        docs_path_url = f"{parsed.scheme}://{parsed.netloc}/docs/"
-        candidates.append(("docs_path", docs_path_url))
+    _, _, clean_name_norm = _normalize_lib_name(lib_name)
+    candidates = _get_probe_candidates(homepage, lib_name, registry)
 
     if not candidates:
         return homepage
 
     # Include the original homepage as a candidate so it competes fairly.
-    # This prevents ReadTheDocs/docs subdomain from incorrectly overriding
-    # an already-good docs URL (e.g. docs.djangoproject.com → django.readthedocs.io).
     candidates.insert(0, ("original", homepage))
-
-    async def _check(
-        client: httpx.AsyncClient, label: str, url: str
-    ) -> tuple[str, str, int, bool] | None:
-        try:
-            resp = await client.get(url)
-            if resp.status_code != 200:
-                return None
-            content = resp.text
-            content_len = len(content)
-            # Must be substantial HTML/text, not an error page
-            if content_len < 500:
-                return None
-            final_url = str(resp.url)
-            # Reject login/auth/account pages (false positive redirects)
-            final_path = urlparse(final_url).path.lower()
-            _auth_segments = (
-                "/login",
-                "/signin",
-                "/signup",
-                "/account",
-                "/auth",
-                "/register",
-            )
-            if any(seg in final_path for seg in _auth_segments):
-                return None
-            # Avoid redirect loops back to the original homepage
-            if urlparse(final_url).netloc == parsed.netloc and label not in (
-                "docs_path",
-                "original",
-            ):
-                final_parsed = urlparse(final_url)
-                if not final_parsed.path.startswith("/docs"):
-                    if "docs" not in final_parsed.netloc:
-                        return None
-            # Check for objects.inv (Sphinx docs indicator)
-            has_inv = False
-            inv_url = final_url.rstrip("/") + "/objects.inv"
-            try:
-                inv_resp = await client.get(inv_url)
-                if inv_resp.status_code == 200 and inv_resp.content[:30].startswith(
-                    b"# Sphinx inventory version"
-                ):
-                    # For ReadTheDocs: validate project name matches lib
-                    # and has enough objects (>= 50) to be real docs,
-                    # not a squatter/placeholder project.
-                    if label == "readthedocs":
-                        inv_content = inv_resp.content
-                        inv_text = inv_content[:500].decode("utf-8", errors="replace")
-                        proj_match = re.search(
-                            r"^# Project:\s*(.+)$", inv_text, re.MULTILINE
-                        )
-                        if proj_match:
-                            proj_name = (
-                                proj_match.group(1)
-                                .strip()
-                                .lower()
-                                .replace("-", "")
-                                .replace("_", "")
-                                .replace(" ", "")
-                            )
-                            if clean_name_norm not in proj_name:
-                                logger.debug(
-                                    f"RTD project '{proj_match.group(1).strip()}'"
-                                    f" doesn't match '{lib_name}', skipping"
-                                )
-                                return None
-                        # Count objects: real docs have 50+, squatters < 30
-                        try:
-                            # Find end of header (4 lines starting with #)
-                            hdr_pos = 0
-                            for _ in range(4):
-                                hdr_pos = inv_content.index(b"\n", hdr_pos) + 1
-                            decompressed = zlib.decompress(inv_content[hdr_pos:])
-                            obj_count = len(decompressed.split(b"\n")) - 1
-                            if obj_count < 50:
-                                logger.debug(
-                                    f"RTD {lib_name}: only {obj_count} "
-                                    f"objects, likely squatter — skipping"
-                                )
-                                return None
-                        except Exception:
-                            # Can't count objects — reject for safety
-                            return None
-                    has_inv = True
-            except Exception:
-                pass
-            # ReadTheDocs without objects.inv is unreliable — skip
-            if label == "readthedocs" and not has_inv:
-                return None
-            return (label, final_url, content_len, has_inv)
-        except Exception:
-            return None
+    homepage_netloc = urlparse(homepage).netloc
 
     async with _safe_httpx_client(timeout=10, follow_redirects=True) as client:
         results = await asyncio.gather(
-            *[_check(client, label, url) for label, url in candidates],
+            *[
+                _check_candidate_url(
+                    client,
+                    label,
+                    url,
+                    homepage_netloc,
+                    lib_name,
+                    clean_name_norm,
+                )
+                for label, url in candidates
+            ],
             return_exceptions=True,
         )
 
@@ -1025,6 +1067,7 @@ async def _probe_docs_url(homepage: str, lib_name: str, registry: str = "") -> s
             score += 5
         elif size > 500:
             score += 2
+
         # docs subdomain gets small bonus (same org, high confidence)
         if label == "docs_subdomain":
             score += 3
@@ -1032,6 +1075,7 @@ async def _probe_docs_url(homepage: str, lib_name: str, registry: str = "") -> s
         # only replace if an alternative is strictly superior.
         if label == "original":
             score += 5
+
         if score > best_score:
             best_score = score
             best = (label, final_url)


### PR DESCRIPTION
This PR refactors the `_probe_docs_url` function in `src/wet_mcp/sources/docs.py`, which was identified as being overly long and complex.

### Changes:
- **Constant Extraction**: Moved `_GENERIC_NAMES`, `_SKIP_DOCS_SUBDOMAINS`, `_RTD_SKIP_REGISTRIES`, and `_AUTH_PATH_SEGMENTS` to the module level.
- **Modularization**: Decomposed the logic into four specific helper functions:
    - `_normalize_lib_name`: Handles parsing of library names (e.g., scoped packages).
    - `_get_probe_candidates`: Centralizes the generation of potential documentation URL candidates.
    - `_validate_sphinx_inventory`: Logic for parsing and validating `objects.inv` files.
    - `_check_candidate_url`: An async function that probes and validates individual candidates.
- **Function Simplification**: The main `_probe_docs_url` function now acts as a high-level orchestrator.

### Impact:
The refactoring improves code maintainability and testability without altering the existing functionality.

### Verification:
- Ran `pytest tests/test_docs_coverage.py` and `pytest tests/test_docs_comprehensive.py` (all 183 tests passed).
- Verified syntax with `ast.parse`.
- Ran `ruff` for linting and formatting.

---
*PR created automatically by Jules for task [9672493322643197673](https://jules.google.com/task/9672493322643197673) started by @n24q02m*