### PR TITLE
feat: merge setup tool into config with setup_* sub-actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,19 @@ mise run dev       # uv run wet-mcp
 - `asyncio.to_thread()` cho wrapping sync operations
 - Embedding luu tai 768 dims (default). Doi provider KHONG lam hu vector table
 - Renovate: Python upgrades DISABLED
+
+## Known bugs / gotchas (phat hien 2026-04-18 E2E)
+
+1. **Setup flow 2-phase race condition**:
+   - Phase 1: user submit API keys form -> `writeConfig(SERVER_NAME, config)` -> `state=configured` (nhanh, ~5-30s)
+   - Phase 2: Google Drive OAuth Device Code flow start (async, BLOCKING user hanh dong tren `google.com/device`)
+   - Sau Phase 2, token save vao `~/.wet-mcp/tokens/google_drive.json`
+   - **Gotcha:** E2E test script KHONG duoc kill server process sau Phase 1 -- PHAI wait cho `google_drive.json` ton tai TRUOC KHI exit. Neu kill som -> OAuth token mat -> next run phai re-auth.
+   - Example fix: `phase-m-e2e-test/test_wet_full.py` phase_1 dung check `pathlib.Path(token_path).exists()` + 300s timeout after state=configured.
+
+2. **GDrive token shared voi mnemo-mcp**:
+   - Neu user auth mot account Google cho wet-mcp, mnemo-mcp co the auto-detect va skip device code flow (shared account pool ong)
+   - Chua verify chinh xac mechanism, nhung observed 2026-04-18 E2E: setup mnemo ngay sau wet -> report "configured" rat nhanh
+   - **Impact:** Tot cho UX, nhung can check xem logic share co security concern khong (token scope, privilege escalation)
+
+3. **Relay "Setup complete" browser UI**: Python core-py relay implementation works correctly (browser hien "Setup complete!" sau phase 2). KHAC voi TS consumers (notion/email) bi stuck -- see `C:\Users\n24q02m-wlap\projects\mcp-core\CLAUDE.md` Known bugs #2.

--- a/src/wet_mcp/docs/config.md
+++ b/src/wet_mcp/docs/config.md
@@ -79,3 +79,53 @@ With explicit remote type:
 | `remote_type` | No | `drive` | Remote type (`drive`, `dropbox`, etc.) |
 
 Returns: authorization instructions and status.
+
+### setup_open_relay
+
+Open browser-based setup page to configure all API keys at once.
+
+```json
+{"action": "setup_open_relay"}
+```
+
+Force restart of relay session:
+
+```json
+{"action": "setup_open_relay", "force": true}
+```
+
+### setup_status
+
+Show current credential state and configured keys.
+
+```json
+{"action": "setup_status"}
+```
+
+Returns: credential state (`awaiting_setup`, `configured`, `local`), setup URL, detected cloud keys.
+
+### setup_skip
+
+Opt into local-only mode (uses local ONNX models, no cloud API keys required).
+
+```json
+{"action": "setup_skip"}
+```
+
+### setup_reset
+
+Clear all credentials and reset state. Next tool call will prompt setup again.
+
+```json
+{"action": "setup_reset"}
+```
+
+### setup_complete
+
+Re-resolve credentials from environment after manual configuration.
+
+```json
+{"action": "setup_complete"}
+```
+
+Returns: updated credential state and whether backends were re-initialized.

--- a/src/wet_mcp/docs/help.md
+++ b/src/wet_mcp/docs/help.md
@@ -97,6 +97,21 @@ Welcome to **WET** (Web Extended Toolkit) MCP Server.
 
 // Configure cloud sync
 {"action": "setup_sync"}
