### PR TITLE
fix: register config__open_relay tool (Transparent Bridge Wave 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # Per-domain rate limiting for batch operations
     "aiolimiter>=1.2.1",
     # Relay setup (zero-env-config)
-    "n24q02m-mcp-core>=1.10.0",
+    "n24q02m-mcp-core>=1.11.0",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance
     # downgrading to CVE-vulnerable 2.x (5 CVEs including critical SSRF).
     # Must stay >=3.2.3,<4 until mcp-core bumps its own floor past 3.x.

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -456,6 +456,15 @@ mcp = FastMCP(
     lifespan=_lifespan,
 )
 
+# Register the standard `config__open_relay` MCP tool so an LLM can re-trigger
+# the relay form after the daemon is already running (Transparent Bridge v2).
+# Helper lives in mcp-core >=1.11.0; see ``register_open_relay_tool`` docstring.
+from mcp_core.relay.tool_helpers import register_open_relay_tool  # noqa: E402
+
+from wet_mcp.relay_schema import RELAY_SCHEMA  # noqa: E402
+
+register_open_relay_tool(mcp, "wet-mcp", RELAY_SCHEMA)
+
 # Grace period (seconds) given to a cancelled task to clean up resources
 # (e.g. close browser tabs) before we abandon it entirely.
 _CANCEL_GRACE_PERIOD = 5.0

--- a/tests/test_config_open_relay_registered.py
+++ b/tests/test_config_open_relay_registered.py
@@ -1,0 +1,21 @@
+"""Smoke test: ``config__open_relay`` MCP tool is registered.
+
+Transparent Bridge v2 (Wave 3) — wet-mcp consumes the
+``register_open_relay_tool`` helper from ``mcp-core`` so an LLM can
+re-trigger the relay form after the daemon is already running. This test
+imports ``wet_mcp.server`` (running module-level registration) and asserts
+the tool name appears in the FastMCP tool registry.
+"""
+
+from __future__ import annotations
+
+
+def test_config_open_relay_tool_is_registered() -> None:
+    from wet_mcp import server
+
+    names = {tool.name for tool in server.mcp._tool_manager.list_tools()}
+    assert "config__open_relay" in names, (
+        "register_open_relay_tool() must register `config__open_relay` "
+        "into the FastMCP instance at module import time. Registered "
+        f"tools were: {sorted(names)}"
+    )


### PR DESCRIPTION
## Summary

- Bump `n24q02m-mcp-core` pin from `>=1.10.0` to `>=1.11.0` to pull in the new `register_open_relay_tool` helper.
- Register the standard `config__open_relay` MCP tool at module import time in `src/wet_mcp/server.py`, right after the `FastMCP(...)` instance is constructed. An LLM can now re-trigger the relay form after the daemon is already running; the tool returns `{url, browser_opened, status}` and auto-respawns the daemon if it died.
- Reuses `RELAY_SCHEMA` already defined in `wet_mcp.relay_schema` — no circular import (the schema module only depends on `typing`). Schema unchanged, no new fields, existing relay flow untouched.
- Wave 3 of the Transparent Bridge v2 cascade across the MCP stack.

## Test plan

- [x] `uv run pytest tests/test_config_open_relay_registered.py -v` — new smoke test passes.
- [x] `uv run pytest -q` — full suite green (1511 passed, 34 skipped).
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean.
- [x] `uv run ty check` — clean.
- [x] Pre-commit hooks (gitleaks, ruff, ty, pytest, commit-prefix) — all passed.
- [x] Manual sanity: `python -c "from wet_mcp import server; print('config__open_relay' in {t.name for t in server.mcp._tool_manager.list_tools()})"` returns `True`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>