### PR TITLE
[FIX] Remove unused import in relay_setup.py

### DIFF
--- a/src/wet_mcp/relay_setup.py
+++ b/src/wet_mcp/relay_setup.py
@@ -7,8 +7,6 @@ Resolution order (relay only when ALL local sources are empty):
 4. LOCAL MODE        -- Fallback (ONNX embedding, SearXNG search)
 """
 
-from __future__ import annotations
-
 import os
 import sys
 


### PR DESCRIPTION
This PR removes the redundant `from __future__ import annotations` import from `src/wet_mcp/relay_setup.py`. 

Since the project uses Python 3.13, this import is no longer necessary for the type hint syntax used in this module (e.g., `dict[str, str] | None`). The other unused imports mentioned in the task (`asyncio`, `List`) were not found in the file and were likely already removed or were part of a draft.

Verification:
- Ran `uv run ruff check src/wet_mcp/relay_setup.py` (passed).
- Ran `uv run ruff format src/wet_mcp/relay_setup.py` (applied).
- Ran `uv run pytest tests/test_relay_setup.py` (15 passed).

---
*PR created automatically by Jules for task [7457107722998383212](https://jules.google.com/task/7457107722998383212) started by @n24q02m*