### PR TITLE
fix: rebuild uv.lock without local path source

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1748,8 +1748,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.10.0"
-source = { editable = "../mcp-core/packages/core-py" }
+version = "1.11.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -1762,29 +1762,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=47.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "filelock", specifier = ">=3.16.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.9,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.32" },
+sdist = { url = "https://files.pythonhosted.org/packages/41/4d/8e69f77a6bee34d760e00a9e54c604899dcc74959231a488351c290315eb/n24q02m_mcp_core-1.11.1.tar.gz", hash = "sha256:8ebbb010d0d2bf9c30050fc3000b1bd8455e6225ad8ef73c6acce80a12d812a1", size = 193544, upload-time = "2026-04-29T06:01:15.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/77/7e3cd158310b89e62f10460ef8a77c798b35ded70bb1521be49bc88bfc5b/n24q02m_mcp_core-1.11.1-py3-none-any.whl", hash = "sha256:842204935208105b359fe7777fb95ae7c4d019f18b4722a32cda2d8ac10c53d9", size = 120017, upload-time = "2026-04-29T06:01:16.402Z" },
 ]
 
 [[package]]
@@ -3387,7 +3367,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.28.4"
+version = "2.28.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3447,7 +3427,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", editable = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.11.0" },
     { name = "n24q02m-web-core", specifier = ">=1.3.8" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pillow", specifier = ">=12.2.0" },


### PR DESCRIPTION
Docker CD failed because uv.lock had path source instead of PyPI. Re-locked with UV_NO_SOURCES=1. See memory feedback_uv_lock_docker_trap.md.