### PR TITLE
fix: skip uvx detection inside Docker (Method 3 bug)

### DIFF
--- a/src/wet_mcp/transport_check.py
+++ b/src/wet_mcp/transport_check.py
@@ -16,6 +16,7 @@ they hit upstream HTTP directly via ``httpx`` and require no SearXNG.
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -25,17 +26,24 @@ _UVX_TOOL_VENV_CACHE: bool | None = None
 def is_uvx_tool_venv() -> bool:
     """Return True when the current interpreter lives in a uvx tool venv.
 
-    Detection is positive on either of two independent signals:
+    Detection is layered to avoid false positives:
 
-    1. ``sys.executable`` contains the ``uv/tools/`` segment used by uv on
-       Linux/Mac (``~/.local/share/uv/tools/<name>/...``) or Windows
+    1. **Docker short-circuit**: if ``/.dockerenv`` exists (every Docker
+       container has this marker file), return ``False`` immediately. The
+       wet-mcp Docker image uses ``uv sync`` which produces a venv WITHOUT
+       pip — that signal would otherwise trigger detection #3 below and
+       reject SearXNG-dependent actions even though Method 3 stdio Docker
+       has full Docker daemon access.
+    2. **Path-based positive**: ``sys.executable`` contains the
+       ``uv/tools/`` segment used by uv on Linux/Mac
+       (``~/.local/share/uv/tools/<name>/...``) or Windows
        (``%APPDATA%/uv/tools/<name>/...``).
-    2. ``importlib.util.find_spec("pip")`` returns ``None`` — uv tool venvs
-       deliberately omit pip, while normal venvs (and Docker images that
-       run ``uv sync``) keep it.
+    3. **Module-based fallback**: ``importlib.util.find_spec("pip")``
+       returns ``None`` — uv tool venvs deliberately omit pip, while
+       normal pip-managed venvs keep it. Only checked if not in Docker.
 
-    Either signal alone is sufficient; both together is the common case.
-    Result is memoized for the lifetime of the process.
+    Either path/module signal alone is sufficient. Result is memoized for
+    the lifetime of the process.
     """
     global _UVX_TOOL_VENV_CACHE
     if _UVX_TOOL_VENV_CACHE is not None:
@@ -45,8 +53,24 @@ def is_uvx_tool_venv() -> bool:
     return _UVX_TOOL_VENV_CACHE
 
 
+def _is_in_docker() -> bool:
+    """Detect Docker container runtime via the standard ``/.dockerenv`` marker.
+
+    Docker creates this file in every container regardless of base image,
+    so it is the most reliable cross-distro signal. Podman creates it too
+    when running with Docker compatibility mode.
+    """
+    return os.path.exists("/.dockerenv")
+
+
 def _detect_uvx_tool_venv() -> bool:
     """Run the actual detection (no caching). Exposed for tests."""
+    # Docker short-circuit: containers running ``uv sync`` images would
+    # otherwise trip the no-pip fallback even though they have Docker
+    # daemon access for SearXNG.
+    if _is_in_docker():
+        return False
+
     # Path-based check: uv installs tool venvs under a "uv/tools/" directory
     # on every platform. ``Path.parts`` works regardless of separator quirks.
     try:

