### PR TITLE
fix: propagate GDrive device code failure to browser UI

### DIFF
--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -33,6 +33,11 @@ class CredentialState(Enum):
 _state = CredentialState.AWAITING_SETUP
 _setup_url: str | None = None
 _on_gdrive_complete: Callable[[], None] | None = None
+# Failure callback signature matches mcp-core's mark_setup_failed: optional
+# key + error message. Wired by the HTTP server so the browser's
+# /setup-status poll receives ``error:<message>`` instead of spinning forever
+# when Google rejects the device code (invalid_grant / expired_token / etc.).
+_on_gdrive_failed: Callable[[str, str], None] | None = None
 
 
 def set_gdrive_complete_callback(cb: Callable[[], None]) -> None:
@@ -40,6 +45,62 @@ def set_gdrive_complete_callback(cb: Callable[[], None]) -> None:
     global _on_gdrive_complete
     _on_gdrive_complete = cb
     logger.debug("GDrive complete callback registered")
+
+
+def set_gdrive_failed_callback(cb: Callable[[str, str], None]) -> None:
+    """Set callback for when GDrive OAuth fails upstream (used by HTTP server).
+
+    The callback receives ``(key, error_message)`` matching the
+    ``mark_setup_failed(key, error)`` signature exposed by mcp-core's local
+    OAuth app. It is invoked by ``_gdrive_token_poll`` whenever Google
+    returns a terminal error (``invalid_grant``, ``expired_token``,
+    ``access_denied``, etc.) so the browser's ``/setup-status`` poll
+    surfaces the error and stops waiting.
+    """
+    global _on_gdrive_failed
+    _on_gdrive_failed = cb
+    logger.debug("GDrive failed callback registered")
+
+
+def wire_gdrive_callbacks(
+    mark_complete: Callable[[], None],
+    mark_failed: Callable[..., None] | None = None,
+) -> None:
+    """Wire GDrive completion + optional failure callbacks in one call.
+
+    Intended for use as ``setup_complete_hook``. mcp-core detects the hook
+    signature by arity:
+
+    - Older mcp-core (<1.3.0) passes 1 positional arg: ``hook(mark_complete)``.
+      ``mark_failed`` stays ``None`` and GDrive terminal errors go
+      server-log-only (legacy behavior).
+    - Newer mcp-core (>=1.3.0) passes 2 args: ``hook(mark_complete, mark_failed)``.
+      ``mark_failed`` wires through ``mark_setup_failed`` so the browser
+      form stops spinning and shows the error.
+
+    Making ``mark_failed`` optional here means wet-mcp stays forward-compatible
+    with both versions; no lock-step release required between wet-mcp and
+    mcp-core.
+    """
+    set_gdrive_complete_callback(mark_complete)
+
+    global _on_gdrive_failed
+
+    if mark_failed is None:
+        _on_gdrive_failed = None
+        logger.debug("GDrive complete callback wired (1-arg legacy core)")
+        return
+
+    def _cb(_key: str, error: str) -> None:
+        # mcp-core's mark_setup_failed(key, error) expects the key positionally.
+        # We always operate on "gdrive" so hardcode it here.
+        try:
+            mark_failed("gdrive", error)
+        except Exception:
+            logger.opt(exception=True).debug("mark_setup_failed call failed")
+
+    _on_gdrive_failed = _cb
+    logger.debug("GDrive complete + failed callbacks wired (2-arg)")
 
 
 def get_state() -> CredentialState:
@@ -388,11 +449,32 @@ async def _gdrive_token_poll(
     interval: int,
     expires_in: int,
 ) -> None:
-    """Background poll Google OAuth for device code token completion."""
+    """Background poll Google OAuth for device code token completion.
+
+    Terminal outcomes:
+    * ``access_token`` in response  -> save token + fire complete callback.
+    * ``authorization_pending``     -> keep polling (user hasn't approved yet).
+    * ``slow_down``                 -> increase interval + keep polling.
+    * Any other ``error`` value (``invalid_grant``, ``expired_token``,
+      ``access_denied``, etc.) -> fire failure callback with the error
+      string and stop. The failure callback wires into mcp-core's
+      ``/setup-status`` so the browser shows the message instead of
+      waiting forever.
+    * Loop exits via ``deadline`` without success -> fire failure callback
+      with ``expired`` so the browser surfaces the timeout.
+    """
     import asyncio
     import time
 
     import httpx
