### PR TITLE
fix: bump mcp-core to 1.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,17 @@
 # ========================
 # Stage 1: Builder
 # ========================
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
+# Use python:3.13-slim (Debian bookworm) which tracks the latest 3.13 patch
+# (currently 3.13.13). The astral-sh/uv Docker image still pins an older
+# build with uv 0.9.30 + Python 3.13.11, which does not satisfy
+# requires-python = ">=3.13.13" from web-core 1.3.5.
+# Copy the uv binary from the standalone uv image (always latest).
+FROM python:3.13-slim-bookworm@sha256:bada92bcc2794014c291cd97ac3604eb907746b9d3f4b4ff5a8a1ffeff40ceff AS builder
+COPY --from=ghcr.io/astral-sh/uv:latest@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /uvx /usr/local/bin/
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
-    UV_PYTHON_DOWNLOADS=automatic
+    UV_PYTHON_DOWNLOADS=never
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # Per-domain rate limiting for batch operations
     "aiolimiter>=1.2.1",
     # Relay setup (zero-env-config)
-    "n24q02m-mcp-core>=1.6.2",
+    "n24q02m-mcp-core>=1.6.3",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance
     # downgrading to CVE-vulnerable 2.x (5 CVEs including critical SSRF).
     # Must stay >=3.2.3,<4 until mcp-core bumps its own floor past 3.x.

--- a/uv.lock
+++ b/uv.lock
@@ -1732,7 +1732,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.6.2"
+version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1745,9 +1745,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/60/f81f1d394228cd00cc46966d37919b7036086731f56f2ddb71907daa1ddf/n24q02m_mcp_core-1.6.2.tar.gz", hash = "sha256:253686a8c52a2cb5744d375b2c01375599280d1ee0cd9d7b8b2bfce3b31b157e", size = 153937, upload-time = "2026-04-22T08:05:55.185Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/da/50f3012aa594b42b875b8624668b767e31bfefbac7917d1df802ea5c3940/n24q02m_mcp_core-1.6.3.tar.gz", hash = "sha256:84d66bc8d088701d6aa6cb7db7244b01db433d4cd86c48f2120a1ace31b8fa2b", size = 154516, upload-time = "2026-04-22T10:01:57.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/25/5b075e9e677cb4de5c2c2a31fd83d05443e0a7ce891cd89ef46af7495275/n24q02m_mcp_core-1.6.2-py3-none-any.whl", hash = "sha256:7211bb7403850c289e7267b438ef1d36d6511f95db44eb6a7b83b176ade1359a", size = 93986, upload-time = "2026-04-22T08:05:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f6/98954d794692979adc1ccea1e76126bce12154772c2fdeac899c79e635fd/n24q02m_mcp_core-1.6.3-py3-none-any.whl", hash = "sha256:3025e35dd31a92939f222f7235eda516f9bc4a57c99bafeaea6e98808369bf0b", size = 94351, upload-time = "2026-04-22T10:01:55.802Z" },
 ]
 
 [[package]]
@@ -3350,7 +3350,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.26.3"
+version = "2.26.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3408,7 +3408,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.6.2" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.6.3" },
     { name = "n24q02m-web-core", specifier = ">=1.3.5" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pillow", specifier = ">=12.2.0" },


### PR DESCRIPTION
Pulls mcp-core 1.6.3: relay form now navigates to redirect_url on successful POST /authorize (was showing static 'close tab' message, causing external OAuth clients to hang). See mcp-core PR #75.