### PR TITLE
feat: route stdio mode to FastMCP/MCP SDK direct + multi-target Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,14 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 RUN uv run python -m playwright install chromium
 
 # ========================
-# Stage 2: Runtime
+# Stage 2: Runtime base (shared by stdio + http targets)
 # ========================
-FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33
+# Multi-target Dockerfile per spec
+# `~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md`
+# section D6. Build stdio: `docker buildx build --target stdio -t <repo>:stdio .`
+# Build http:  `docker buildx build --target http  -t <repo>:http .`
+# Build latest (= http): `docker buildx build --target http -t <repo>:latest .`
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/n24q02m/wet-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.n24q02m/wet-mcp"
@@ -121,5 +126,18 @@ RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -m appuser \
 VOLUME /data
 USER appuser
 
-# Stdio transport by default
-CMD ["python", "-m", "wet_mcp"]
+# ========================
+# Stage 3a: stdio target (default for plugin marketplace & uvx-style usage)
+# ========================
+FROM runtime AS stdio
+ENV MCP_TRANSPORT=stdio
+ENTRYPOINT ["python", "-m", "wet_mcp"]
+
+# ========================
+# Stage 3b: http target (multi-user remote daemon)
+# ========================
+FROM runtime AS http
+ENV MCP_TRANSPORT=http \
+    MCP_PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["python", "-m", "wet_mcp"]

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2094,10 +2094,11 @@ def main() -> None:
     mode = (os.environ.get("MCP_MODE") or "").strip().lower()
 
     if "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT") == "stdio":
