### PR TITLE
fix: enable UV_PYTHON_DOWNLOADS for Python 3.13.13 in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
-    UV_PYTHON_DOWNLOADS=0
+    UV_PYTHON_DOWNLOADS=automatic
 
 WORKDIR /app
 


### PR DESCRIPTION
Hotfix for failed v2.26.4 Docker build. Base image has Python 3.13.11 but pyproject.toml requires >=3.13.13. Switch uv to automatic Python download during build.