### PR TITLE
[FIX] Refactor long function: _fetch_and_chunk_docs

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1516,6 +1516,90 @@ async def _do_research(
 _MIN_GH_CHUNKS = 20
 
 
+async def _chunk_pages(pages: list[dict]) -> list[dict]:
+    """Helper to chunk multiple pages into searchable chunks."""
+    from wet_mcp.sources.docs import chunk_markdown
+
+    chunks: list[dict] = []
+    for page in pages:
+        page_chunks = await asyncio.to_thread(
+            chunk_markdown,
+            content=page["content"],
+            url=page.get("url", ""),
+        )
+        for chunk in page_chunks:
+            if not chunk.get("title") and page.get("title"):
+                chunk["title"] = page["title"]
+        chunks.extend(page_chunks)
+    return chunks
+
+async def _try_tier_llms_txt(docs_url: str) -> list[dict] | None:
+    """Tier 0: Try llms.txt (fastest, best quality)."""
+    from wet_mcp.sources.docs import chunk_llms_txt, try_llms_txt
+
+    llms_content = await try_llms_txt(docs_url)
+    if llms_content:
+        chunks = chunk_llms_txt(llms_content, base_url=docs_url)
+        if len(chunks) >= _MIN_GH_CHUNKS:
+            logger.info(f"Indexed {len(chunks)} chunks from llms.txt")
+            return chunks
+        else:
+            logger.info(
+                f"llms.txt produced only {len(chunks)} chunks "
+                f"(min {_MIN_GH_CHUNKS}), falling through"
+            )
+    return None
+
+
+async def _try_tier_github_raw(
+    docs_url: str, repo_url: str, library_hint: str
+) -> tuple[list[dict], int] | None:
+    """Tier 1: Try GitHub raw markdown (clean content, no JS rendering)."""
+    from wet_mcp.sources.docs import _try_github_raw_docs
+
+    gh_target = repo_url or docs_url
+    gh_pages = await _try_github_raw_docs(
+        gh_target, max_files=50, library_hint=library_hint
+    )
+    if not gh_pages:
+        return None
+
+    gh_chunks = await _chunk_pages(gh_pages)
+    return gh_chunks, len(gh_pages)
+
+
+async def _try_tier_crawl(docs_url: str, query: str) -> tuple[list[dict], int] | None:
+    """Tier 2: Crawl docs pages (rendered HTML -> markdown)."""
+    from wet_mcp.sources.docs import fetch_docs_pages
+
+    pages = await fetch_docs_pages(
+        docs_url=docs_url,
+        query=query,
+        max_pages=50,
+    )
+    if not pages:
+        return None
+
+    chunks = await _chunk_pages(pages)
+    return chunks, len(pages)
+
+
+
+async def _try_tier_readme_fallback(repo_url: str, docs_url: str) -> list[dict] | None:
+    """Tier 3: Last-resort README fallback."""
+    from wet_mcp.sources.docs import _fetch_github_readme
+
+    readme_chunks = await _fetch_github_readme(repo_url or docs_url)
+    if readme_chunks:
+        logger.info(
+            f"All tiers failed, using {len(readme_chunks)} chunks "
+            "from GitHub README (last resort)"
+        )
+        return readme_chunks
+    return None
+
+
+
 async def _fetch_and_chunk_docs(
     docs_url: str,
     repo_url: str = "",
@@ -1532,58 +1616,25 @@ async def _fetch_and_chunk_docs(
     Returns:
         Tuple of (chunks, page_count).
     """
-    from wet_mcp.sources.docs import (
-        _try_github_raw_docs,
-        chunk_llms_txt,
-        chunk_markdown,
-        fetch_docs_pages,
-        try_llms_txt,
-    )
-
     # Tier 0: Try llms.txt (fastest, best quality)
-    llms_content = await try_llms_txt(docs_url)
-    if llms_content:
-        chunks = chunk_llms_txt(llms_content, base_url=docs_url)
-        # Quality gate: skip llms.txt if it's too small (likely a TOC/meta file)
-        if len(chunks) >= _MIN_GH_CHUNKS:
-            logger.info(f"Indexed {len(chunks)} chunks from llms.txt")
-            return chunks, 1
-        else:
-            logger.info(
-                f"llms.txt produced only {len(chunks)} chunks "
-                f"(min {_MIN_GH_CHUNKS}), falling through"
-            )
+    llms_chunks = await _try_tier_llms_txt(docs_url)
+    if llms_chunks:
+        return llms_chunks, 1
 
     # Tier 1: Try GitHub raw markdown (clean content, no JS rendering)
-    gh_target = repo_url or docs_url
-    gh_pages = await _try_github_raw_docs(
-        gh_target, max_files=50, library_hint=library_hint
-    )
+    gh_result = await _try_tier_github_raw(docs_url, repo_url, library_hint)
     gh_chunks: list[dict] = []
     gh_page_count = 0
-    if gh_pages:
-        for page in gh_pages:
-            page_chunks = await asyncio.to_thread(
-                chunk_markdown,
-                content=page["content"],
-                url=page.get("url", ""),
-            )
-            for chunk in page_chunks:
-                if not chunk.get("title") and page.get("title"):
-                    chunk["title"] = page["title"]
-            gh_chunks.extend(page_chunks)
-        gh_page_count = len(gh_pages)
-
-        # Quality gate: if GitHub raw produced too few meaningful chunks,
-        # fall through to Tier 2 (crawl docs site). This handles repos
-        # where docs use template macros (Polars), RST, or other formats
-        # that produce poor raw markdown.
+    if gh_result:
+        gh_chunks, gh_page_count = gh_result
+        # Quality gate: if GitHub raw produced enough meaningful chunks, use it.
+        # Otherwise, fall through to Tier 2 (crawl docs site).
         if len(gh_chunks) >= _MIN_GH_CHUNKS:
             logger.info(
-                f"Indexed {len(gh_chunks)} chunks from {len(gh_pages)} "
+                f"Indexed {len(gh_chunks)} chunks from {gh_page_count} "
                 "GitHub raw markdown files"
             )
-            return gh_chunks, len(gh_pages)
+            return gh_chunks, gh_page_count
         else:
             logger.info(
                 f"GitHub raw produced only {len(gh_chunks)} chunks "
@@ -1591,22 +1642,11 @@ async def _fetch_and_chunk_docs(
             )
 
     # Tier 2: Crawl docs pages (rendered HTML -> markdown)
-    pages = await fetch_docs_pages(
-        docs_url=docs_url,
-        query=query,
-        max_pages=50,
-    )
+    crawl_result = await _try_tier_crawl(docs_url, query)
     chunks: list[dict] = []
-    for page in pages:
-        page_chunks = await asyncio.to_thread(
-            chunk_markdown,
-            content=page["content"],
-            url=page.get("url", ""),
-        )
-        for chunk in page_chunks:
-            if not chunk.get("title") and page.get("title"):
-                chunk["title"] = page["title"]
-        chunks.extend(page_chunks)
+    page_count = 0
+    if crawl_result:
+        chunks, page_count = crawl_result
 
     # If Tier 2 crawl produced no results (e.g. Cloudflare blocked) but
     # Tier 1 GitHub raw had some content (below threshold), use it instead
@@ -1620,23 +1660,13 @@ async def _fetch_and_chunk_docs(
         return gh_chunks, gh_page_count
 
     # Tier 3: Last-resort README fallback.
-    # When all tiers fail AND we have a GitHub repo, fetch just the
-    # README.md.  This handles repos without a docs/ directory whose
-    # docs site is also uncrawlable (Cloudflare, JS-rendered, etc.).
     if not chunks:
-        from wet_mcp.sources.docs import _fetch_github_readme
-
-        readme_chunks = await _fetch_github_readme(repo_url or docs_url)
+        readme_chunks = await _try_tier_readme_fallback(repo_url, docs_url)
         if readme_chunks:
-            logger.info(
-                f"All tiers failed, using {len(readme_chunks)} chunks "
-                "from GitHub README (last resort)"
-            )
             return readme_chunks, 1
 
-    logger.info(f"Indexed {len(chunks)} chunks from {len(pages)} pages")
-    return chunks, len(pages)
-
+    logger.info(f"Indexed {len(chunks)} chunks from {page_count} pages")
+    return chunks, page_count
 
 # ---------------------------------------------------------------------------
 # Docs search (library documentation with auto-indexing)

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1533,6 +1533,7 @@ async def _chunk_pages(pages: list[dict]) -> list[dict]:
         chunks.extend(page_chunks)
     return chunks
 
+
 async def _try_tier_llms_txt(docs_url: str) -> list[dict] | None:
     """Tier 0: Try llms.txt (fastest, best quality)."""
     from wet_mcp.sources.docs import chunk_llms_txt, try_llms_txt
@@ -1584,7 +1585,6 @@ async def _try_tier_crawl(docs_url: str, query: str) -> tuple[list[dict], int] |
     return chunks, len(pages)
 
 
-
 async def _try_tier_readme_fallback(repo_url: str, docs_url: str) -> list[dict] | None:
     """Tier 3: Last-resort README fallback."""
     from wet_mcp.sources.docs import _fetch_github_readme
@@ -1597,7 +1597,6 @@ async def _try_tier_readme_fallback(repo_url: str, docs_url: str) -> list[dict] 
         )
         return readme_chunks
     return None
-
 
 
 async def _fetch_and_chunk_docs(
@@ -1667,6 +1666,7 @@ async def _fetch_and_chunk_docs(
 
     logger.info(f"Indexed {len(chunks)} chunks from {page_count} pages")
     return chunks, page_count
+
 
 # ---------------------------------------------------------------------------
 # Docs search (library documentation with auto-indexing)


### PR DESCRIPTION
This PR refactors the long `_fetch_and_chunk_docs` function in `src/wet_mcp/server.py` into a modular pipeline. 

Changes:
- Extracted shared markdown chunking logic into `_chunk_pages`.
- Extracted Tier 0 (llms.txt) logic into `_try_tier_llms_txt`.
- Extracted Tier 1 (GitHub raw) logic into `_try_tier_github_raw`.
- Extracted Tier 2 (Crawl) logic into `_try_tier_crawl`.
- Extracted Tier 3 (README fallback) logic into `_try_tier_readme_fallback`.
- Updated `_fetch_and_chunk_docs` to orchestrate these helpers.

The refactor preserves all existing functionality, including:
- Priority order (Tier 0 -> Tier 1 -> Tier 2 -> Tier 3).
- Quality gates (`_MIN_GH_CHUNKS` check for llms.txt and GitHub raw).
- Fallback to GitHub raw if crawl produces 0 chunks.
- Logging and timeouts.

Verification:
- Syntax check and linting passed.
- Targeted unit tests for success and fallthrough paths passed.
- Existing `tests/test_docs_coverage.py` and `tests/test_server_coverage.py` passed.

---
*PR created automatically by Jules for task [17163208431630381210](https://jules.google.com/task/17163208431630381210) started by @n24q02m*