### PR TITLE
feat: multi-user remote mode (PUBLIC_URL + per-JWT-sub)

### DIFF
--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -20,9 +20,11 @@ is reserved for explicit ``MCP_MODE`` HTTP deployments. See
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from collections.abc import Callable
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -319,13 +321,47 @@ def _share_cloud_keys_to_peers(config: dict[str, str]) -> None:
         )
 
 
-def save_credentials(config: dict[str, str], _context: dict[str, str]) -> dict | None:
+def _sub_data_dir(sub: str) -> Path:
+    """Per-sub data directory under ``WET_DATA_DIR`` (or ``~/.wet-mcp``).
+
+    Used by remote multi-user mode (``PUBLIC_URL`` set): each authenticated
+    JWT subject gets its own credential bucket, isolated from other users
+    that authorized concurrently against the same wet-mcp deployment.
+    """
+    base = Path(os.environ.get("WET_DATA_DIR", str(Path.home() / ".wet-mcp")))
+    d = base / "subs" / sub
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def store_for_sub(sub: str, config: dict[str, str]) -> None:
+    """Persist a credential dict for a specific JWT ``sub``.
+
+    Plain JSON (not config.enc): remote multi-user deployments rely on the
+    host filesystem permissions plus mcp-core's per-sub directory scoping
+    rather than the local single-user encrypted store.
+    """
+    (_sub_data_dir(sub) / "config.json").write_text(json.dumps(config))
+
+
+def read_for_sub(sub: str) -> dict[str, str]:
+    """Load the credential dict previously stored for ``sub``.
+
+    Returns an empty dict when no credentials have been saved for the
+    subject yet (first /authorize for a brand-new user).
+    """
+    p = _sub_data_dir(sub) / "config.json"
+    return json.loads(p.read_text()) if p.exists() else {}
+
+
+def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
     """Save credentials from OAuth form to config.enc and apply to environment.
 
-    ``_context`` carries the per-authorize ``sub`` (for future multi-user
-    extensions). Wet-mcp is single-user by design — optional API keys live in
-    one shared ``config.enc`` on the host running the server, so the subject
-    is intentionally unused here.
+    ``context`` carries the per-authorize ``sub`` issued by mcp-core's local
+    OAuth AS. In remote multi-user mode (``PUBLIC_URL`` set) we route the
+    credentials into a per-sub bucket via :func:`store_for_sub` so concurrent
+    users do not overwrite each other. In single-user mode the subject is
+    ignored and a single ``config.enc`` on the host is reused.
 
     Called by the local OAuth AS when the user submits API keys via the
     browser form. Writes to encrypted config file, applies to env vars
@@ -336,6 +372,17 @@ def save_credentials(config: dict[str, str], _context: dict[str, str]) -> dict |
     for the form to display.
     """
     global _state
