### PR TITLE
fix(credentials): rip _share_cloud_keys_to_peers — per-server isolation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -23,7 +23,10 @@
         "--python",
         "3.13",
         "wet-mcp"
-      ]
+      ],
+      "env": {
+        "MCP_TRANSPORT": "stdio"
+      }
     }
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: ty
         name: ty type check
-        entry: uv run ty check
+        entry: uv run --no-sync ty check
         language: system
         types: [python]
         pass_filenames: false
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest (Python)
-        entry: uv run pytest --tb=short -q --timeout=30
+        entry: uv run --no-sync pytest --tb=short -q --timeout=30
         language: system
         types: [python]
         pass_filenames: false

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -174,8 +174,6 @@ def resolve_credential_state() -> CredentialState:
                     os.environ[key] = value
             logger.info("Config loaded from encrypted file")
             _state = CredentialState.CONFIGURED
-            # Propagate shared cloud keys to sibling servers on every startup
-            _share_cloud_keys_to_peers(saved)
             return _state
     except Exception:
         logger.opt(exception=True).debug("Failed to read config")
@@ -294,31 +292,6 @@ async def trigger_relay_setup(
         await _close_active_handle()
         _setup_url = None
         return None
-
-
-def _share_cloud_keys_to_peers(config: dict[str, str]) -> None:
-    """Write shared cloud API keys to mnemo-mcp and CRG config files.
-
-    wet-mcp, mnemo-mcp, and better-code-review-graph all use the same
-    cloud embedding/LLM keys. Sharing avoids needing separate relay sessions
-    for each server — one relay configures all three.
-    """
-    try:
-        from mcp_core.storage.config_file import write_config
-
-        shared = {k: v for k, v in config.items() if k in CLOUD_KEYS and v}
-        if not shared:
-            return
-        for peer in ("mnemo-mcp", "better-code-review-graph"):
-            try:
-                write_config(peer, shared)
-                logger.debug("Shared cloud keys to {}", peer)
-            except Exception:
-                logger.opt(exception=True).debug("Failed to share keys to {}", peer)
-    except Exception:
-        logger.opt(exception=True).debug(
-            "_share_cloud_keys_to_peers failed (non-fatal)"
-        )
 
 
 def _sub_data_dir(sub: str) -> Path:
@@ -460,9 +433,6 @@ def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | 
         logger.opt(exception=True).debug(
             "Provider re-init after save failed (non-fatal)"
         )
-
-    # Share cloud keys with sibling servers
-    _share_cloud_keys_to_peers(config)
 
     # Trigger GDrive OAuth Device Code flow if configured
     try:

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -414,61 +414,42 @@ class TestServerSetupToolNewActions:
             mock_settings.setup_providers.assert_called_once()
 
 
-class TestShareCloudKeysToPeers:
-    """Tests for _share_cloud_keys_to_peers helper."""
+class TestCredentialIsolation:
+    """save_credentials must NOT write to peer MCP server configs.
 
-    def test_shares_cloud_keys(self):
-        """Shares matching cloud keys to peer servers."""
-        from wet_mcp.credential_state import _share_cloud_keys_to_peers
+    Replaces the prior `_share_cloud_keys_to_peers` helper which intentionally
+    propagated cloud keys to mnemo-mcp + crg. The transparent-bridge
+    architecture mandates per-server credential isolation: each server
+    presents its own relay form and persists only its own keys, so a
+    compromised key in one server never leaks into another.
+    """
 
-        config = {"GEMINI_API_KEY": "test-key", "SOME_OTHER": "val"}
-        with patch("mcp_core.storage.config_file.write_config") as mock_write:
-            _share_cloud_keys_to_peers(config)
-            assert mock_write.call_count == 2
-            # Should write to both peers
-            calls = [c.args[0] for c in mock_write.call_args_list]
-            assert "mnemo-mcp" in calls
-            assert "better-code-review-graph" in calls
+    def test_save_credentials_does_not_write_to_peers(self):
+        """save_credentials must touch only wet-mcp's own config."""
+        from wet_mcp.credential_state import save_credentials
 
-    def test_skips_when_no_cloud_keys(self):
-        """Skips when config has no matching cloud keys."""
-        from wet_mcp.credential_state import _share_cloud_keys_to_peers
+        config = {
+            "GEMINI_API_KEY": "test-key",
+            "JINA_AI_API_KEY": "jina",
+        }
 
-        config = {"SOME_KEY": "value"}
-        with patch("mcp_core.storage.config_file.write_config") as mock_write:
-            _share_cloud_keys_to_peers(config)
-            mock_write.assert_not_called()
-
-    def test_handles_write_error(self):
-        """Handles write_config error for individual peer and continues."""
-        from wet_mcp.credential_state import _share_cloud_keys_to_peers
-
-        config = {"OPENAI_API_KEY": "test-key"}
-
-        def side_effect(peer, shared):
-            if peer == "mnemo-mcp":
-                raise RuntimeError("mnemo failed")
-            return None
-
-        with patch(
-            "mcp_core.storage.config_file.write_config",
-            side_effect=side_effect,
-        ) as mock_write:
-            # Should not raise
-            _share_cloud_keys_to_peers(config)
-            # Should still attempt both peers
-            assert mock_write.call_count == 2
-
-    def test_handles_import_error(self):
-        """Handles import error gracefully."""
-        from wet_mcp.credential_state import _share_cloud_keys_to_peers
-
-        config = {"GEMINI_API_KEY": "test-key"}
-        with patch(
-            "mcp_core.storage.config_file.write_config",
-            side_effect=ImportError("no module"),
+        with (
+            patch("mcp_core.storage.config_file.write_config") as mock_write_config,
+            patch("wet_mcp.relay_setup.apply_config"),
+            patch("wet_mcp.config.settings"),
         ):
-            _share_cloud_keys_to_peers(config)
+            save_credentials(config, {"sub": "local-user"})
+
+            written_servers = [c.args[0] for c in mock_write_config.call_args_list]
+            assert all(s == "wet-mcp" for s in written_servers), written_servers
+            for peer in ("mnemo-mcp", "better-code-review-graph", "imagine-mcp"):
+                assert peer not in written_servers
+
+    def test_no_share_cloud_keys_to_peers_function_exists(self):
+        """Defensive: regression guard against re-introducing peer sharing."""
+        import wet_mcp.credential_state as mod
+
+        assert not hasattr(mod, "_share_cloud_keys_to_peers")
 
 
 class TestRequireCredentials:
@@ -536,7 +517,6 @@ class TestSaveCredentialsGdriveNextStep:
         with (
             patch("mcp_core.storage.config_file.write_config"),
             patch("wet_mcp.relay_setup.apply_config"),
-            patch("wet_mcp.credential_state._share_cloud_keys_to_peers"),
             patch("wet_mcp.config.settings") as mock_settings,
             patch("httpx.post", return_value=mock_httpx_response),
             patch("threading.Thread") as mock_thread,
@@ -565,7 +545,6 @@ class TestSaveCredentialsGdriveNextStep:
         with (
             patch("mcp_core.storage.config_file.write_config"),
             patch("wet_mcp.relay_setup.apply_config"),
-            patch("wet_mcp.credential_state._share_cloud_keys_to_peers"),
             patch("wet_mcp.config.settings") as mock_settings,
             patch("httpx.post", return_value=mock_httpx_response),
         ):
@@ -583,7 +562,6 @@ class TestSaveCredentialsGdriveNextStep:
         with (
             patch("mcp_core.storage.config_file.write_config"),
             patch("wet_mcp.relay_setup.apply_config"),
-            patch("wet_mcp.credential_state._share_cloud_keys_to_peers"),
             patch("wet_mcp.config.settings") as mock_settings,
         ):
             mock_settings.google_drive_client_id = ""
@@ -601,7 +579,6 @@ class TestSaveCredentialsGdriveNextStep:
         with (
             patch("mcp_core.storage.config_file.write_config"),
             patch("wet_mcp.relay_setup.apply_config"),
-            patch("wet_mcp.credential_state._share_cloud_keys_to_peers"),
             patch("wet_mcp.config.settings") as mock_settings,
         ):
             mock_settings.setup_providers = MagicMock(
@@ -631,7 +608,6 @@ class TestSaveCredentialsGdriveNextStep:
         with (
             patch("mcp_core.storage.config_file.write_config"),
             patch("wet_mcp.relay_setup.apply_config"),
-            patch("wet_mcp.credential_state._share_cloud_keys_to_peers"),
             patch("wet_mcp.config.settings") as mock_settings,
             patch("httpx.post", return_value=mock_httpx_response),
             patch("threading.Thread") as mock_thread,
@@ -664,7 +640,6 @@ class TestSaveCredentialsGdriveNextStep:
         with (
             patch("mcp_core.storage.config_file.write_config"),
             patch("wet_mcp.relay_setup.apply_config"),
-            patch("wet_mcp.credential_state._share_cloud_keys_to_peers"),
             patch("wet_mcp.config.settings") as mock_settings,
             patch("httpx.post", side_effect=ConnectionError("oauth down")),
         ):
@@ -810,33 +785,6 @@ class TestSetGdriveFailedCallback:
         assert mod._on_gdrive_failed is None
 
         _reset_callbacks_for_test()
-
-
-class TestShareCloudKeysOuterException:
-    def test_outer_import_error_non_fatal(self):
-        """Outer ImportError for write_config should be swallowed."""
-        import builtins
-
-        from wet_mcp.credential_state import _share_cloud_keys_to_peers
-
-        real_import = builtins.__import__
-
-        def fake_import(name, *args, **kwargs):
-            if name == "mcp_core.storage.config_file":
-                raise ImportError("no mcp_core")
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=fake_import):
-            # Should not raise
-            _share_cloud_keys_to_peers({"GEMINI_API_KEY": "key"})
-
-    def test_outer_exception_swallowed(self):
-        """Broad Exception in outer block should be swallowed."""
-        from wet_mcp.credential_state import _share_cloud_keys_to_peers
-
-        # Passing None as config triggers AttributeError in shared = {...}
-        with patch("mcp_core.storage.config_file.write_config"):
-            _share_cloud_keys_to_peers(None)  # type: ignore
 
 
 class TestGdriveTokenPoll:

--- a/uv.lock
+++ b/uv.lock
@@ -3366,7 +3366,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.28.2"
+version = "2.28.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Wave 4 of the Transparent Bridge plan: each MCP server owns its own credentials.

Changes:
- Removed `_share_cloud_keys_to_peers` helper. wet-mcp no longer writes to mnemo-mcp / better-code-review-graph configs.
- Removed module-level call from resolve_credential_state and save_credentials.
- Replaced TestShareCloudKeys* tests with TestCredentialIsolation regression guard (no peer writes, helper does not exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)