### PR TITLE
[FIX] Remove unused import in embedder.py

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -14,8 +14,6 @@ Backend selection (always returns a valid backend):
 Embeddings are truncated to fixed dims in server._embed().
 """
 
-from __future__ import annotations
-
 import asyncio
 import os
 from typing import Protocol


### PR DESCRIPTION
Removed redundant 'from __future__ import annotations' in src/wet_mcp/embedder.py. The imports 'json', 'List', and 'Optional' mentioned in the issue were already absent. The file now adheres to Python 3.13 standards and project formatting. Verified with a full test suite run.

---
*PR created automatically by Jules for task [10598293524314819987](https://jules.google.com/task/10598293524314819987) started by @n24q02m*