+
+    # Remote multi-user branch: scope credential storage by JWT sub so
+    # concurrent /authorize sessions do not clobber each other.
+    if os.environ.get("PUBLIC_URL"):
+        sub = context.get("sub") if context else None
+        if not sub:
+            raise RuntimeError("multi-user mode: SubjectContext sub required")
+        store_for_sub(sub, config)
+        _state = CredentialState.CONFIGURED
+        logger.info(f"Credentials saved for sub={sub} via remote multi-user form")
+        return None
 
     from mcp_core.storage.config_file import write_config
 

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2027,24 +2027,38 @@ async def _do_immediate_fallback_search(
 
 
 async def run_http(port: int = 0) -> None:
-    """Run wet-mcp as local HTTP server with OAuth credential flow.
+    """Run wet-mcp as HTTP server. Local single-user (default) or remote
+    multi-user (when PUBLIC_URL env set).
 
-    Starts an HTTP server on 127.0.0.1 with a local OAuth 2.1 AS that
-    serves a credential form. When the user submits API keys, they are
-    saved to config.enc and applied to the environment immediately.
-
-    Args:
-        port: TCP port to bind. 0 means auto-find a free port.
+    Local mode binds 127.0.0.1 with a single shared ``config.enc``. Remote
+    multi-user mode binds 0.0.0.0:8080, requires ``MCP_DCR_SERVER_SECRET``
+    as proof of intentional multi-user deployment, and scopes credentials
+    per JWT ``sub`` (see ``credential_state.store_for_sub``).
     """
     from mcp_core.transport.local_server import run_local_server
 
     from wet_mcp.credential_state import save_credentials, wire_gdrive_callbacks
     from wet_mcp.relay_schema import RELAY_SCHEMA
 
+    public_url = os.environ.get("PUBLIC_URL")
+    if public_url:
+        if not os.environ.get("MCP_DCR_SERVER_SECRET"):
+            raise SystemExit(
+                "wet-mcp refuses to start: PUBLIC_URL set but "
+                "MCP_DCR_SERVER_SECRET missing. Multi-user remote mode "
+                "requires the DCR secret as proof of intentional multi-user "
+                "deployment (prevents accidental single-user credential leak)."
+            )
+        host = "0.0.0.0"
+        port = int(os.environ.get("MCP_PORT", "8080"))
+    else:
+        host = "127.0.0.1"
+
     await run_local_server(
         mcp,  # ty: ignore[invalid-argument-type]
         server_name="wet-mcp",
         relay_schema=RELAY_SCHEMA,
+        host=host,
         port=port,
         on_credentials_saved=save_credentials,
         # 2-arg hook: receive BOTH mark_setup_complete and mark_setup_failed
@@ -2053,52 +2067,6 @@ async def run_http(port: int = 0) -> None:
         # stuck on "Waiting for authorization..." forever.
         setup_complete_hook=wire_gdrive_callbacks,
     )
-
-
-async def run_remote_relay() -> None:
-    """Run wet-mcp in remote-relay mode (self-host deployment).
-
-    Fetch credentials via a remote relay server (``MCP_RELAY_URL``) using
-    ``create_session`` + ``poll_for_result`` from mcp-core, then serve the
-    MCP protocol over Streamable HTTP on ``127.0.0.1:<port>``.
-
-    Unlike the default ``http local relay`` mode, this path does NOT serve
-    a credential form locally -- the user pastes API keys into the remote
-    relay's browser form (URL printed to stderr) and the encrypted payload
-    flows back through ECDH + AES-256-GCM.
-    """
-    from wet_mcp.relay_setup import apply_config, ensure_config
-
-    # Block until the relay session completes (user submits creds at the
-    # remote URL printed below, 5-minute default window). `force=True`
-    # skips the "already have creds" shortcut so the relay flow always
-    # runs.  A finite timeout is required -- poll_for_result treats None
-    # as an invalid deadline and raises before the user can react.
-    try:
-        timeout = float(os.environ.get("MCP_RELAY_TIMEOUT_S", "300"))
-    except ValueError:
-        timeout = 300.0
-    config = await ensure_config(force=True, timeout=timeout)
-    if config is None:
-        logger.warning(
-            "Remote relay produced no credentials; continuing in LOCAL mode "
-            "(ONNX embedding + SearXNG). Set API keys via env vars to re-enable cloud."
-        )
-    else:
-        apply_config(config)
-
-    # Serve MCP protocol only. No /authorize form -- creds already settled.
-    host = os.environ.get("MCP_HOST", "127.0.0.1")
-    try:
-        port = int(os.environ.get("MCP_PORT", "0"))
-    except ValueError:
-        port = 0
-    mcp.settings.host = host
-    mcp.settings.port = port
-    logger.info(
-        f"Starting MCP Streamable HTTP on {host}:{port or '<auto>'}{mcp.settings.streamable_http_path}"
-    )
-    await mcp.run_streamable_http_async()
 
 
 def main() -> None:
@@ -2122,13 +2090,17 @@ def main() -> None:
         daemon_cmd = [sys.executable, "-m", "wet_mcp"]
         sys.exit(run_smart_stdio_proxy("wet-mcp", daemon_cmd))
     elif mode == "remote-relay":
-        asyncio.run(run_remote_relay())
+        raise SystemExit(
+            "MCP_MODE=remote-relay is deprecated since 2026-04-25 (single-user "
+            "MCP_RELAY_URL pattern). For multi-user remote: set PUBLIC_URL + "
+            "MCP_DCR_SERVER_SECRET and run with default mode."
+        )
     elif mode in ("", "local-relay"):
         asyncio.run(run_http())
     else:
         raise SystemExit(
-            f"Unsupported MCP_MODE={mode!r}. Supported: local-relay (default), "
-            "remote-relay, or set MCP_TRANSPORT=stdio / pass --stdio."
+            f"Unsupported MCP_MODE={mode!r}. Supported: local-relay (default) "
+            "or set MCP_TRANSPORT=stdio / pass --stdio."
         )
 
 

--- a/tests/integration/test_multi_user_remote.py
+++ b/tests/integration/test_multi_user_remote.py
@@ -1,0 +1,31 @@
+"""Per-sub credential isolation in wet-mcp remote multi-user mode."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_two_subs_isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    from wet_mcp.credential_state import read_for_sub, store_for_sub
+
+    store_for_sub("user_a", {"JINA_AI_API_KEY": "key_a"})
+    store_for_sub("user_b", {"JINA_AI_API_KEY": "key_b"})
+
+    assert read_for_sub("user_a") == {"JINA_AI_API_KEY": "key_a"}
+    assert read_for_sub("user_b") == {"JINA_AI_API_KEY": "key_b"}
+    assert read_for_sub("user_a") != read_for_sub("user_b")
+
+
+@pytest.mark.integration
+def test_save_credentials_uses_sub_when_public_url_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PUBLIC_URL", "https://wet.example.com")
+    from wet_mcp.credential_state import read_for_sub, save_credentials
+
+    save_credentials({"JINA_AI_API_KEY": "k1"}, {"sub": "user_a"})
+    save_credentials({"JINA_AI_API_KEY": "k2"}, {"sub": "user_b"})
+
+    assert read_for_sub("user_a")["JINA_AI_API_KEY"] == "k1"
+    assert read_for_sub("user_b")["JINA_AI_API_KEY"] == "k2"

--- a/tests/test_server_main_dispatch.py
+++ b/tests/test_server_main_dispatch.py
@@ -1,134 +1,23 @@
-"""Tests for wet_mcp.server main() entry point + run_remote_relay().
+"""Tests for wet_mcp.server main() entry point + run_http() modes.
 
-Covers MCP_MODE dispatch branches and the remote-relay setup wired in
-2026-04-22 (matrix correction for self-host semantics).
+Covers MCP_MODE dispatch branches and the multi-user remote mode wired in
+2026-04-26 (PUBLIC_URL switch + per-sub credential storage). The legacy
+``run_remote_relay()`` (single-user MCP_RELAY_URL pattern) was deleted in
+the same change; ``MCP_MODE=remote-relay`` now raises a deprecation
+SystemExit.
 """
 
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-
-
-class TestRunRemoteRelay:
-    """run_remote_relay() drives ensure_config and starts Streamable HTTP."""
-
-    @pytest.fixture(autouse=True)
-    def _relay_url(self, monkeypatch):
-        """Remote-relay mode requires explicit MCP_RELAY_URL per matrix 2.5."""
-        monkeypatch.setenv("MCP_RELAY_URL", "https://relay.example.com")
-
-    async def test_ensure_config_applied_when_available(self, monkeypatch):
-        """Happy path: ensure_config returns creds, apply_config called, server starts."""
-        from wet_mcp.server import run_remote_relay
-
-        mock_config = {"GEMINI_API_KEY": "from-relay"}
-
-        with (
-            patch(
-                "wet_mcp.relay_setup.ensure_config", new_callable=AsyncMock
-            ) as mock_ec,
-            patch("wet_mcp.relay_setup.apply_config") as mock_apply,
-            patch("wet_mcp.server.mcp") as mock_mcp,
-        ):
-            mock_ec.return_value = mock_config
-            mock_mcp.run_streamable_http_async = AsyncMock()
-            mock_mcp.settings = MagicMock()
-
-            await run_remote_relay()
-
-            mock_ec.assert_called_once()
-            mock_apply.assert_called_once_with(mock_config)
-            mock_mcp.run_streamable_http_async.assert_called_once()
-
-    async def test_warns_when_relay_produces_no_creds(self, monkeypatch):
-        """When ensure_config returns None, logs warning but still starts server."""
-        from wet_mcp.server import run_remote_relay
-
-        with (
-            patch(
-                "wet_mcp.relay_setup.ensure_config", new_callable=AsyncMock
-            ) as mock_ec,
-            patch("wet_mcp.relay_setup.apply_config") as mock_apply,
-            patch("wet_mcp.server.mcp") as mock_mcp,
-        ):
-            mock_ec.return_value = None
-            mock_mcp.run_streamable_http_async = AsyncMock()
-            mock_mcp.settings = MagicMock()
-
-            await run_remote_relay()
-
-            mock_apply.assert_not_called()
-            mock_mcp.run_streamable_http_async.assert_called_once()
-
-    async def test_reads_mcp_host_port_env_vars(self, monkeypatch):
-        """MCP_HOST and MCP_PORT env vars override defaults."""
-        from wet_mcp.server import run_remote_relay
-
-        monkeypatch.setenv("MCP_HOST", "0.0.0.0")
-        monkeypatch.setenv("MCP_PORT", "18080")
-
-        with (
-            patch(
-                "wet_mcp.relay_setup.ensure_config", new_callable=AsyncMock
-            ) as mock_ec,
-            patch("wet_mcp.server.mcp") as mock_mcp,
-        ):
-            mock_ec.return_value = None
-            mock_mcp.run_streamable_http_async = AsyncMock()
-            mock_mcp.settings = MagicMock()
-
-            await run_remote_relay()
-
-            assert mock_mcp.settings.host == "0.0.0.0"
-            assert mock_mcp.settings.port == 18080
-
-    async def test_invalid_port_falls_back_to_zero(self, monkeypatch):
-        """Non-numeric MCP_PORT uses auto-port (0)."""
-        from wet_mcp.server import run_remote_relay
-
-        monkeypatch.setenv("MCP_PORT", "not-a-number")
-
-        with (
-            patch(
-                "wet_mcp.relay_setup.ensure_config", new_callable=AsyncMock
-            ) as mock_ec,
-            patch("wet_mcp.server.mcp") as mock_mcp,
-        ):
-            mock_ec.return_value = None
-            mock_mcp.run_streamable_http_async = AsyncMock()
-            mock_mcp.settings = MagicMock()
-
-            await run_remote_relay()
-
-            assert mock_mcp.settings.port == 0
-
-    async def test_invalid_timeout_falls_back_to_300(self, monkeypatch):
-        """Non-numeric MCP_RELAY_TIMEOUT_S uses default 300s."""
-        from wet_mcp.server import run_remote_relay
-
-        monkeypatch.setenv("MCP_RELAY_TIMEOUT_S", "not-a-number")
-
-        with (
-            patch(
-                "wet_mcp.relay_setup.ensure_config", new_callable=AsyncMock
-            ) as mock_ec,
-            patch("wet_mcp.server.mcp") as mock_mcp,
-        ):
-            mock_ec.return_value = None
-            mock_mcp.run_streamable_http_async = AsyncMock()
-            mock_mcp.settings = MagicMock()
-
-            await run_remote_relay()
-
-            _, kwargs = mock_ec.call_args
-            assert kwargs["timeout"] == 300.0
 
 
 class TestRunHttp:
     """run_http() starts local HTTP server via mcp-core run_local_server."""
 
-    async def test_delegates_to_run_local_server(self):
+    async def test_delegates_to_run_local_server(self, monkeypatch):
+        monkeypatch.delenv("PUBLIC_URL", raising=False)
         from wet_mcp.server import run_http
 
         with (
@@ -143,10 +32,12 @@ class TestRunHttp:
             args, kwargs = mock_run_local.call_args
             assert kwargs["server_name"] == "wet-mcp"
             assert kwargs["port"] == 0
+            assert kwargs["host"] == "127.0.0.1"
             assert "relay_schema" in kwargs
             assert "on_credentials_saved" in kwargs
 
-    async def test_custom_port_passed_through(self):
+    async def test_custom_port_passed_through(self, monkeypatch):
+        monkeypatch.delenv("PUBLIC_URL", raising=False)
         from wet_mcp.server import run_http
 
         with patch(
@@ -156,6 +47,52 @@ class TestRunHttp:
             await run_http(port=19999)
             _, kwargs = mock_run_local.call_args
             assert kwargs["port"] == 19999
+
+    async def test_public_url_without_dcr_secret_refuses_start(self, monkeypatch):
+        """Multi-user remote mode requires MCP_DCR_SERVER_SECRET."""
+        from wet_mcp.server import run_http
+
+        monkeypatch.setenv("PUBLIC_URL", "https://wet.example.com")
+        monkeypatch.delenv("MCP_DCR_SERVER_SECRET", raising=False)
+
+        with pytest.raises(SystemExit, match="MCP_DCR_SERVER_SECRET missing"):
+            await run_http()
+
+    async def test_public_url_with_dcr_secret_binds_0000_8080(self, monkeypatch):
+        """PUBLIC_URL + MCP_DCR_SERVER_SECRET -> 0.0.0.0:8080 multi-user remote."""
+        from wet_mcp.server import run_http
+
+        monkeypatch.setenv("PUBLIC_URL", "https://wet.example.com")
+        monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "test-dcr-secret")
+        monkeypatch.delenv("MCP_PORT", raising=False)
+
+        with patch(
+            "mcp_core.transport.local_server.run_local_server",
+            new_callable=AsyncMock,
+        ) as mock_run_local:
+            await run_http()
+
+            _, kwargs = mock_run_local.call_args
+            assert kwargs["host"] == "0.0.0.0"
+            assert kwargs["port"] == 8080
+
+    async def test_public_url_respects_mcp_port_override(self, monkeypatch):
+        """MCP_PORT overrides default 8080 in multi-user remote mode."""
+        from wet_mcp.server import run_http
+
+        monkeypatch.setenv("PUBLIC_URL", "https://wet.example.com")
+        monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "test-dcr-secret")
+        monkeypatch.setenv("MCP_PORT", "9090")
+
+        with patch(
+            "mcp_core.transport.local_server.run_local_server",
+            new_callable=AsyncMock,
+        ) as mock_run_local:
+            await run_http()
+
+            _, kwargs = mock_run_local.call_args
+            assert kwargs["host"] == "0.0.0.0"
+            assert kwargs["port"] == 9090
 
 
 class TestMainDispatch:
@@ -199,20 +136,16 @@ class TestMainDispatch:
         args = mock_proxy.call_args[0]
         assert args[0] == "wet-mcp"
 
-    def test_remote_relay_mode_runs_remote_relay(self, monkeypatch):
+    def test_remote_relay_mode_raises_deprecation(self, monkeypatch):
+        """MCP_MODE=remote-relay was deprecated 2026-04-26 (single-user pattern)."""
         from wet_mcp.server import main
 
         monkeypatch.setattr(sys, "argv", ["wet-mcp"])
         monkeypatch.setenv("MCP_MODE", "remote-relay")
         monkeypatch.delenv("MCP_TRANSPORT", raising=False)
 
-        with (
-            patch("wet_mcp.server.asyncio.run") as mock_run,
-            patch("wet_mcp.server.run_remote_relay") as mock_remote,
-        ):
+        with pytest.raises(SystemExit, match="deprecated"):
             main()
-            mock_run.assert_called_once()
-            mock_remote.assert_called_once()
 
     def test_local_relay_mode_runs_http(self, monkeypatch):
         from wet_mcp.server import main


### PR DESCRIPTION
## Summary
- Multi-user remote mode via \`PUBLIC_URL\` env switch
- Per-JWT-sub credential storage (\`store_for_sub\`/\`read_for_sub\`)
- Refuses to start in remote mode without \`MCP_DCR_SERVER_SECRET\`
- Drops legacy \`run_remote_relay()\` (single-user shared config)

## Test plan
- [x] Unit tests pass
- [ ] T2 wet-full live verification post-CI image build

🤖 Generated with [Claude Code](https://claude.com/claude-code)