### PR TITLE
fix: restrict Windows token file permissions to current user only

### DIFF
--- a/src/wet_mcp/token_store.py
+++ b/src/wet_mcp/token_store.py
@@ -13,9 +13,11 @@ Token lifecycle:
 
 from __future__ import annotations
 
+import getpass
 import json
 import os
 import stat
+import subprocess
 from pathlib import Path
 
 from loguru import logger
@@ -31,6 +33,35 @@ def _get_token_dir() -> Path:
 def get_token_path(provider: str) -> Path:
     """Get path for a provider's token file."""
     return _get_token_dir() / f"{provider}.json"
+
+
+def _set_secure_permissions(path: Path) -> None:
+    """Restrict access to owner-only.
+
+    Unix: chmod 0700 for directories, 0600 for files.
+    Windows: icacls /inheritance:r + /grant:r <user>:F -- remove inherited
+    ACEs and grant full control to the current user only, so other local
+    users cannot read token files even when stored under the user profile.
+    """
+    if os.name != "nt":
+        try:
+            if path.is_dir():
+                path.chmod(stat.S_IRWXU)  # 0700
+            else:
+                path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        except OSError as e:
+            logger.debug(f"chmod failed for {path}: {e}")
+        return
+
+    try:
+        user = getpass.getuser()
+        subprocess.run(
+            ["icacls", str(path), "/inheritance:r", "/grant:r", f"{user}:F"],
+            capture_output=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.debug(f"icacls failed for {path}: {e}")
 
 
 def load_token(provider: str) -> dict | None:
@@ -60,22 +91,10 @@ def save_token(provider: str, token: dict) -> None:
     """
     token_dir = _get_token_dir()
     token_dir.mkdir(parents=True, exist_ok=True)
-
-    # Secure directory permissions (Unix only)
-    if os.name != "nt":  # pragma: no cover
-        try:
-            token_dir.chmod(stat.S_IRWXU)  # 0700
-        except OSError:
-            pass
+    _set_secure_permissions(token_dir)
 
     path = get_token_path(provider)
     path.write_text(json.dumps(token, indent=2), encoding="utf-8")
-
-    # Secure file permissions (Unix only)
-    if os.name != "nt":  # pragma: no cover
-        try:
-            path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
-        except OSError:
-            pass
+    _set_secure_permissions(path)
 
     logger.info(f"Token saved: {path}")

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -16,10 +16,17 @@ from wet_mcp.token_store import (
 
 @pytest.fixture
 def token_dir(tmp_path):
-    """Provide a temp token directory and patch settings."""
+    """Provide a temp token directory and patch settings.
+
+    Also patches subprocess.run so the real Windows icacls call cannot
+    lock down pytest tmp paths during test runs (would break cleanup).
+    """
     d = tmp_path / "tokens"
     d.mkdir()
-    with patch("wet_mcp.token_store.settings") as mock_settings:
+    with (
+        patch("wet_mcp.token_store.settings") as mock_settings,
+        patch("wet_mcp.token_store.subprocess.run"),
+    ):
         mock_settings.get_data_dir.return_value = tmp_path
         yield d
 
@@ -81,28 +88,59 @@ def test_load_oserror(token_dir):
 
 def test_save_token_creates_dir(tmp_path):
     """save_token creates token dir if it doesn't exist."""
-    with patch("wet_mcp.token_store.settings") as mock_settings:
+    with (
+        patch("wet_mcp.token_store.settings") as mock_settings,
+        patch("wet_mcp.token_store.subprocess.run"),
+    ):
         mock_settings.get_data_dir.return_value = tmp_path
         save_token("s3", {"access_token": "abc"})
         assert (tmp_path / "tokens" / "s3.json").exists()
 
 
 def test_save_token_chmod_oserror(token_dir):
-    """save_token ignores OSError from chmod."""
-    with patch.object(Path, "chmod", side_effect=OSError("perm error")):
+    """save_token ignores OSError from chmod (Unix branch)."""
+    with (
+        patch("wet_mcp.token_store.os.name", "posix"),
+        patch.object(Path, "chmod", side_effect=OSError("perm error")),
+    ):
         # Should not raise exception
         save_token("drive", {"access_token": "test"})
         assert (token_dir / "drive.json").exists()
 
 
 def test_save_token_windows_permissions(token_dir):
-    """On Windows, skip chmod calls."""
+    """On Windows, invoke icacls (not chmod) to lock down inheritance + grant."""
     with (
         patch("wet_mcp.token_store.os.name", "nt"),
+        patch("wet_mcp.token_store.subprocess.run") as mock_run,
+        patch("wet_mcp.token_store.getpass.getuser", return_value="tester"),
         patch.object(Path, "chmod") as mock_chmod,
     ):
         save_token("drive", {"access_token": "test"})
         mock_chmod.assert_not_called()
+        # One call for the directory + one for the file
+        assert mock_run.call_count == 2
+        for call_args in mock_run.call_args_list:
+            cmd = call_args[0][0]
+            assert cmd[0] == "icacls"
+            assert "/inheritance:r" in cmd
+            assert "/grant:r" in cmd
+            assert "tester:F" in cmd
+        assert load_token("drive") == {"access_token": "test"}
+
+
+def test_save_token_windows_icacls_failure_non_fatal(token_dir):
+    """icacls failure must not break save_token flow."""
+    with (
+        patch("wet_mcp.token_store.os.name", "nt"),
+        patch(
+            "wet_mcp.token_store.subprocess.run",
+            side_effect=OSError("icacls missing"),
+        ),
+        patch("wet_mcp.token_store.getpass.getuser", return_value="tester"),
+    ):
+        # Should not raise
+        save_token("drive", {"access_token": "test"})
         assert load_token("drive") == {"access_token": "test"}
 
 


### PR DESCRIPTION
## Summary
- On Windows, `save_token` previously wrote tokens with inherited ACLs, leaving token files readable by any other local user of the machine.
- New `_set_secure_permissions` helper: Unix `chmod 0700/0600` (unchanged); Windows `icacls /inheritance:r /grant:r <user>:F` so only the owning user has access.
- Surgical diff: only `src/wet_mcp/token_store.py` + `tests/test_token_store.py`.

## Why this instead of #825
#825 touched 31 files (+366/-1841) far outside the stated scope. This PR keeps the security fix and drops the unrelated churn.

## Test plan
- [x] `uv run pytest tests/test_token_store.py` -- 13/13 pass locally (Windows)
- [x] Pre-commit hooks (ruff lint/format, ty, pytest) pass
- [x] Tests cover: icacls command shape on Windows, icacls OSError non-fatal, Unix chmod OSError non-fatal, Unix 0700/0600 mode
- [ ] CI green on all 3 OS (Lint & Test matrix)

Closes #825