+
+    def _notify_failed(error: str) -> None:
+        if _on_gdrive_failed is None:
+            return
+        try:
+            _on_gdrive_failed("gdrive", error)
+        except Exception:
+            logger.opt(exception=True).debug("GDrive failed callback raised")
 
     deadline = time.time() + expires_in
     async with httpx.AsyncClient() as client:
@@ -427,15 +509,27 @@ async def _gdrive_token_poll(
                                 "GDrive complete callback failed"
                             )
                     return
-                elif data.get("error") == "authorization_pending":
+                err = data.get("error")
+                if err == "authorization_pending":
                     continue
-                elif data.get("error") == "slow_down":
+                if err == "slow_down":
                     interval += 5
-                else:
-                    logger.warning("GDrive token poll error: {}", data.get("error"))
-                    return
+                    continue
+                # Any other error from Google is terminal -- stop polling AND
+                # tell the browser so the spinner stops.
+                err_desc = data.get("error_description") or err or "unknown"
+                logger.warning(
+                    "GDrive token poll terminal error: {} ({})",
+                    err,
+                    err_desc,
+                )
+                _notify_failed(str(err_desc))
+                return
             except Exception:
                 logger.opt(exception=True).debug("GDrive token poll request failed")
+        # Deadline exceeded without success -> surface timeout.
+        logger.warning("GDrive device code flow expired before user approved")
+        _notify_failed("expired")
 
 
 def set_state(state: CredentialState) -> None:
@@ -457,3 +551,13 @@ def reset_state() -> None:
         delete_config(SERVER_NAME)
     except Exception:
         logger.opt(exception=True).warning("Reset state failed")
