### PR TITLE
fix: reject web.search in stdio uvx mode (Docker-only feature)

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -33,6 +33,7 @@ from wet_mcp.sources.crawler import (
     sitemap as _sitemap,
 )
 from wet_mcp.sources.searxng import search as searxng_search
+from wet_mcp.transport_check import is_uvx_tool_venv, uvx_searxng_blocked_error
 
 # Configure logging
 logger.remove()
@@ -618,6 +619,17 @@ async def search(  # noqa: PLR0913
     blocked = _require_credentials()
     if blocked:
         return blocked
+
+    # Stdio uvx tool venv lacks pip, so the web-core SearXNG runner cannot
+    # install/start a local SearXNG instance, and its hardcoded
+    # ``localhost:8080`` fallback is wrong for our pinned Docker port.
+    # Per spec ``2026-05-01-stdio-pure-http-multiuser.md`` §4.1.1, reject
+    # SearXNG-dependent actions with a clear error pointing at Method 3
+    # (stdio Docker) or Method 2 (HTTP Docker). Other actions on the
+    # ``extract`` tool (``extract`` / ``crawl`` / ``map`` / ``media``) hit
+    # upstream via ``httpx`` directly and remain available.
+    if action in ("search", "research", "docs", "similar") and is_uvx_tool_venv():
+        return uvx_searxng_blocked_error(action)
 
     match action:
         case "search":

--- a/src/wet_mcp/transport_check.py
+++ b/src/wet_mcp/transport_check.py
@@ -1,0 +1,95 @@
+"""Transport / runtime venv detection helpers.
+
+Stdio uvx native invocation (`uvx wet-mcp`) places the server inside a
+uv-managed tool venv that ships without `pip`. The web-core SearXNG
+runner relies on `pip install` and a Docker fallback that neither is
+available nor reliable in that context (see spec
+``2026-05-01-stdio-pure-http-multiuser.md`` §4.1.1).
+
+This module provides a single memoized predicate, :func:`is_uvx_tool_venv`,
+used to short-circuit ``web.search`` / ``research`` / ``docs`` / ``similar``
+actions with a clear error message in stdio uvx mode. Other actions
+(``extract`` / ``crawl`` / ``map`` / ``media``) remain available because
+they hit upstream HTTP directly via ``httpx`` and require no SearXNG.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_UVX_TOOL_VENV_CACHE: bool | None = None
+
+
+def is_uvx_tool_venv() -> bool:
+    """Return True when the current interpreter lives in a uvx tool venv.
+
+    Detection is positive on either of two independent signals:
+
+    1. ``sys.executable`` contains the ``uv/tools/`` segment used by uv on
+       Linux/Mac (``~/.local/share/uv/tools/<name>/...``) or Windows
+       (``%APPDATA%/uv/tools/<name>/...``).
+    2. ``importlib.util.find_spec("pip")`` returns ``None`` — uv tool venvs
+       deliberately omit pip, while normal venvs (and Docker images that
+       run ``uv sync``) keep it.
+
+    Either signal alone is sufficient; both together is the common case.
+    Result is memoized for the lifetime of the process.
+    """
+    global _UVX_TOOL_VENV_CACHE
+    if _UVX_TOOL_VENV_CACHE is not None:
+        return _UVX_TOOL_VENV_CACHE
+
+    _UVX_TOOL_VENV_CACHE = _detect_uvx_tool_venv()
+    return _UVX_TOOL_VENV_CACHE
+
+
+def _detect_uvx_tool_venv() -> bool:
+    """Run the actual detection (no caching). Exposed for tests."""
+    # Path-based check: uv installs tool venvs under a "uv/tools/" directory
+    # on every platform. ``Path.parts`` works regardless of separator quirks.
+    try:
+        parts = Path(sys.executable).resolve().parts
+    except (OSError, ValueError):
+        parts = ()
+
+    for i in range(len(parts) - 1):
+        if parts[i].lower() == "uv" and parts[i + 1].lower() == "tools":
+            return True
+
+    # Module-based check: uv tool venvs ship without pip.
+    if importlib.util.find_spec("pip") is None:
+        return True
+
+    return False
+
+
+def reset_cache() -> None:
+    """Clear the memoized detection result.
+
+    Tests use this between cases that monkeypatch ``sys.executable`` or
+    ``importlib.util.find_spec``. Production code never calls this.
+    """
+    global _UVX_TOOL_VENV_CACHE
+    _UVX_TOOL_VENV_CACHE = None
+
+
+# Error message returned by tools when SearXNG-dependent actions are
+# invoked from inside a uvx tool venv. Per spec
+# ``2026-05-01-stdio-pure-http-multiuser.md`` §4.1.1.
+UVX_SEARXNG_BLOCKED_ERROR = (
+    "Error: action '{action}' requires SearXNG which is not available in "
+    "stdio uvx mode.\n"
+    "Options:\n"
+    "  1. Run via Docker (Method 3 stdio Docker): "
+    "docker run -i --rm -e ENV n24q02m/wet-mcp:latest\n"
+    "  2. Run via HTTP mode (Method 2 HTTP Docker recommended): "
+    "docker run -p 8080:8080 n24q02m/wet-mcp:latest --http\n"
+    "See https://github.com/n24q02m/wet-mcp#setup for details."
+)
+
+
+def uvx_searxng_blocked_error(action: str) -> str:
+    """Format the SearXNG-blocked error message for ``action``."""
+    return UVX_SEARXNG_BLOCKED_ERROR.format(action=action)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,30 @@ pytest_plugins = ["conftest_e2e"]
 
 
 @pytest.fixture(autouse=True)
+def _disable_uvx_tool_venv_detection(monkeypatch):
+    """Default ``is_uvx_tool_venv`` to ``False`` for all tests.
+
+    The real detection inspects the dev ``.venv`` (which also lacks pip in
+    uv-managed projects) and would otherwise short-circuit search-tool
+    tests. Tests that exercise the uvx detection itself reset
+    ``transport_check._UVX_TOOL_VENV_CACHE`` and patch the underlying
+    signals directly.
+    """
+    import sys
+
+    import wet_mcp.transport_check as tc
+
+    monkeypatch.setattr(tc, "is_uvx_tool_venv", lambda: False)
+    # ``test_server_timeout.py`` re-imports ``wet_mcp.server`` under heavy
+    # mocking; patch every live copy registered in ``sys.modules`` so
+    # subsequent tests still see ``False``.
+    for mod_name, mod in list(sys.modules.items()):
+        if mod_name == "wet_mcp.server" and hasattr(mod, "is_uvx_tool_venv"):
+            monkeypatch.setattr(mod, "is_uvx_tool_venv", lambda: False)
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _set_credential_state_configured():
     """Set credential state to CONFIGURED for all tests.
 

--- a/tests/test_transport_check.py
+++ b/tests/test_transport_check.py
@@ -1,0 +1,190 @@
+"""Tests for ``wet_mcp.transport_check`` and the search-tool uvx gate.
+
+Per spec ``2026-05-01-stdio-pure-http-multiuser.md`` §4.1.1: stdio uvx
+mode must reject ``web.search`` / ``research`` / ``docs`` / ``similar``
+because the bundled web-core SearXNG runner cannot install or start
+SearXNG inside a pip-less uvx tool venv. Other actions (``extract`` /
+``crawl`` / ``map`` / ``media``) hit upstream HTTP directly and remain
+available.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import wet_mcp.transport_check as tc
+
+
+@pytest.fixture
+def _allow_real_uvx_detection(monkeypatch):
+    """Undo the global ``_disable_uvx_tool_venv_detection`` fixture.
+
+    Re-binds ``is_uvx_tool_venv`` in both the transport_check module and
+    the server module to point at the real implementation again, so a
+    test can monkeypatch the underlying signals (``sys.executable``,
+    ``importlib.util.find_spec``) and observe the genuine outcome.
+    """
+    import wet_mcp.server as srv
+
+    # Resolve the real function via the module ``__dict__`` source rather
+    # than the live attribute, so we don't accidentally restore a stub
+    # already installed by the autouse fixture.
+    real_fn = tc._detect_uvx_tool_venv
+
+    def real_is_uvx_tool_venv() -> bool:
+        return real_fn()
+
+    monkeypatch.setattr(tc, "is_uvx_tool_venv", real_is_uvx_tool_venv)
+    monkeypatch.setattr(srv, "is_uvx_tool_venv", real_is_uvx_tool_venv)
+    tc.reset_cache()
+    yield
+    tc.reset_cache()
+
+
+# ---------------------------------------------------------------------------
+# is_uvx_tool_venv() detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_uvx_tool_venv_true_when_executable_under_uv_tools(
+    _allow_real_uvx_detection, monkeypatch, tmp_path
+):
+    """``sys.executable`` containing ``uv/tools/`` triggers detection."""
+    fake_exe = tmp_path / "uv" / "tools" / "wet-mcp" / "Scripts" / "python.exe"
+    fake_exe.parent.mkdir(parents=True)
+    fake_exe.touch()
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    # Pretend pip *is* importable so the path check is the only signal.
+    monkeypatch.setattr(
+        tc.importlib.util, "find_spec", lambda name: object() if name == "pip" else None
+    )
+
+    assert tc.is_uvx_tool_venv() is True
+
+
+def test_is_uvx_tool_venv_true_when_pip_missing(
+    _allow_real_uvx_detection, monkeypatch, tmp_path
+):
+    """``find_spec('pip') is None`` triggers detection on its own."""
+    # Path does NOT contain uv/tools.
+    fake_exe = tmp_path / "normal" / "venv" / "bin" / "python"
+    fake_exe.parent.mkdir(parents=True)
+    fake_exe.touch()
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(tc.importlib.util, "find_spec", lambda name: None)
+
+    assert tc.is_uvx_tool_venv() is True
+
+
+def test_is_uvx_tool_venv_false_for_normal_venv(
+    _allow_real_uvx_detection, monkeypatch, tmp_path
+):
+    """Normal venv with pip installed and no uv/tools path -> False."""
+    fake_exe = tmp_path / "project" / ".venv" / "bin" / "python"
+    fake_exe.parent.mkdir(parents=True)
+    fake_exe.touch()
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(
+        tc.importlib.util, "find_spec", lambda name: object() if name == "pip" else None
+    )
+
+    assert tc.is_uvx_tool_venv() is False
+
+
+def test_is_uvx_tool_venv_memoizes(_allow_real_uvx_detection, monkeypatch, tmp_path):
+    """Result is cached after the first call."""
+    fake_exe = tmp_path / "uv" / "tools" / "wet-mcp" / "bin" / "python"
+    fake_exe.parent.mkdir(parents=True)
+    fake_exe.touch()
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(
+        tc.importlib.util, "find_spec", lambda name: object() if name == "pip" else None
+    )
+
+    first = tc.is_uvx_tool_venv()
+
+    # Flip both signals; cached result must persist.
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "other" / "python"))
+    monkeypatch.setattr(tc.importlib.util, "find_spec", lambda name: None)
+
+    second = tc.is_uvx_tool_venv()
+    assert first == second is True
+
+
+# ---------------------------------------------------------------------------
+# search() short-circuit on uvx detection
+# ---------------------------------------------------------------------------
+
+
+def _force_uvx(monkeypatch, value: bool):
+    """Force ``is_uvx_tool_venv`` to return ``value`` in every live binding.
+
+    ``test_server_timeout.py`` deletes and reimports ``wet_mcp.server``
+    under heavy mocking, so two distinct copies of that module can coexist
+    in ``sys.modules`` for the rest of the run. Patch every copy reachable
+    from ``sys.modules`` (and ``transport_check``) and return the freshly
+    resolved module so tests use the live version.
+    """
+    import sys
+
+    monkeypatch.setattr(tc, "is_uvx_tool_venv", lambda: value)
+    if "wet_mcp.server" not in sys.modules:
+        import wet_mcp.server  # noqa: F401
+    srv = sys.modules["wet_mcp.server"]
+    monkeypatch.setattr(srv, "is_uvx_tool_venv", lambda: value)
+    return srv
+
+
+@pytest.mark.parametrize("action", ["search", "research", "docs", "similar"])
+@pytest.mark.asyncio
+async def test_search_actions_rejected_in_uvx_mode(monkeypatch, action):
+    """All four SearXNG-dependent actions return the spec error in uvx."""
+    srv = _force_uvx(monkeypatch, True)
+
+    # ``docs`` requires ``library``; ``similar`` requires a URL query. Pass
+    # values that would normally make it past input validation so we know
+    # the rejection comes from the uvx gate, not from missing parameters.
+    kwargs = {"query": "https://example.com"}
+    if action == "docs":
+        kwargs["library"] = "fastapi"
+
+    result = await srv.search(action=action, **kwargs)
+
+    assert result.startswith(f"Error: action '{action}' requires SearXNG")
+    assert "Method 3 stdio Docker" in result
+    assert "Method 2 HTTP Docker" in result
+
+
+@pytest.mark.asyncio
+async def test_search_action_proceeds_when_not_uvx(monkeypatch):
+    """In a normal venv, ``search`` reaches ``ensure_searxng`` as before."""
+    srv = _force_uvx(monkeypatch, False)
+
+    with (
+        patch.object(srv, "ensure_searxng", new_callable=AsyncMock) as mock_ensure,
+        patch.object(srv, "searxng_search", new_callable=AsyncMock) as mock_search,
+    ):
+        mock_ensure.return_value = "http://localhost:8080"
+        mock_search.return_value = "Search Results"
+
+        result = await srv.search(action="search", query="hello world")
+
+        assert "Search Results" in result
+        mock_ensure.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_extract_action_works_regardless_of_uvx(monkeypatch):
+    """``extract`` action stays available in uvx mode (no SearXNG dep)."""
+    srv = _force_uvx(monkeypatch, True)
+
+    with patch.object(srv, "_extract", new_callable=AsyncMock) as mock_extract:
+        mock_extract.return_value = "Extracted Content"
+
+        result = await srv.extract(action="extract", urls=["https://example.com"])
+
+        assert "Extracted Content" in result
+        mock_extract.assert_called_once()


### PR DESCRIPTION
## Summary

Stdio uvx native invocation (`uvx wet-mcp`) places the server in a uv-managed tool venv that lacks `pip`. The web-core SearXNG runner relies on `pip install` to bootstrap SearXNG and uses a hardcoded `localhost:8080` fallback that is wrong for our pinned Docker port (41592). Spawning a Docker SearXNG container from inside that venv is also unreliable (no Docker daemon guarantee on user laptop).

Per spec [`2026-05-01-stdio-pure-http-multiuser.md` section 4.1.1](../.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md), stdio uvx scope is locked to `extract` / `crawl` / `map` / `media`. `web.search` / `research` / `docs` / `similar` must reject with a clear pointer to Docker mode.

- New `wet_mcp.transport_check` module: memoized `is_uvx_tool_venv()` predicate (positive on `uv/tools/` in `sys.executable` OR `find_spec("pip") is None`) plus a single canonical error string formatter.
- `server.search()` short-circuits the four SearXNG-dependent actions before `ensure_searxng()`. `extract` tool actions are untouched.
- 10 new tests in `tests/test_transport_check.py` covering: detection paths (uv/tools, pip-missing, normal venv, memoization), per-action rejection in uvx mode, normal-venv proceed, and `extract` invariance under uvx.
- Autouse conftest fixture defaults `is_uvx_tool_venv` to `False` so existing tests (which run in the dev `.venv` that itself lacks pip) keep working without per-test mocks.

No changes to `web-core/runner.py` (kept minimal per scope decision); no fallback subprocess pip install; no other refactor.

## Test plan

- [x] `uv run pytest` -- 1528 passed, 34 skipped, 140 deselected
- [x] `uv run ruff check . && uv run ruff format --check .` -- all clean
- [x] `uv run ty check` -- all clean (pre-commit hook also covers this)
- [x] Smoke import: `from wet_mcp.transport_check import is_uvx_tool_venv; is_uvx_tool_venv()` returns `True` in dev `.venv` (pip absent), confirming detection logic
- [x] Manual confirmation that the autouse fixture neutralizes detection in the existing `test_search_*` suite

DO NOT MERGE -- leaving open for review.