### PR TITLE
fix: use dynamic SearXNG port in test assertions (web-core 1.2.0 parity)

### DIFF
--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -578,15 +578,25 @@ class TestHandleRestartCrashDiagnostics:
         module._restart_count = 0
         module._last_restart_time = 0.0
 
+        expected_url = "http://127.0.0.1:8080"
         with (
             patch("web_core.search.runner._is_searxng_installed", return_value=True),
+            # web-core 1.2.0 tries Docker before subprocess; disable it so
+            # _start_searxng_subprocess is reached and returns a known URL.
+            # Use create=True so the patch is a no-op on web-core 1.1.0
+            # where the Docker path does not exist.
+            patch(
+                "web_core.search.runner._start_docker_searxng",
+                AsyncMock(return_value=None),
+                create=True,
+            ),
             patch(
                 "web_core.search.runner._start_searxng_subprocess",
-                return_value="http://127.0.0.1:8080",
+                AsyncMock(return_value=expected_url),
             ),
         ):
             url = await _handle_restart_and_start(start_port=8080)
-            assert "8080" in url
+            assert url == expected_url
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_searxng_runner_comprehensive.py
+++ b/tests/test_searxng_runner_comprehensive.py
@@ -41,19 +41,23 @@ from wet_mcp.searxng_runner import (
 def reset_globals():
     import web_core.search.runner as module
 
-    module._searxng_process = None
-    module._searxng_port = None
-    module._restart_count = 0
-    module._last_restart_time = 0.0
-    module._is_owner = False
-    module._startup_lock = None
+    def _reset() -> None:
+        module._searxng_process = None
+        module._searxng_port = None
+        module._restart_count = 0
+        module._last_restart_time = 0.0
+        module._is_owner = False
+        module._startup_lock = None
+        # web-core 1.2.0 added Docker fallback; reset its globals too so state
+        # does not leak across tests.
+        if hasattr(module, "_searxng_docker_container"):
+            module._searxng_docker_container = None
+        if hasattr(module, "_searxng_settings_path"):
+            module._searxng_settings_path = None
+
+    _reset()
     yield
-    module._searxng_process = None
-    module._searxng_port = None
-    module._restart_count = 0
-    module._last_restart_time = 0.0
-    module._is_owner = False
-    module._startup_lock = None
+    _reset()
 
 
 def test_get_pip_command():
@@ -541,9 +545,17 @@ async def test_ensure_searxng_locked_alive_but_unhealthy():
         patch("web_core.search.runner._force_kill_process") as mock_force_kill,
         patch("web_core.search.runner._try_reuse_existing", return_value=None),
         patch("web_core.search.runner._is_searxng_installed", return_value=True),
+        # web-core 1.2.0 tries Docker before subprocess; disable it so
+        # _start_searxng_subprocess is reached. create=True so the patch
+        # is a no-op on web-core 1.1.0 where the Docker path is absent.
+        patch(
+            "web_core.search.runner._start_docker_searxng",
+            AsyncMock(return_value=None),
+            create=True,
+        ),
         patch(
             "web_core.search.runner._start_searxng_subprocess",
-            return_value="http://127.0.0.1:8085",
+            AsyncMock(return_value="http://127.0.0.1:8085"),
         ),
     ):
         url = await _ensure_searxng_locked(auto_start=True, start_port=8080)
@@ -569,9 +581,17 @@ async def test_ensure_searxng_locked_start():
     with (
         patch("web_core.search.runner._try_reuse_existing", return_value=None),
         patch("web_core.search.runner._is_searxng_installed", return_value=True),
+        # web-core 1.2.0 tries Docker before subprocess; disable it so
+        # _start_searxng_subprocess is reached. create=True so the patch
+        # is a no-op on web-core 1.1.0 where the Docker path is absent.
+        patch(
+            "web_core.search.runner._start_docker_searxng",
+            AsyncMock(return_value=None),
+            create=True,
+        ),
         patch(
             "web_core.search.runner._start_searxng_subprocess",
-            return_value="http://127.0.0.1:8082",
+            AsyncMock(return_value="http://127.0.0.1:8082"),
         ),
     ):
         url = await _ensure_searxng_locked(auto_start=True, start_port=8080)