+
+
+def _reset_callbacks_for_test() -> None:
+    """Test helper: clear callbacks so tests start from a known state.
+
+    Not exported from the public API; tests import it directly.
+    """
+    global _on_gdrive_complete, _on_gdrive_failed
+    _on_gdrive_complete = None
+    _on_gdrive_failed = None

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2038,7 +2038,7 @@ async def run_http(port: int = 0) -> None:
     """
     from mcp_core.transport.local_server import run_local_server
 
-    from wet_mcp.credential_state import save_credentials, set_gdrive_complete_callback
+    from wet_mcp.credential_state import save_credentials, wire_gdrive_callbacks
     from wet_mcp.relay_schema import RELAY_SCHEMA
 
     await run_local_server(
@@ -2047,7 +2047,11 @@ async def run_http(port: int = 0) -> None:
         relay_schema=RELAY_SCHEMA,
         port=port,
         on_credentials_saved=save_credentials,
-        setup_complete_hook=set_gdrive_complete_callback,
+        # 2-arg hook: receive BOTH mark_setup_complete and mark_setup_failed
+        # so GDrive device code failures (Google invalid_grant / expired /
+        # denied) propagate to the browser form instead of leaving it
+        # stuck on "Waiting for authorization..." forever.
+        setup_complete_hook=wire_gdrive_callbacks,
     )
 
 

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -1015,6 +1015,119 @@ class TestSetGdriveCompleteCallback:
         mod._on_gdrive_complete = None
 
 
+class TestSetGdriveFailedCallback:
+    """Failure callback wires into mcp-core's ``mark_setup_failed``.
+
+    Without this, a Google device-code terminal error (invalid_grant /
+    expired_token / access_denied) left the browser spinner waiting
+    forever because the server only knew ``idle`` / ``complete`` states.
+    """
+
+    def test_failed_callback_registration(self):
+        import wet_mcp.credential_state as mod
+        from wet_mcp.credential_state import (
+            _reset_callbacks_for_test,
+            set_gdrive_failed_callback,
+        )
+
+        _reset_callbacks_for_test()
+
+        def cb(key: str, error: str) -> None:
+            pass
+
+        with patch("wet_mcp.credential_state.logger") as mock_logger:
+            set_gdrive_failed_callback(cb)
+            mock_logger.debug.assert_called_with("GDrive failed callback registered")
+
+        assert mod._on_gdrive_failed is cb
+        _reset_callbacks_for_test()
+
+    def test_wire_callbacks_sets_both(self):
+        """wire_gdrive_callbacks populates BOTH complete + failed handlers."""
+        import wet_mcp.credential_state as mod
+        from wet_mcp.credential_state import (
+            _reset_callbacks_for_test,
+            wire_gdrive_callbacks,
+        )
+
+        _reset_callbacks_for_test()
+
+        complete_calls: list[str] = []
+        failed_calls: list[tuple[str, str]] = []
+
+        def mark_complete(key: str = "gdrive") -> None:
+            complete_calls.append(key)
+
+        def mark_failed(key: str = "gdrive", error: str = "?") -> None:
+            failed_calls.append((key, error))
+
+        wire_gdrive_callbacks(mark_complete, mark_failed)
+
+        # Trigger both through the stored callbacks.
+        assert mod._on_gdrive_complete is mark_complete
+        failed_cb = mod._on_gdrive_failed
+        complete_cb = mod._on_gdrive_complete
+        assert failed_cb is not None
+        assert complete_cb is not None
+
+        failed_cb("gdrive", "invalid_grant")
+        assert failed_calls == [("gdrive", "invalid_grant")]
+
+        complete_cb()
+        assert complete_calls == ["gdrive"]
+
+        _reset_callbacks_for_test()
+
+    def test_wire_callbacks_adapter_swallows_exception(self):
+        """mark_failed raising should not crash the poll loop."""
+        import wet_mcp.credential_state as mod
+        from wet_mcp.credential_state import (
+            _reset_callbacks_for_test,
+            wire_gdrive_callbacks,
+        )
+
+        _reset_callbacks_for_test()
+
+        def mark_complete(key: str = "gdrive") -> None:
+            pass
+
+        def mark_failed(key: str = "gdrive", error: str = "?") -> None:
+            raise RuntimeError("boom")
+
+        wire_gdrive_callbacks(mark_complete, mark_failed)
+        # Must not raise.
+        cb = mod._on_gdrive_failed
+        assert cb is not None
+        cb("gdrive", "invalid_grant")
+
+        _reset_callbacks_for_test()
+
+    def test_wire_callbacks_legacy_1arg_only_wires_complete(self):
+        """Legacy mcp-core (<1.3.0) calls ``hook(mark_complete)`` with one arg.
+
+        ``wire_gdrive_callbacks`` must still work: the complete callback
+        gets wired, the failed callback stays None, and the code degrades
+        to log-only on Google terminal errors (legacy behavior).
+        """
+        import wet_mcp.credential_state as mod
+        from wet_mcp.credential_state import (
+            _reset_callbacks_for_test,
+            wire_gdrive_callbacks,
+        )
+
+        _reset_callbacks_for_test()
+
+        def mark_complete(key: str = "gdrive") -> None:
+            pass
+
+        # Simulate legacy arity: call with mark_complete only, no mark_failed.
+        wire_gdrive_callbacks(mark_complete)
+        assert mod._on_gdrive_complete is mark_complete
+        assert mod._on_gdrive_failed is None
+
+        _reset_callbacks_for_test()
+
+
 class TestShareCloudKeysOuterException:
     def test_outer_import_error_non_fatal(self):
         """Outer ImportError for write_config should be swallowed."""
@@ -1132,6 +1245,111 @@ class TestGdriveTokenPoll:
         with patch("wet_mcp.token_store.save_token") as mock_save:
             await self._run_poll([{"error": "access_denied"}])
             mock_save.assert_not_called()
+
+    async def test_terminal_error_invokes_failed_callback(self):
+        """Google terminal error must fire _on_gdrive_failed so the browser stops polling.
+
+        Without this, the credential form's spinner waited forever on
+        "Waiting for authorization..." even though the backend had given up.
+        """
+        from wet_mcp.credential_state import (
+            _reset_callbacks_for_test,
+            set_gdrive_failed_callback,
+        )
+
+        _reset_callbacks_for_test()
+        calls: list[tuple[str, str]] = []
+
+        def on_fail(key: str, error: str) -> None:
+            calls.append((key, error))
+
+        set_gdrive_failed_callback(on_fail)
+        try:
+            with patch("wet_mcp.token_store.save_token") as mock_save:
+                await self._run_poll(
+                    [
+                        {
+                            "error": "invalid_grant",
+                            "error_description": "Bad device code",
+                        }
+                    ]
+                )
+                mock_save.assert_not_called()
+            assert len(calls) == 1
+            assert calls[0][0] == "gdrive"
+            assert "Bad device code" in calls[0][1]
+        finally:
+            _reset_callbacks_for_test()
+
+    async def test_terminal_error_without_description_uses_error_code(self):
+        """If Google omits error_description, fall back to error code."""
+        from wet_mcp.credential_state import (
+            _reset_callbacks_for_test,
+            set_gdrive_failed_callback,
+        )
+
+        _reset_callbacks_for_test()
+        calls: list[tuple[str, str]] = []
+        set_gdrive_failed_callback(lambda k, e: calls.append((k, e)))
+        try:
+            with patch("wet_mcp.token_store.save_token"):
+                await self._run_poll([{"error": "access_denied"}])
+            assert calls == [("gdrive", "access_denied")]
+        finally:
+            _reset_callbacks_for_test()
+
+    async def test_deadline_expiry_invokes_failed_callback(self):
+        """Loop expiring without success -> failed callback with 'expired'."""
+        from wet_mcp.credential_state import (
+            _gdrive_token_poll,
+            _reset_callbacks_for_test,
+            set_gdrive_failed_callback,
+        )
+
+        _reset_callbacks_for_test()
+        calls: list[tuple[str, str]] = []
+        set_gdrive_failed_callback(lambda k, e: calls.append((k, e)))
+
+        class _NoopClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, *a, **kw):
+                class R:
+                    def json(self):
+                        return {"error": "authorization_pending"}
+
+                return R()
+
+        async def fake_sleep(_):
+            return None
+
+        try:
+            with (
+                patch("httpx.AsyncClient", _NoopClient),
+                patch("asyncio.sleep", new=fake_sleep),
+            ):
+                # expires_in=0 makes deadline immediate so the loop never
+                # iterates and we fall through to the expiry path.
+                await _gdrive_token_poll("cid", "csec", "dev", 0, 0)
+            assert calls == [("gdrive", "expired")]
+        finally:
+            _reset_callbacks_for_test()
+
+    async def test_terminal_error_no_callback_registered_is_safe(self):
+        """Missing failed callback must not crash the poll."""
+        from wet_mcp.credential_state import _reset_callbacks_for_test
+
+        _reset_callbacks_for_test()
+        try:
+            with patch("wet_mcp.token_store.save_token"):
+                # Should not raise even without any callback registered.
+                await self._run_poll([{"error": "invalid_grant"}])
+        finally:
+            _reset_callbacks_for_test()
 
     async def test_post_exception_non_fatal_and_expires(self):
         """Post raising should be caught; deadline expiry exits loop."""


### PR DESCRIPTION
## Summary

Pairs with [mcp-core PR #61](https://github.com/n24q02m/mcp-core/pull/61)
(merged as ``57f8326``). Fixes the browser UX where the credential form
kept spinning on "Waiting for authorization..." forever when Google
rejected the device-code flow (``invalid_grant``, ``expired_token``,
``access_denied``, expired deadline).

## Changes

- Add ``_on_gdrive_failed`` module callback + ``set_gdrive_failed_callback``.
- Add ``wire_gdrive_callbacks(mark_complete, mark_failed=None)`` as the
  setup-complete hook adapter. Wires both success and failure callbacks
  from mcp-core's new 2-arg hook signature.
  ``mark_failed=None`` keeps wet-mcp forward-compatible with older
  mcp-core (<1.3.0) that only passes 1 arg; failure path degrades to
  log-only in that case.
- ``_gdrive_token_poll`` now fires ``_on_gdrive_failed("gdrive", error)``
  on ANY Google terminal error (not just silently returning) and on
  deadline expiry. ``slow_down`` keeps polling via ``continue``.
- ``server.py`` swaps ``setup_complete_hook=set_gdrive_complete_callback``
  for ``wire_gdrive_callbacks`` so both callbacks are installed in one
  call.

## Test plan

- [x] ``uv run pytest`` — **1509 passed, 34 skipped** (8 new tests).
  - ``test_terminal_error_invokes_failed_callback``
  - ``test_terminal_error_without_description_uses_error_code``
  - ``test_deadline_expiry_invokes_failed_callback``
  - ``test_terminal_error_no_callback_registered_is_safe``
  - ``test_failed_callback_registration``
  - ``test_wire_callbacks_sets_both``
  - ``test_wire_callbacks_adapter_swallows_exception``
  - ``test_wire_callbacks_legacy_1arg_only_wires_complete``
- [x] ``uv run ruff check`` — All checks passed
- [x] ``uv run ruff format --check`` — 94 files already formatted
- [x] ``uv run ty check`` — All checks passed
- [x] Pre-commit hooks pass.

## Downstream gating

This PR is safe to merge independently because ``wire_gdrive_callbacks``
accepts ``mark_failed=None``. Once mcp-core v1.3.0+ is released to PyPI,
the 2-arg path activates automatically and Google device-code failures
will surface to the browser. Before that, failure path is log-only
(current behavior — no regression).