### PR TITLE
[FIX] Update try_llms_txt test to use safe httpx client

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -660,7 +660,7 @@ async def download_media(
                     "error": str(e),
                 }
 
-    async with httpx.AsyncClient(
+    async with _safe_httpx_client(
         timeout=settings.crawler_timeout, transport=transport, headers=headers
     ) as client:
         tasks = [_download_one(url, client) for url in media_urls]

--- a/tests/test_crawler_download.py
+++ b/tests/test_crawler_download.py
@@ -33,7 +33,7 @@ async def test_download_media_success(tmp_path):
     url = "http://example.com/file.txt"
     output_dir = str(tmp_path)
 
-    with patch("wet_mcp.sources.crawler.httpx.AsyncClient", mock_client_cls):
+    with patch("wet_mcp.sources.crawler._safe_httpx_client", mock_client_cls):
         result_json = await download_media([url], output_dir)
 
     results = json.loads(result_json)
@@ -78,7 +78,7 @@ async def test_download_media_protocol_relative(tmp_path):
     url = "//example.com/image.jpg"
     output_dir = str(tmp_path)
 
-    with patch("wet_mcp.sources.crawler.httpx.AsyncClient", mock_client_cls):
+    with patch("wet_mcp.sources.crawler._safe_httpx_client", mock_client_cls):
         result_json = await download_media([url], output_dir)
 
     results = json.loads(result_json)
@@ -121,7 +121,7 @@ async def test_download_media_http_error(tmp_path):
 
     url = "http://example.com/missing.txt"
 
-    with patch("wet_mcp.sources.crawler.httpx.AsyncClient", mock_client_cls):
+    with patch("wet_mcp.sources.crawler._safe_httpx_client", mock_client_cls):
         result_json = await download_media([url], str(tmp_path))
 
     results = json.loads(result_json)
@@ -164,7 +164,7 @@ async def test_download_media_file_write_error(tmp_path):
     # The 'filepath' is a concrete Path object (PosixPath or WindowsPath).
     # Patching 'pathlib.Path.write_bytes' works for all instances.
 
-    with patch("wet_mcp.sources.crawler.httpx.AsyncClient", mock_client_cls):
+    with patch("wet_mcp.sources.crawler._safe_httpx_client", mock_client_cls):
         with patch(
             "pathlib.Path.write_bytes", side_effect=PermissionError("Access denied")
         ):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -239,7 +239,7 @@ class TestDiscoverLibrary:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = None
 
-        with patch("wet_mcp.sources.docs.httpx.AsyncClient", return_value=mock_client):
+        with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=mock_client):
             result = await discover_library("react")
 
         assert result is not None
@@ -286,7 +286,7 @@ class TestDiscoverLibrary:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = None
 
-        with patch("wet_mcp.sources.docs.httpx.AsyncClient", return_value=mock_client):
+        with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=mock_client):
             result = await discover_library("fastapi")
 
         assert result is not None
@@ -304,7 +304,7 @@ class TestDiscoverLibrary:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = None
 
-        with patch("wet_mcp.sources.docs.httpx.AsyncClient", return_value=mock_client):
+        with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=mock_client):
             result = await discover_library("nonexistent-library-xyz")
 
         assert result is None
@@ -330,7 +330,7 @@ class TestTryLlmsTxt:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = None
 
-        with patch("wet_mcp.sources.docs.httpx.AsyncClient", return_value=mock_client):
+        with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=mock_client):
             result = await try_llms_txt("https://example.com/docs")
 
         assert result == long_content
@@ -347,7 +347,7 @@ class TestTryLlmsTxt:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = None
 
-        with patch("wet_mcp.sources.docs.httpx.AsyncClient", return_value=mock_client):
+        with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=mock_client):
             result = await try_llms_txt("https://example.com")
 
         assert result is None
@@ -364,7 +364,7 @@ class TestTryLlmsTxt:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = None
 
