### PR TITLE
[FIX] Remove unused import in relay_schema.py

### DIFF
--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -1,7 +1,5 @@
 """Config schema for relay page setup."""
 
-from __future__ import annotations
-
 from typing import Any
 
 RELAY_SCHEMA: dict[str, Any] = {


### PR DESCRIPTION
Removed the redundant `from __future__ import annotations` import from `src/wet_mcp/relay_schema.py`. This import is not required in Python 3.13 for the type hints used in this file. Other unused imports (`json`, `Dict`) mentioned in the issue were already absent.

---
*PR created automatically by Jules for task [15696190743389954007](https://jules.google.com/task/15696190743389954007) started by @n24q02m*