-        from mcp_core.transport import run_smart_stdio_proxy
-
-        daemon_cmd = [sys.executable, "-m", "wet_mcp"]
-        sys.exit(run_smart_stdio_proxy("wet-mcp", daemon_cmd))
+        # Stdio mode: run FastMCP stdio server directly. No bridge layer.
+        # Universal MCP client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
+        # See: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md
+        mcp.run(transport="stdio")
+        return
     elif mode == "remote-relay":
         raise SystemExit(
             "MCP_MODE=remote-relay is deprecated since 2026-04-25 (single-user "

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -543,18 +543,13 @@ async def test_with_timeout_expired():
 
 
 def test_main():
+    """main() in stdio mode runs FastMCP stdio server directly (no bridge)."""
     with (
-        patch(
-            "mcp_core.transport.run_smart_stdio_proxy",
-            return_value=0,
-        ) as mock_proxy,
+        patch.object(server.mcp, "run") as mock_run,
         patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"}),
-        pytest.raises(SystemExit, match="0"),
     ):
         server.main()
-    mock_proxy.assert_called_once()
-    args = mock_proxy.call_args[0]
-    assert args[0] == "wet-mcp"
+    mock_run.assert_called_once_with(transport="stdio")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -1128,19 +1128,13 @@ async def test_discover_docs_url_with_language():
 
 
 def test_main_entry_point():
-    """main() in stdio mode uses run_smart_stdio_proxy."""
+    """main() in stdio mode runs FastMCP stdio server directly (no bridge)."""
     with (
-        patch(
-            "mcp_core.transport.run_smart_stdio_proxy",
-            return_value=0,
-        ) as mock_proxy,
+        patch.object(server.mcp, "run") as mock_run,
         patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"}),
-        pytest.raises(SystemExit, match="0"),
     ):
         server.main()
-    mock_proxy.assert_called_once()
-    args = mock_proxy.call_args[0]
-    assert args[0] == "wet-mcp"
+    mock_run.assert_called_once_with(transport="stdio")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_main_dispatch.py
+++ b/tests/test_server_main_dispatch.py
@@ -99,42 +99,30 @@ class TestMainDispatch:
     """main() routes to correct entry point based on MCP_MODE."""
 
     def test_stdio_flag_runs_mcp(self, monkeypatch):
+        """--stdio flag routes main() to FastMCP stdio server directly."""
+        from wet_mcp import server
         from wet_mcp.server import main
 
         monkeypatch.setattr(sys, "argv", ["wet-mcp", "--stdio"])
         monkeypatch.delenv("MCP_MODE", raising=False)
         monkeypatch.delenv("MCP_TRANSPORT", raising=False)
 
-        with (
-            patch(
-                "mcp_core.transport.run_smart_stdio_proxy",
-                return_value=0,
-            ) as mock_proxy,
-            pytest.raises(SystemExit, match="0"),
-        ):
+        with patch.object(server.mcp, "run") as mock_run:
             main()
-        mock_proxy.assert_called_once()
-        args = mock_proxy.call_args[0]
-        assert args[0] == "wet-mcp"
+        mock_run.assert_called_once_with(transport="stdio")
 
     def test_mcp_transport_stdio_runs_mcp(self, monkeypatch):
+        """MCP_TRANSPORT=stdio routes main() to FastMCP stdio server directly."""
+        from wet_mcp import server
         from wet_mcp.server import main
 
         monkeypatch.setattr(sys, "argv", ["wet-mcp"])
         monkeypatch.setenv("MCP_TRANSPORT", "stdio")
         monkeypatch.delenv("MCP_MODE", raising=False)
 
-        with (
-            patch(
-                "mcp_core.transport.run_smart_stdio_proxy",
-                return_value=0,
-            ) as mock_proxy,
-            pytest.raises(SystemExit, match="0"),
-        ):
+        with patch.object(server.mcp, "run") as mock_run:
             main()
-        mock_proxy.assert_called_once()
-        args = mock_proxy.call_args[0]
-        assert args[0] == "wet-mcp"
+        mock_run.assert_called_once_with(transport="stdio")
 
     def test_remote_relay_mode_raises_deprecation(self, monkeypatch):
         """MCP_MODE=remote-relay was deprecated 2026-04-26 (single-user pattern)."""

--- a/tests/test_stdio_direct.py
+++ b/tests/test_stdio_direct.py
@@ -1,0 +1,143 @@
+"""Verify wet-mcp runs in stdio direct mode (no smart_stdio bridge).
+
+Spawns ``python -m wet_mcp`` with ``MCP_TRANSPORT=stdio`` and exercises the
+JSON-RPC handshake plus ``tools/list`` to prove the FastMCP stdio server is
+wired directly (no daemon-spawn bridge layer in front of it).
+
+Marked ``live`` because it spawns a real subprocess and speaks the MCP
+protocol; excluded from the default ``pytest`` invocation but runs under
+``uv run pytest -m live``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.live, pytest.mark.timeout(60)]
+
+
+def _spawn_stdio_server() -> subprocess.Popen[str]:
+    """Start ``python -m wet_mcp`` with stdio transport.
+
+    Returns the running subprocess. Caller is responsible for terminating it.
+    """
+    env = {**os.environ, "MCP_TRANSPORT": "stdio"}
+    return subprocess.Popen(
+        [sys.executable, "-m", "wet_mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _read_response(proc: subprocess.Popen[str]) -> dict:
+    """Read one JSON-RPC line from stdout, parsed as dict."""
+    assert proc.stdout is not None and proc.stderr is not None
+    line = proc.stdout.readline()
+    if not line:
+        stderr = proc.stderr.read()
+        raise RuntimeError(
+            f"server closed stdout without sending a response. stderr=\n{stderr}"
+        )
+    return json.loads(line)
+
+
+def test_stdio_direct_init_responds():
+    """Spawn the server with MCP_TRANSPORT=stdio; verify init response shape."""
+    proc = _spawn_stdio_server()
+    assert proc.stdin is not None
+    init_request = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        )
+        + "\n"
+    )
+    try:
+        proc.stdin.write(init_request)
+        proc.stdin.flush()
+        response = _read_response(proc)
+        assert response["id"] == 1
+        assert "result" in response, f"unexpected response: {response}"
+        # FastMCP negotiates protocol version; just assert it returned one.
+        assert "protocolVersion" in response["result"]
+        assert response["result"]["serverInfo"]["name"] == "wet"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_stdio_direct_tools_list_returns_expected_tools():
+    """Verify tools/list returns the expected wet tool set over stdio."""
+    proc = _spawn_stdio_server()
+    assert (
+        proc.stdin is not None and proc.stdout is not None and proc.stderr is not None
+    )
+    requests = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+    ]
+    try:
+        for r in requests:
+            proc.stdin.write(r + "\n")
+            proc.stdin.flush()
+        responses: dict[int, dict] = {}
+        while len(responses) < 2:
+            line = proc.stdout.readline()
+            if not line:
+                stderr = proc.stderr.read()
+                raise RuntimeError(
+                    f"server closed stdout before tools/list response. "
+                    f"stderr=\n{stderr}"
+                )
+            data = json.loads(line)
+            if "id" in data:
+                responses[data["id"]] = data
+        assert 2 in responses, f"missing tools/list response: {responses}"
+        tools = responses[2]["result"]["tools"]
+        tool_names = {t["name"] for t in tools}
+        # Core wet tools that must be exposed in stdio mode. Relay-only tool
+        # ``config__open_relay`` may or may not be registered depending on the
+        # relay-setup state, so we don't assert it here.
+        expected = {"search", "extract", "media", "config", "help"}
+        assert expected.issubset(tool_names), (
+            f"missing tools: {expected - tool_names}; got: {tool_names}"
+        )
+        assert len(tools) >= 5
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
Migrate stdio path from smart_stdio bridge to direct FastMCP/MCP SDK stdio. Universal MCP client compat. Multi-target Dockerfile (:stdio + :http). Spec: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md