+
+// Setup: open browser to configure API keys
+{"action": "setup_open_relay"}
+
+// Setup: show credential state
+{"action": "setup_status"}
+
+// Setup: use local models only (no cloud)
+{"action": "setup_skip"}
+
+// Setup: clear credentials and reset
+{"action": "setup_reset"}
+
+// Setup: re-resolve credentials from environment
+{"action": "setup_complete"}
 ```
 
 ## Getting Full Documentation

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -70,8 +70,8 @@ def _require_credentials() -> str | None:
                 "state": "awaiting_setup",
                 "setup_url": url,
                 "instructions": (
-                    "API keys required. Call setup(action='open_relay') to configure via browser, "
-                    "or setup(action='skip') to opt into local-only mode."
+                    "API keys required. Call config(action='setup_open_relay') to configure via browser, "
+                    "or config(action='setup_skip') to opt into local-only mode."
                 ),
             }
         )
@@ -1116,7 +1116,8 @@ async def help(tool_name: str = "search") -> str:
 @mcp.tool(
     description=(
         "Server config and management. Actions: "
-        "status|set|cache_clear|docs_reindex. "
+        "status|set|cache_clear|docs_reindex|warmup|setup_sync|"
+        "setup_open_relay|setup_status|setup_skip|setup_reset|setup_complete. "
         "Use help tool with tool_name='config' for full docs."
     ),
     annotations=ToolAnnotations(
@@ -1132,6 +1133,7 @@ async def config(
     key: str | None = None,
     value: str | None = None,
     remote_type: str | None = None,
+    force: bool = False,
 ) -> str:
     """Server configuration and management.
 
@@ -1142,6 +1144,11 @@ async def config(
     - docs_reindex: Force re-index a library (key = library name)
     - warmup: Pre-download models and run first-time setup
     - setup_sync: Configure Google Drive sync (OAuth Device Code flow)
+    - setup_open_relay: Open browser-based setup to configure all API keys at once
+    - setup_status: Show current credential state and configured keys
+    - setup_skip: Use local ONNX models (explicit opt-in, no cloud features)
+    - setup_reset: Clear all credentials and reset state
+    - setup_complete: Re-resolve credentials from environment
     """
     match action:
         case "status":
@@ -1251,67 +1258,19 @@ async def config(
                 )
             return json.dumps({"error": f"Library '{key}' not found in index"})
 
-        case _:
-            import difflib
+        case "warmup":
+            from wet_mcp.setup_tool import run_warmup
 
-            valid_actions = ["cache_clear", "docs_reindex", "set", "status"]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
-            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return json.dumps(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                }
-            )
+            result = await run_warmup()
+            return json.dumps(result, indent=2, default=str)
 
+        case "setup_sync":
+            from wet_mcp.setup_tool import run_setup_sync
 
-# ---------------------------------------------------------------------------
-# Setup (warmup + setup-sync as MCP tool)
-# ---------------------------------------------------------------------------
+            result = await run_setup_sync(remote_type or "drive")
+            return json.dumps(result, indent=2, default=str)
 
-
-@mcp.tool(
-    description=(
-        "Server setup, credentials, and warmup. Actions: "
-        "open_relay|status|skip|reset|complete|warmup|setup_sync. "
-        "open_relay: Open browser-based setup page to configure all API keys at once. "
-        "status: Show current credential state and configured keys. "
-        "skip: Use local ONNX models (explicit opt-in, no cloud). "
-        "reset: Clear all credentials and reset state. "
-        "complete: Re-resolve credentials from environment. "
-        "warmup: Pre-download models and install dependencies. "
-        "setup_sync: Configure Google Drive sync (OAuth Device Code)."
-    ),
-    annotations=ToolAnnotations(
-        title="Setup",
-        readOnlyHint=False,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=True,
-    ),
-)
-async def setup(
-    action: str,
-    key: str | None = None,
-    value: str | None = None,
-    remote_type: str | None = None,
-    force: bool = False,
-) -> str:
-    """Server setup, credentials, and warmup.
-
-    Actions:
-    - open_relay: Open browser-based setup to configure all API keys at once.
-    - status: Show current credential state and configured keys.
-    - skip: Use local ONNX models (explicit opt-in, no cloud features).
-    - reset: Clear all credentials and reset state.
-    - complete: Re-resolve credentials from environment.
-    - warmup: Pre-download models and install dependencies.
-    - setup_sync: Configure Google Drive sync (OAuth Device Code).
-    """
-    from wet_mcp.setup_tool import run_setup_sync, run_warmup
-
-    match action:
-        case "open_relay":
+        case "setup_open_relay":
             from wet_mcp.credential_state import trigger_relay_setup
 
             url = await trigger_relay_setup(force=force)
@@ -1327,15 +1286,7 @@ async def setup(
                 {"status": "error", "message": "Failed to start relay session."}
             )
 
-        case "warmup":
-            result = await run_warmup()
-            return json.dumps(result, indent=2, default=str)
-
-        case "setup_sync":
-            result = await run_setup_sync(remote_type or "drive")
-            return json.dumps(result, indent=2, default=str)
-
-        case "status":
+        case "setup_status":
             from wet_mcp import credential_state as _cs
 
             state = _cs.get_state()
@@ -1349,16 +1300,7 @@ async def setup(
                 }
             )
 
-        case "start" | "setup_relay":
-            # Backward compat aliases → redirect to open_relay
-            from wet_mcp.credential_state import trigger_relay_setup
-
-            url = await trigger_relay_setup(force=force)
-            if url:
-                return json.dumps({"status": "relay_started", "setup_url": url})
-            return json.dumps({"status": "error", "message": "Relay setup failed."})
-
-        case "skip":
+        case "setup_skip":
             from mcp_core import set_local_mode
 
             from wet_mcp.credential_state import CredentialState, set_state
@@ -1372,7 +1314,7 @@ async def setup(
                 }
             )
 
-        case "reset":
+        case "setup_reset":
             from wet_mcp.credential_state import reset_state
 
             reset_state()
@@ -1383,7 +1325,7 @@ async def setup(
                 }
             )
 
-        case "complete":
+        case "setup_complete":
             from wet_mcp.credential_state import (
                 CredentialState,
                 resolve_credential_state,
@@ -1413,12 +1355,15 @@ async def setup(
             import difflib
 
             valid_actions = [
-                "complete",
-                "open_relay",
-                "reset",
+                "cache_clear",
+                "docs_reindex",
+                "set",
+                "setup_complete",
+                "setup_open_relay",
+                "setup_reset",
+                "setup_skip",
+                "setup_status",
                 "setup_sync",
-                "skip",
-                "start",
                 "status",
                 "warmup",
             ]

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -1707,23 +1707,31 @@ class TestServerConfigTool:
         data = json.loads(result)
         assert "error" in data
 
-    async def test_config_warmup_unknown(self):
-        """Warmup action is no longer in config tool (moved to setup)."""
-        from wet_mcp.server import config
+    async def test_config_warmup_action(self):
+        """Warmup action is now part of config tool (merged from setup)."""
+        with patch(
+            "wet_mcp.setup_tool.run_warmup",
+            new_callable=AsyncMock,
+            return_value={"status": "ok", "steps": [], "mode": "local"},
+        ):
+            from wet_mcp.server import config
 
-        result = await config(action="warmup")
-        data = json.loads(result)
-        assert "error" in data
-        assert "Unknown action" in data["error"]
+            result = await config(action="warmup")
+            data = json.loads(result)
+            assert data["status"] == "ok"
 
-    async def test_config_setup_sync_unknown(self):
-        """setup_sync action is no longer in config tool (moved to setup)."""
-        from wet_mcp.server import config
+    async def test_config_setup_sync_action(self):
+        """setup_sync action is now part of config tool (merged from setup)."""
+        with patch(
+            "wet_mcp.setup_tool.run_setup_sync",
+            new_callable=AsyncMock,
+            return_value={"status": "ok", "remote_type": "drive", "message": "done"},
+        ):
+            from wet_mcp.server import config
 
-        result = await config(action="setup_sync")
-        data = json.loads(result)
-        assert "error" in data
-        assert "Unknown action" in data["error"]
+            result = await config(action="setup_sync", remote_type="drive")
+            data = json.loads(result)
+            assert data["status"] == "ok"
 
     async def test_config_invalid_action(self):
         """Invalid config action returns error."""
@@ -1771,66 +1779,66 @@ class TestServerConfigTool:
 
 
 class TestServerSetupTool:
-    """Cover setup tool branches (warmup, setup_sync, setup_relay)."""
+    """Cover setup_* actions in config tool (warmup, setup_sync, setup_open_relay)."""
 
     async def test_setup_warmup(self):
         """Warmup action delegates to run_warmup."""
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         with patch(
             "wet_mcp.setup_tool.run_warmup",
             new_callable=AsyncMock,
             return_value={"status": "ok", "mode": "local", "steps": []},
         ):
-            result = await setup(action="warmup")
+            result = await config(action="warmup")
             data = json.loads(result)
             assert data["status"] == "ok"
 
     async def test_setup_sync(self):
         """setup_sync action delegates to run_setup_sync."""
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         with patch(
             "wet_mcp.setup_tool.run_setup_sync",
             new_callable=AsyncMock,
             return_value={"status": "ok", "provider": "google_drive"},
         ):
-            result = await setup(action="setup_sync")
+            result = await config(action="setup_sync")
             data = json.loads(result)
             assert data["status"] == "ok"
 
     async def test_setup_relay(self):
-        """setup_relay action delegates to trigger_relay_setup(force=True)."""
-        from wet_mcp.server import setup
+        """setup_open_relay action delegates to trigger_relay_setup."""
+        from wet_mcp.server import config
 
         with patch(
             "wet_mcp.credential_state.trigger_relay_setup",
             new_callable=AsyncMock,
             return_value="https://relay.example.com/setup/abc",
         ):
-            result = await setup(action="setup_relay")
+            result = await config(action="setup_open_relay")
             data = json.loads(result)
             assert data["status"] == "relay_started"
             assert "setup_url" in data
 
     async def test_setup_relay_failure(self):
-        """setup_relay returns error when relay setup fails."""
-        from wet_mcp.server import setup
+        """setup_open_relay returns error when relay setup fails."""
+        from wet_mcp.server import config
 
         with patch(
             "wet_mcp.credential_state.trigger_relay_setup",
             new_callable=AsyncMock,
             return_value=None,
         ):
-            result = await setup(action="setup_relay")
+            result = await config(action="setup_open_relay")
             data = json.loads(result)
             assert data["status"] == "error"
 
     async def test_setup_invalid_action(self):
-        """Invalid setup action returns error with suggestions."""
-        from wet_mcp.server import setup
+        """Invalid config action returns error with suggestions."""
+        from wet_mcp.server import config
 
-        result = await setup(action="invalid_action")
+        result = await config(action="invalid_action_xyz")
         data = json.loads(result)
         assert "error" in data
         assert "Unknown action" in data["error"]

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -490,37 +490,37 @@ class TestResetState:
 
 
 class TestServerSetupToolNewActions:
-    """Tests for new setup tool actions (status, start, skip, reset)."""
+    """Tests for setup_* actions in config tool (setup_status, setup_skip, setup_reset, etc.)."""
 
     async def test_status_action(self, monkeypatch):
-        """status action returns current state."""
+        """setup_status action returns current state."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         set_state(CredentialState.CONFIGURED)
         monkeypatch.setenv("GEMINI_API_KEY", "test")
-        result = await setup(action="status")
+        result = await config(action="setup_status")
         data = json.loads(result)
         assert data["state"] == "configured"
         assert "GEMINI_API_KEY" in data["cloud_keys_in_env"]
 
     async def test_start_action_when_configured(self):
-        """start action returns error when CONFIGURED and no force (relay skips)."""
+        """setup_open_relay returns error when CONFIGURED and no force (relay skips)."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         set_state(CredentialState.CONFIGURED)
-        result = await setup(action="start")
+        result = await config(action="setup_open_relay")
         data = json.loads(result)
         assert data["status"] == "error"
 
     async def test_start_action_force(self):
-        """start action with force triggers relay."""
+        """setup_open_relay with force triggers relay."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         set_state(CredentialState.CONFIGURED)
         with patch(
@@ -528,16 +528,16 @@ class TestServerSetupToolNewActions:
             new_callable=AsyncMock,
             return_value="https://relay.example.com/setup/abc",
         ):
-            result = await setup(action="start", force=True)
+            result = await config(action="setup_open_relay", force=True)
             data = json.loads(result)
             assert data["status"] == "relay_started"
             assert data["setup_url"] == "https://relay.example.com/setup/abc"
 
     async def test_start_action_failure(self):
-        """start action returns error when relay fails."""
+        """setup_open_relay returns error when relay fails."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         set_state(CredentialState.AWAITING_SETUP)
         with patch(
@@ -545,35 +545,35 @@ class TestServerSetupToolNewActions:
             new_callable=AsyncMock,
             return_value=None,
         ):
-            result = await setup(action="start")
+            result = await config(action="setup_open_relay")
             data = json.loads(result)
             assert data["status"] == "error"
 
     async def test_skip_action(self):
-        """skip action sets LOCAL mode."""
+        """setup_skip action sets LOCAL mode."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         with patch("mcp_core.set_local_mode") as mock_set:
-            result = await setup(action="skip")
+            result = await config(action="setup_skip")
             data = json.loads(result)
             assert data["status"] == "ok"
             assert get_state() == CredentialState.LOCAL
             mock_set.assert_called_once_with("wet-mcp")
 
     async def test_reset_action(self):
-        """reset action clears state."""
+        """setup_reset action clears state."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         set_state(CredentialState.CONFIGURED)
         with (
             patch("mcp_core.clear_mode"),
             patch("mcp_core.storage.config_file.delete_config"),
         ):
-            result = await setup(action="reset")
+            result = await config(action="setup_reset")
             data = json.loads(result)
             assert data["status"] == "ok"
             assert get_state() == CredentialState.AWAITING_SETUP
@@ -582,24 +582,24 @@ class TestServerSetupToolNewActions:
         """Invalid action includes fuzzy match suggestion."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
-        result = await setup(action="statu")
+        result = await config(action="setup_statu")
         data = json.loads(result)
         assert "error" in data
-        assert "status" in data["error"]  # fuzzy match suggestion
+        assert "setup_status" in data["error"]  # fuzzy match suggestion
 
     async def test_complete_action_refreshes_state(self, monkeypatch):
-        """complete action re-resolves credentials and transitions to CONFIGURED."""
+        """setup_complete action re-resolves credentials and transitions to CONFIGURED."""
         import json
 
-        from wet_mcp.server import setup
+        from wet_mcp.server import config
 
         set_state(CredentialState.AWAITING_SETUP)
         monkeypatch.setenv("GEMINI_API_KEY", "test-complete-key")
         with patch("wet_mcp.server.settings") as mock_settings:
             mock_settings.setup_providers = MagicMock()
-            result = await setup(action="complete")
+            result = await config(action="setup_complete")
             data = json.loads(result)
             assert data["status"] == "ok"
             assert data["state"] == "configured"

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -203,22 +203,22 @@ class TestRunSetupSync:
 
 
 class TestSetupMcpTool:
-    """Tests for warmup/setup_sync actions in setup tool."""
+    """Tests for warmup/setup_sync/setup_* actions in config tool."""
 
-    async def test_setup_tool_warmup_action(self):
-        """setup tool with action='warmup' calls run_warmup."""
+    async def test_config_tool_warmup_action(self):
+        """config tool with action='warmup' calls run_warmup."""
         with patch(
             "wet_mcp.setup_tool.run_warmup",
             new_callable=AsyncMock,
             return_value={"status": "ok", "steps": [], "mode": "local"},
         ):
-            from wet_mcp.server import setup
+            from wet_mcp.server import config
 
-            result = await setup(action="warmup")
+            result = await config(action="warmup")
             assert '"status": "ok"' in result
 
-    async def test_setup_tool_setup_sync_action(self):
-        """setup tool with action='setup_sync' calls run_setup_sync."""
+    async def test_config_tool_setup_sync_action(self):
+        """config tool with action='setup_sync' calls run_setup_sync."""
         with patch(
             "wet_mcp.setup_tool.run_setup_sync",
             new_callable=AsyncMock,
@@ -228,20 +228,20 @@ class TestSetupMcpTool:
                 "message": "Sync setup complete",
             },
         ):
-            from wet_mcp.server import setup
+            from wet_mcp.server import config
 
-            result = await setup(action="setup_sync", remote_type="drive")
+            result = await config(action="setup_sync", remote_type="drive")
             assert '"status": "ok"' in result
 
-    async def test_setup_tool_invalid_action(self):
-        """setup tool with invalid action returns error string."""
-        from wet_mcp.server import setup
+    async def test_config_tool_invalid_action(self):
+        """config tool with invalid action returns error string."""
+        from wet_mcp.server import config
 
-        result = await setup(action="invalid")
+        result = await config(action="invalid_xyz_action")
         assert '"error"' in result
         assert "Unknown action" in result
 
-    async def test_setup_tool_setup_sync_default_remote(self):
+    async def test_config_tool_setup_sync_default_remote(self):
         """setup_sync action without remote_type uses 'drive'."""
         with patch(
             "wet_mcp.setup_tool.run_setup_sync",
@@ -252,7 +252,34 @@ class TestSetupMcpTool:
                 "message": "Sync setup complete",
             },
         ) as mock_sync:
-            from wet_mcp.server import setup
+            from wet_mcp.server import config
 
-            await setup(action="setup_sync")
+            await config(action="setup_sync")
             mock_sync.assert_called_once_with("drive")
+
+    async def test_config_tool_dispatches_setup_status_action(self):
+        """setup_status action (formerly on setup tool) should work via config tool."""
+        with (
+            patch("wet_mcp.credential_state.get_state") as mock_get_state,
+            patch("wet_mcp.credential_state.get_setup_url", return_value=None),
+            patch("wet_mcp.credential_state.CLOUD_KEYS", []),
+        ):
+            mock_state = MagicMock()
+            mock_state.value = "configured"
+            mock_get_state.return_value = mock_state
+
+            from wet_mcp.server import config
+
+            result = await config(action="setup_status")
+            assert "unknown action" not in result.lower()
+            assert "state" in result
+
+    async def test_config_tool_dispatches_setup_reset_action(self):
+        """setup_reset action (formerly on setup tool) should work via config tool."""
+        with patch("wet_mcp.credential_state.reset_state") as mock_reset:
+            from wet_mcp.server import config
+
+            result = await config(action="setup_reset")
+            assert "unknown action" not in result.lower()
+            assert '"status": "ok"' in result
+            mock_reset.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -3324,7 +3324,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.25.0"
+version = "2.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3380,7 +3380,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.1.1" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.2.0" },
     { name = "n24q02m-web-core", specifier = ">=1.1.0" },
     { name = "openai", specifier = ">=2.31.0" },
     { name = "pillow", specifier = ">=12.2.0" },


### PR DESCRIPTION
Unify auxiliary tools to match 7-MCP matrix: each server exposes exactly `help` + `config`. Previously wet had both `config` + `setup` tools — merged into single `config` with setup_* prefixed actions.

Actions in unified config tool:
- Runtime: status, set, cache_clear, docs_reindex, warmup
- Setup flow: setup_open_relay, setup_status, setup_skip, setup_reset, setup_complete, setup_sync

Commit: a481afd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)