### PR TITLE
feat(docs): add trust model section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ uv sync
 uv run wet-mcp
 ```
 
+## Trust Model
+
+This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+
+| Mode | Storage | Encryption | Who can read your data? |
+|---|---|---|---|
+| stdio (default) | `~/.wet-mcp/config.json` | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
+| HTTP self-host | Same as stdio | Same | Only you (admin = user) |
+
 ## License
 
 MIT -- See [LICENSE](LICENSE).


### PR DESCRIPTION
Per spec `~/projects/.superpower/mcp-core/specs/2026-04-30-trust-model-alignment.md` § 4.D4. Links to canonical mcp-core/docs/TRUST-MODEL.md. Documents TC-Local storage, encryption, and threat model.