### PR TITLE
[FIX] Fix Windows console encoding for Unicode output

### DIFF
--- a/src/wet_mcp/__main__.py
+++ b/src/wet_mcp/__main__.py
@@ -4,6 +4,16 @@ from wet_mcp.server import main
 
 
 def _cli() -> None:
+    import sys
+    if sys.platform == "win32":
+        import io
+        for _s in (sys.stdout, sys.stderr):
+            if _s is not None:
+                try:
+                    _s.reconfigure(encoding="utf-8", errors="replace")
+                except (AttributeError, io.UnsupportedOperation):
+                    pass
+
     """Start the MCP server."""
     main()
 

--- a/src/wet_mcp/__main__.py
+++ b/src/wet_mcp/__main__.py
@@ -5,8 +5,10 @@ from wet_mcp.server import main
 
 def _cli() -> None:
     import sys
+
     if sys.platform == "win32":
         import io
+
         for _s in (sys.stdout, sys.stderr):
             if _s is not None:
                 try:

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 # Fix Windows console encoding for Unicode output
 if sys.platform == "win32":
     import io
+
     for _s in (sys.stdout, sys.stderr):
         if _s is not None:
             try:

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -10,6 +10,16 @@ from importlib.resources import files
 from pathlib import Path
 from urllib.parse import urlparse
 
+# Fix Windows console encoding for Unicode output
+if sys.platform == "win32":
+    import io
+    for _s in (sys.stdout, sys.stderr):
+        if _s is not None:
+            try:
+                _s.reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, io.UnsupportedOperation):
+                pass
+
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations

--- a/tests/run_benchmark.py
+++ b/tests/run_benchmark.py
@@ -18,6 +18,7 @@ import warnings
 # Fix Windows console encoding for Unicode output
 if sys.platform == "win32":
     import io
+
     for _s in (sys.stdout, sys.stderr):
         if _s is not None:
             try:

--- a/tests/run_benchmark.py
+++ b/tests/run_benchmark.py
@@ -17,8 +17,13 @@ import warnings
 
 # Fix Windows console encoding for Unicode output
 if sys.platform == "win32":
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    import io
+    for _s in (sys.stdout, sys.stderr):
+        if _s is not None:
+            try:
+                _s.reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, io.UnsupportedOperation):
+                pass
 
 # Suppress noisy ResourceWarnings from SearXNG subprocess cleanup
 warnings.filterwarnings("ignore", category=ResourceWarning)


### PR DESCRIPTION
The Windows console often defaults to non-UTF-8 encodings, which can cause errors when printing Unicode characters. This PR enhances the existing workaround in the benchmark script to be more robust (handling None streams and missing reconfigure attributes) and applies it to the main MCP server entry points (server.py and __main__.py) to ensure consistent behavior for Windows users.

---
*PR created automatically by Jules for task [1023062174066842802](https://jules.google.com/task/1023062174066842802) started by @n24q02m*