--- a/tests/test_transport_check.py
+++ b/tests/test_transport_check.py
@@ -49,6 +49,30 @@ def _allow_real_uvx_detection(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_is_uvx_tool_venv_false_in_docker(
+    _allow_real_uvx_detection, monkeypatch, tmp_path
+):
+    """Docker short-circuit: even with no pip + uv venv path, container = False.
+
+    The wet-mcp Docker image uses ``uv sync`` which produces a venv WITHOUT
+    pip. Without the Docker short-circuit, that signal would trip the
+    pip-missing fallback and incorrectly reject SearXNG-dependent actions
+    inside Method 3 stdio Docker (where Docker daemon access enables
+    SearXNG via the host socket mount).
+    """
+    # Inside Docker, even pip-missing AND uv tools path must NOT be detected
+    # as a uvx tool venv.
+    fake_exe = tmp_path / "app" / ".venv" / "bin" / "python"
+    fake_exe.parent.mkdir(parents=True)
+    fake_exe.touch()
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(tc.importlib.util, "find_spec", lambda name: None)
+    # Simulate /.dockerenv presence — the standard Docker container marker.
+    monkeypatch.setattr(tc, "_is_in_docker", lambda: True)
+
+    assert tc.is_uvx_tool_venv() is False
+
+
 def test_is_uvx_tool_venv_true_when_executable_under_uv_tools(
     _allow_real_uvx_detection, monkeypatch, tmp_path
 ):
@@ -57,6 +81,8 @@ def test_is_uvx_tool_venv_true_when_executable_under_uv_tools(
     fake_exe.parent.mkdir(parents=True)
     fake_exe.touch()
     monkeypatch.setattr(sys, "executable", str(fake_exe))
+    # Force not-in-Docker so the path-based signal can fire.
+    monkeypatch.setattr(tc, "_is_in_docker", lambda: False)
     # Pretend pip *is* importable so the path check is the only signal.
     monkeypatch.setattr(
         tc.importlib.util, "find_spec", lambda name: object() if name == "pip" else None
@@ -74,6 +100,7 @@ def test_is_uvx_tool_venv_true_when_pip_missing(
     fake_exe.parent.mkdir(parents=True)
     fake_exe.touch()
     monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(tc, "_is_in_docker", lambda: False)
     monkeypatch.setattr(tc.importlib.util, "find_spec", lambda name: None)
 
     assert tc.is_uvx_tool_venv() is True
@@ -87,6 +114,7 @@ def test_is_uvx_tool_venv_false_for_normal_venv(
     fake_exe.parent.mkdir(parents=True)
     fake_exe.touch()
     monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(tc, "_is_in_docker", lambda: False)
     monkeypatch.setattr(
         tc.importlib.util, "find_spec", lambda name: object() if name == "pip" else None
     )
@@ -100,6 +128,7 @@ def test_is_uvx_tool_venv_memoizes(_allow_real_uvx_detection, monkeypatch, tmp_p
     fake_exe.parent.mkdir(parents=True)
     fake_exe.touch()
     monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(tc, "_is_in_docker", lambda: False)
     monkeypatch.setattr(
         tc.importlib.util, "find_spec", lambda name: object() if name == "pip" else None
     )


### PR DESCRIPTION
## Summary
Add Docker short-circuit to \`is_uvx_tool_venv()\`: \`/.dockerenv\` present → return False immediately. Prevents pip-missing fallback (signal #3) from triggering inside the Docker image (which uses \`uv sync\` and ships without pip).

## Why
PR #1019 + #1020 detected uvx tool venv via:
1. \`sys.executable\` under \`uv/tools/\` (path)
2. \`find_spec(\"pip\") is None\` (fallback for dev .venv coverage)

Method 3 stdio Docker test verified end-to-end via Test B Round 7 (em was running wet 2.29.0b9 inside container via \`docker run -i --rm\`):
- \`web.extract\` → PASS (httpx scrape, no SearXNG)
- \`web.search\` → **incorrectly rejected** with uvx error message

Inside the container, \`/app/.venv/bin/python\` (uv-managed) had no pip → signal #2 fired → search action rejected even though Docker daemon is mounted and SearXNG sibling spawn works.

## Fix
\`/.dockerenv\` is the standard Docker container marker (every image has it). Returning False on Docker detection comes BEFORE the pip-missing fallback, so:
- Stdio uvx (no Docker, no pip) → True (rejected, correct)
- Method 3 stdio Docker (Docker, no pip) → False (allowed, correct)
- Dev \`.venv\` with pip → False (allowed, correct)

## Test plan
- [x] \`uv run pytest tests/test_transport_check.py -q\` → 11 passed (1 new \`test_is_uvx_tool_venv_false_in_docker\` + existing 10 patched to force not-in-Docker for non-Docker scenarios)
- [x] \`ruff check\` + \`ruff format --check\` + \`ty check\` all green
- [x] Pre-commit hooks pass (gitleaks/ruff/pytest/conventional commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)