### PR TITLE
fix: skip SearXNG warmup task in stdio uvx mode

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -198,8 +198,13 @@ async def _lifespan_startup() -> asyncio.Task | None:
     # startup latency on the first search call. If this instance finds an
     # existing healthy SearXNG (started by another MCP server instance), it
     # reuses it instead of spawning a new subprocess.
+    #
+    # Stdio uvx mode skips warmup entirely: the search/research/docs/similar
+    # actions are gated by `is_uvx_tool_venv()` and return a clear error
+    # pointing to Docker mode. Warming SearXNG in uvx mode wastes a Docker
+    # spawn the user will never get value from.
     warmup_task: asyncio.Task | None = None
-    if settings.wet_auto_searxng:
+    if settings.wet_auto_searxng and not is_uvx_tool_venv():
         warmup_task = asyncio.create_task(_warmup_searxng())
 
     # 2. Initialize web cache

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -97,6 +97,55 @@ async def test_lifespan():
 
 
 @pytest.mark.asyncio
+async def test_lifespan_skips_searxng_warmup_in_uvx_tool_venv():
+    """Stdio uvx mode must NOT spawn SearXNG warmup task: search actions are
+    gated to return a clear error message instead.  Spawning the Docker
+    container during startup wastes resources for a feature the user can
+    never use in this transport.
+    """
+    mock_fastmcp = MagicMock()
+    with (
+        patch("wet_mcp.server.WebCache"),
+        patch("wet_mcp.server.DocsDB"),
+        patch(
+            "wet_mcp.server.shutdown_crawler", new_callable=AsyncMock
+        ) as mock_shutdown,
+        patch("wet_mcp.server.stop_searxng"),
+        patch(
+            "wet_mcp.credential_state.resolve_credential_state",
+        ),
+        patch("wet_mcp.server.is_uvx_tool_venv", return_value=True),
+        patch("wet_mcp.server._warmup_searxng", new_callable=AsyncMock) as mock_warmup,
+    ):
+        async with server._lifespan(mock_fastmcp):
+            pass
+
+        mock_warmup.assert_not_called()
+        mock_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_runs_searxng_warmup_outside_uvx():
+    """Non-uvx transports (Docker / dev .venv) keep the eager warmup."""
+    mock_fastmcp = MagicMock()
+    with (
+        patch("wet_mcp.server.WebCache"),
+        patch("wet_mcp.server.DocsDB"),
+        patch("wet_mcp.server.shutdown_crawler", new_callable=AsyncMock),
+        patch("wet_mcp.server.stop_searxng"),
+        patch(
+            "wet_mcp.credential_state.resolve_credential_state",
+        ),
+        patch("wet_mcp.server.is_uvx_tool_venv", return_value=False),
+        patch("wet_mcp.server._warmup_searxng", new_callable=AsyncMock) as mock_warmup,
+    ):
+        async with server._lifespan(mock_fastmcp):
+            pass
+
+        mock_warmup.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_init_embedding_backend():
     with patch("wet_mcp.embedder.init_backend") as mock_init:
         mock_backend = MagicMock()


### PR DESCRIPTION
## Summary
- Gate \`_warmup_searxng()\` background task behind \`is_uvx_tool_venv()\` so stdio uvx startup never spawns Docker SearXNG container
- 2 regression tests: uvx → no warmup, non-uvx → warmup runs

## Why
Per spec [\`2026-05-01-stdio-pure-http-multiuser.md\`](https://github.com/n24q02m/n24q02m) §4.1.1 + memory \`feedback_wet_stdio_no_searxng.md\`, stdio uvx scope = \`extract\`/\`crawl\`/\`map\`/\`media\` only. PR #1019 added action-level reject for \`search\`/\`research\`/\`docs\`/\`similar\` but missed the eager warmup task in \`_lifespan()\` — meaning user observed Docker SearXNG container spawning at server startup before any tool call.

## Test plan
- [x] \`uv run pytest tests/test_transport_check.py tests/test_server_comprehensive.py::test_lifespan_skips_searxng_warmup_in_uvx_tool_venv tests/test_server_comprehensive.py::test_lifespan_runs_searxng_warmup_outside_uvx tests/test_server_comprehensive.py::test_lifespan\` — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)