@@ -605,9 +625,17 @@ async def test_ensure_searxng_locked_crash_cleanup():
     with (
         patch("web_core.search.runner._try_reuse_existing", return_value=None),
         patch("web_core.search.runner._is_searxng_installed", return_value=True),
+        # web-core 1.2.0 tries Docker before subprocess; disable it so
+        # _start_searxng_subprocess is reached. create=True so the patch
+        # is a no-op on web-core 1.1.0 where the Docker path is absent.
+        patch(
+            "web_core.search.runner._start_docker_searxng",
+            AsyncMock(return_value=None),
+            create=True,
+        ),
         patch(
             "web_core.search.runner._start_searxng_subprocess",
-            return_value="http://127.0.0.1:8083",
+            AsyncMock(return_value="http://127.0.0.1:8083"),
         ),
     ):
         url = await _ensure_searxng_locked(auto_start=True, start_port=8080)
@@ -620,6 +648,14 @@ async def test_ensure_searxng_locked_install_fails():
         patch("web_core.search.runner._try_reuse_existing", return_value=None),
         patch("web_core.search.runner._is_searxng_installed", return_value=False),
         patch("web_core.search.runner._install_searxng", return_value=False),
+        # web-core 1.2.0 tries Docker before install check; disable it so the
+        # install-failed branch is reached. create=True so the patch is a
+        # no-op on web-core 1.1.0 where the Docker path is absent.
+        patch(
+            "web_core.search.runner._start_docker_searxng",
+            AsyncMock(return_value=None),
+            create=True,
+        ),
     ):
         with pytest.raises(RuntimeError, match="installation failed"):
             await _ensure_searxng_locked(auto_start=True, start_port=8080)


### PR DESCRIPTION
## Summary

web-core 1.2.0 introduced two behavioural changes in `web_core.search.runner` that broke wet-mcp's test suite:

1. `_find_available_port` now randomises the offset within the port range to avoid TOCTOU races between concurrent starts. The picked port is no longer deterministically equal to `start_port`.
2. `_handle_restart_and_start` now tries `_start_docker_searxng` before `_start_searxng_subprocess`. On CI runners with Docker available (Ubuntu), the Docker path succeeds before the mocked `_start_searxng_subprocess` is reached.

On top of that the new `_searxng_docker_container` module global leaks across tests because the `reset_globals` fixture doesn't reset it.

## Why this blocks other PRs

Renovate PR #901 (non-major dependency bumps) pulls `n24q02m-web-core>=1.2.0`, which surfaces all of the above on Ubuntu CI:

- `tests/test_coverage_misc.py::TestHandleRestartCrashDiagnostics::test_crash_stderr_read_exception`
- `tests/test_searxng_runner_comprehensive.py::test_is_process_alive`
- `tests/test_searxng_runner_comprehensive.py::test_ensure_searxng_locked_alive_but_unhealthy`
- `tests/test_searxng_runner_comprehensive.py::test_ensure_searxng_locked_start`
- `tests/test_searxng_runner_comprehensive.py::test_ensure_searxng_locked_crash_cleanup`
- `tests/test_searxng_runner_comprehensive.py::test_ensure_searxng_locked_install_fails`
- `tests/test_searxng_runner_comprehensive.py::test_cleanup_process`

PR #902 (fastmcp 3.x) sits behind #901, so neither can merge until the tests are fixed.

## Fix (compatible with web-core 1.1.0 and 1.2.0)

- In `test_ensure_searxng_locked_*` and `test_crash_stderr_read_exception`, patch `_start_docker_searxng` to return `None` so the subprocess branch is exercised deterministically. `create=True` makes the patch a no-op on 1.1.0 where the Docker path doesn't exist yet.
- Reset `_searxng_docker_container` and `_searxng_settings_path` in the `reset_globals` fixture (guarded with `hasattr`) so cross-test state does not leak on 1.2.0.
- Switch the `_start_*` mocks to `AsyncMock` since the wrapped callables are coroutines in 1.2.0.

## Test plan

- [x] `uv run pytest tests/test_coverage_misc.py tests/test_searxng_runner_comprehensive.py -v` passes locally against web-core 1.1.0 (pyproject current)
- [x] Same suite passes locally against web-core 1.2.0 (Renovate target)
- [x] Full `uv run pytest` (1501 tests) passes on both versions
- [x] Pre-commit (ruff, ty, pytest, commit prefix) passes
- [ ] Ubuntu CI passes on this PR
- [ ] After merge: `gh pr update-branch 901` + `gh pr update-branch 902` bring the fix into those PRs and their CI goes green