-        with patch("wet_mcp.sources.docs.httpx.AsyncClient", return_value=mock_client):
+        with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=mock_client):
             result = await try_llms_txt("https://example.com")
 
         assert result is None
@@ -386,7 +386,7 @@ class TestTryLlmsTxt:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = None
 
-        with patch("wet_mcp.sources.docs.httpx.AsyncClient", return_value=mock_client):
+        with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=mock_client):
             result = await try_llms_txt("https://example.com")
 
         assert result is None

--- a/tests/test_docs_comprehensive.py
+++ b/tests/test_docs_comprehensive.py
@@ -37,7 +37,7 @@ from wet_mcp.sources.docs import (
 
 @pytest.mark.asyncio
 async def test_all_registries():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -125,7 +125,7 @@ async def test_discover_library(mock_probe, mock_get_gh):
     mock_probe.return_value = "https://docs.test"
     mock_get_gh.return_value = "http://gh"
 
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -145,7 +145,7 @@ async def test_discover_library(mock_probe, mock_get_gh):
 
 @pytest.mark.asyncio
 async def test_probe_docs_url():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -260,7 +260,7 @@ def test_sync_functions():
 
 @pytest.mark.asyncio
 async def test_try_github_raw_docs_success():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -305,7 +305,7 @@ async def test_try_github_raw_docs_success():
 
 @pytest.mark.asyncio
 async def test_try_github_raw_docs_failure():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -319,7 +319,7 @@ async def test_try_github_raw_docs_failure():
 
 @pytest.mark.asyncio
 async def test_try_sitemap_success():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -339,7 +339,7 @@ async def test_try_sitemap_success():
 
 @pytest.mark.asyncio
 async def test_try_sitemap_index():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -361,7 +361,7 @@ async def test_try_sitemap_index():
 
 @pytest.mark.asyncio
 async def test_try_objects_inv_success():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -519,7 +519,7 @@ def test_is_i18n_url():
 
 @pytest.mark.asyncio
 async def test_fetch_github_readme():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -535,7 +535,7 @@ async def test_fetch_github_readme():
 
 @pytest.mark.asyncio
 async def test_probe_docs_url_readthedocs():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
@@ -568,7 +568,7 @@ async def test_probe_docs_url_readthedocs():
 
 @pytest.mark.asyncio
 async def test_probe_docs_url_subdomain():
-    with patch("httpx.AsyncClient") as MockClient:
+    with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 

--- a/tests/test_media_tool.py
+++ b/tests/test_media_tool.py
@@ -147,7 +147,7 @@ async def test_media_download_adds_extension_from_content_type(mock_settings, tm
 
     with (
         patch("wet_mcp.sources.crawler.is_safe_url", return_value=True),
-        patch("wet_mcp.sources.crawler.httpx.AsyncClient") as MockClient,
+        patch("wet_mcp.sources.crawler._safe_httpx_client") as MockClient,
         patch("wet_mcp.sources.crawler.settings") as crawler_settings,
     ):
         crawler_settings.crawler_timeout = 30


### PR DESCRIPTION
This PR updates the test suite for documentation discovery and content extraction to align with the codebase's SSRF protection standards. 

Key changes:
- Refactored `tests/test_docs_comprehensive.py` and `tests/test_docs.py` to mock `wet_mcp.sources.docs._safe_httpx_client` instead of direct `httpx.AsyncClient` instantiation.
- Updated `src/wet_mcp/sources/crawler.py` to use the `_safe_httpx_client` wrapper for media downloads in `download_media`, closing a potential security inconsistency.
- Adjusted tests in `tests/test_crawler_download.py` and `tests/test_media_tool.py` to reflect the updated internal implementation.
- Verified all related tests (236 total) pass successfully and ran quality checks via `ruff`.

---
*PR created automatically by Jules for task [14122422822142435575](https://jules.google.com/task/14122422822142435575) started by @n24q02m*