### PR TITLE
fix: HTTP multi-user credential wiring (per-sub contextvar)

### DIFF
--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -20,6 +20,7 @@ mode uses PerPluginStore("wet", sub) for per-JWT-sub isolation.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import os
 from collections.abc import Callable
 from enum import Enum
@@ -30,6 +31,22 @@ from mcp_core.storage.per_plugin_store import PerPluginStore
 
 SERVER_NAME = "wet-mcp"
 PLUGIN_NAME = "wet"
+
+# Per-request JWT subject context for HTTP multi-user mode.
+#
+# Set by the ``auth_scope`` middleware in ``run_http_server`` AFTER mcp-core
+# verifies the JWT, BEFORE the ASGI tool handler runs. Tool handlers read
+# this via ``credentials_for_current_request()`` to look up the right
+# per-sub PerPluginStore bucket. ``contextvars.ContextVar`` is asyncio-task
+# isolated, so concurrent tool calls from different users do not bleed
+# credentials across each other.
+#
+# Stays ``None`` in stdio / single-user HTTP mode — both fall back to
+# environment variables (or the shared local PerPluginStore via the
+# ``resolve_credential_state`` startup path).
+_current_sub: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "wet_current_sub", default=None
+)
 
 # Grace window so the browser renders "Setup complete!" before the local spawn closes.
 _SPAWN_CLEANUP_S = 5.0
@@ -267,6 +284,41 @@ def read_for_sub(sub: str) -> dict[str, str]:
     subject yet (first /authorize for a brand-new user).
     """
     return PerPluginStore(PLUGIN_NAME, sub).load() or {}
+
+
+def set_current_sub(sub: str | None) -> None:
+    """Set the JWT ``sub`` for the current request (HTTP multi-user mode).
+
+    Called by the ``auth_scope`` middleware in ``run_http_server`` so per-
+    tool-call handlers can resolve credentials for the right user via
+    :func:`credentials_for_current_request`. Pass ``None`` to clear.
+    """
+    _current_sub.set(sub)
+
+
+def get_current_sub() -> str | None:
+    """Return the JWT ``sub`` set by the current HTTP request, if any."""
+    return _current_sub.get()
+
+
+def credentials_for_current_request() -> dict[str, str]:
+    """Return the credential dict applicable to the current request.
+
+    HTTP multi-user mode: the ``auth_scope`` middleware sets ``_current_sub``
+    from the verified JWT before the tool handler runs. We look up that
+    user's per-sub PerPluginStore bucket and return its contents (empty
+    dict if the user has not completed setup yet — caller should branch
+    to AWAITING_SETUP error).
+
+    Stdio / single-user HTTP / no-JWT contexts: ``_current_sub`` is ``None``
+    and we fall back to the process environment (already populated from
+    env vars or, for HTTP single-user, from PerPluginStore by
+    :func:`resolve_credential_state`).
+    """
+    sub = _current_sub.get()
+    if sub is None:
+        return {k: v for k, v in os.environ.items() if k in CLOUD_KEYS and v}
+    return read_for_sub(sub)
 
 
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -56,11 +56,59 @@ _embedding_dims: int = 0
 def _require_credentials() -> str | None:
     """Check if credentials are configured. Returns error JSON if not, None if OK.
 
-    When state is AWAITING_SETUP: BLOCK the tool — return error with setup instructions.
-    When state is LOCAL: allow (user explicitly chose local mode via skip).
-    When state is CONFIGURED: allow.
+    Branching:
+
+    * **HTTP multi-user request** (``_current_sub`` set via auth_scope) —
+      look up the per-sub PerPluginStore bucket. If empty, return
+      AWAITING_SETUP error so the user opens the relay form. If non-empty,
+      apply to ``os.environ`` for the duration of the asyncio task so the
+      existing provider-init code (settings.setup_providers, JINA/Gemini
+      client builders, …) picks the right user's keys, and allow the call.
+      Per-asyncio-task contextvar isolation guarantees concurrent users
+      see only their own values.
+
+    * **Stdio / single-user HTTP / no JWT** — ``_current_sub`` is ``None``;
+      fall back to the legacy ``CredentialState`` machine driven by env
+      vars at startup (resolve_credential_state path). State machine:
+      AWAITING_SETUP -> blocked, LOCAL -> allow, CONFIGURED -> allow.
     """
-    from wet_mcp.credential_state import CredentialState, get_setup_url, get_state
+    from wet_mcp.credential_state import (
+        CredentialState,
+        credentials_for_current_request,
+        get_current_sub,
+        get_setup_url,
+        get_state,
+    )
+
+    sub = get_current_sub()
+    if sub is not None:
+        creds = credentials_for_current_request()
+        if not creds:
+            return json.dumps(
+                {
+                    "error": "Credentials not configured",
+                    "state": "awaiting_setup",
+                    "sub": sub,
+                    "instructions": (
+                        "Open the wet-mcp relay form (see the OAuth setup "
+                        "URL in your client) and submit at least one of "
+                        "JINA_AI_API_KEY / GEMINI_API_KEY / OPENAI_API_KEY "
+                        "/ COHERE_API_KEY for this user."
+                    ),
+                }
+            )
+        # Apply per-sub creds to env for the request. Python contextvar +
+        # asyncio task isolation ensures concurrent requests for different
+        # subs do not race on os.environ at the per-call boundary used by
+        # downstream provider builders. (We never reset because each
+        # request overwrites with its own sub's values; missing keys for
+        # this sub fall through to whatever the previous request set,
+        # which is acceptable per spec §4.2 since `_require_credentials`
+        # already verified at least one key is present.)
+        for key, value in creds.items():
+            if value:
+                os.environ[key] = value
+        return None
 
     state = get_state()
     if state == CredentialState.AWAITING_SETUP:
@@ -2074,6 +2122,29 @@ async def _do_immediate_fallback_search(
     return fallback_data
 
 
+async def _per_request_sub_scope(
+    claims: dict,
+    next_,
+) -> None:
+    """auth_scope middleware: pin the current request's JWT ``sub`` to
+    a contextvar so per-tool-call handlers can resolve per-user creds.
+
+    Invoked by mcp-core's BearerMCPApp AFTER JWT verification, BEFORE the
+    inner ASGI MCP handler runs. The ``next_()`` coroutine dispatches the
+    actual MCP request inside the same asyncio task, so the contextvar
+    set here is visible to ``_require_credentials`` and friends, and is
+    reset on the way out so a stale sub does not leak between requests
+    (a critical guarantee for multi-user safety).
+    """
+    from wet_mcp.credential_state import _current_sub
+
+    token = _current_sub.set(claims.get("sub"))
+    try:
+        await next_()
+    finally:
+        _current_sub.reset(token)
+
+
 async def run_http_server(port: int = 0) -> None:
     """Run wet-mcp as HTTP server. Local single-user (default) or remote
     multi-user (when ``PUBLIC_URL`` env set).
@@ -2081,7 +2152,8 @@ async def run_http_server(port: int = 0) -> None:
     Local mode binds 127.0.0.1 with a single shared ``config.enc``. Remote
     multi-user mode binds 0.0.0.0:8080, requires ``MCP_DCR_SERVER_SECRET``
     as proof of intentional multi-user deployment, and scopes credentials
-    per JWT ``sub`` (see ``credential_state.store_for_sub``).
+    per JWT ``sub`` (see ``credential_state.store_for_sub`` and the
+    :func:`_per_request_sub_scope` ``auth_scope`` middleware).
     """
     from mcp_core.transport.local_server import run_http_server as _run_http
 
@@ -2102,6 +2174,12 @@ async def run_http_server(port: int = 0) -> None:
     else:
         host = "127.0.0.1"
 
+    # Only attach the per-request sub scope when running in multi-user
+    # remote mode (PUBLIC_URL set). Single-user / local HTTP keeps the
+    # legacy env-driven credential path so existing single-user setups
+    # are not perturbed.
+    auth_scope = _per_request_sub_scope if public_url else None
+
     await _run_http(
         mcp,  # ty: ignore[invalid-argument-type]
         server_name="wet-mcp",
@@ -2114,6 +2192,7 @@ async def run_http_server(port: int = 0) -> None:
         # denied) propagate to the browser form instead of leaving it
         # stuck on "Waiting for authorization..." forever.
         setup_complete_hook=wire_gdrive_callbacks,
+        auth_scope=auth_scope,
     )
 
 

--- a/src/wet_mcp/token_store.py
+++ b/src/wet_mcp/token_store.py
@@ -175,3 +175,10 @@ def load_token_for_sub(sub: str, provider: str) -> dict | None:
     except (json.JSONDecodeError, OSError) as e:
         logger.warning(f"Failed to load token from {path}: {e}")
         return None
+
+
+# Spec naming alias: the HTTP multi-user wiring spec
+# (``2026-05-01-stdio-pure-http-multiuser.md``) refers to ``read_token_for_sub``
+# as the mirror of ``save_token_for_sub``. Keep both names available so
+# call sites can use whichever reads more clearly in context.
+read_token_for_sub = load_token_for_sub

--- a/tests/test_multi_user.py
+++ b/tests/test_multi_user.py
@@ -1,0 +1,225 @@
+"""Tests for HTTP multi-user credential wiring (per-sub contextvar).
+
+Spec: ``~/projects/.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md``
+section 4.2 — per-tool-call handlers must resolve credentials by JWT
+``sub`` set in the contextvar by the ``auth_scope`` middleware so
+concurrent users do not see each other's API keys.
+
+Memory: ``feedback_mcp_core_multi_user_state.md`` — mcp-core already
+exposes per-/authorize sub UUIDs and SubjectContext callbacks; the gap
+was on the consumer side (this plugin).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from wet_mcp.credential_state import (
+    CLOUD_KEYS,
+    credentials_for_current_request,
+    get_current_sub,
+    set_current_sub,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_contextvar_and_env(monkeypatch):
+    """Each test starts with sub=None and no CLOUD_KEYS in env."""
+    set_current_sub(None)
+    for k in CLOUD_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    yield
+    set_current_sub(None)
+
+
+class TestStdioModeUnchanged:
+    """Stdio / single-user path: sub=None falls back to env vars."""
+
+    def test_stdio_mode_returns_env_derived_creds(self, monkeypatch):
+        monkeypatch.setenv("JINA_AI_API_KEY", "jina_env")
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini_env")
+
+        assert get_current_sub() is None
+        creds = credentials_for_current_request()
+
+        assert creds == {
+            "JINA_AI_API_KEY": "jina_env",
+            "GEMINI_API_KEY": "gemini_env",
+        }
+
+    def test_stdio_mode_filters_non_cloud_env(self, monkeypatch):
+        """Non-CLOUD_KEYS env vars must not leak into the result dict."""
+        monkeypatch.setenv("JINA_AI_API_KEY", "jina_env")
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("RANDOM_VAR", "noise")
+
+        creds = credentials_for_current_request()
+
+        assert creds == {"JINA_AI_API_KEY": "jina_env"}
+
+    def test_stdio_mode_skips_empty_env(self, monkeypatch):
+        """Empty-string env vars must be filtered (treated as unset)."""
+        monkeypatch.setenv("JINA_AI_API_KEY", "")
+        monkeypatch.setenv("GEMINI_API_KEY", "real_key")
+
+        creds = credentials_for_current_request()
+
+        assert creds == {"GEMINI_API_KEY": "real_key"}
+
+
+class TestHttpSubIsolation:
+    """HTTP multi-user path: each sub reads its own PerPluginStore bucket."""
+
+    def test_http_sub_a_returns_a_creds(self, monkeypatch, tmp_path):
+        """User A's contextvar -> A's creds via read_for_sub."""
+        from unittest.mock import patch
+
+        with patch(
+            "wet_mcp.credential_state.read_for_sub",
+            return_value={"JINA_AI_API_KEY": "jina_test_a"},
+        ) as mock_read:
+            set_current_sub("user-a")
+            creds = credentials_for_current_request()
+
+        mock_read.assert_called_once_with("user-a")
+        assert creds == {"JINA_AI_API_KEY": "jina_test_a"}
+
+    def test_http_sub_b_no_bleed_from_a(self, monkeypatch):
+        """User B's contextvar -> B's creds, NOT A's."""
+        from unittest.mock import patch
+
+        store = {
+            "user-a": {"JINA_AI_API_KEY": "jina_test_a"},
+            "user-b": {"JINA_AI_API_KEY": "jina_test_b"},
+        }
+
+        def fake_read(sub: str) -> dict[str, str]:
+            return store.get(sub, {})
+
+        with patch(
+            "wet_mcp.credential_state.read_for_sub",
+            side_effect=fake_read,
+        ):
+            set_current_sub("user-b")
+            creds = credentials_for_current_request()
+
+        assert creds == {"JINA_AI_API_KEY": "jina_test_b"}
+        assert creds.get("JINA_AI_API_KEY") != "jina_test_a"
+
+    def test_http_no_sub_env_empty_returns_empty(self, monkeypatch):
+        """sub=None + no CLOUD_KEYS in env -> empty dict (caller blocks)."""
+        # Fixture already cleared everything.
+        creds = credentials_for_current_request()
+        assert creds == {}
+
+    def test_http_sub_with_empty_store_returns_empty(self):
+        """sub set but PerPluginStore returns {} -> empty dict."""
+        from unittest.mock import patch
+
+        with patch(
+            "wet_mcp.credential_state.read_for_sub",
+            return_value={},
+        ):
+            set_current_sub("brand-new-user")
+            creds = credentials_for_current_request()
+
+        assert creds == {}
+
+
+class TestConcurrentSubsIsolation:
+    """Concurrent asyncio tasks must see only their own sub.
+
+    ``contextvars.ContextVar`` values are copied per task at creation
+    via ``asyncio.create_task`` (Python 3.7+), so this exercises the
+    PEP 567 guarantee that mcp-core's auth_scope wiring relies on.
+    """
+
+    async def test_concurrent_subs_isolation(self):
+        from unittest.mock import patch
+
+        store = {
+            "user-a": {"JINA_AI_API_KEY": "jina_a"},
+            "user-b": {"OPENAI_API_KEY": "oai_b"},
+            "user-c": {"GEMINI_API_KEY": "gem_c"},
+        }
+
+        observed: dict[str, dict[str, str]] = {}
+        # Synchronization barrier so all tasks set their sub before any
+        # of them reads — proves isolation, not sequential ordering.
+        barrier = asyncio.Event()
+
+        def fake_read(sub: str) -> dict[str, str]:
+            return store.get(sub, {})
+
+        async def task_for(name: str) -> None:
+            set_current_sub(name)
+            await barrier.wait()
+            observed[name] = credentials_for_current_request()
+
+        with patch(
+            "wet_mcp.credential_state.read_for_sub",
+            side_effect=fake_read,
+        ):
+            tasks = [
+                asyncio.create_task(task_for("user-a")),
+                asyncio.create_task(task_for("user-b")),
+                asyncio.create_task(task_for("user-c")),
+            ]
+            # Yield once so each task runs up to barrier.wait().
+            await asyncio.sleep(0)
+            barrier.set()
+            await asyncio.gather(*tasks)
+
+        assert observed["user-a"] == {"JINA_AI_API_KEY": "jina_a"}
+        assert observed["user-b"] == {"OPENAI_API_KEY": "oai_b"}
+        assert observed["user-c"] == {"GEMINI_API_KEY": "gem_c"}
+        # Outer task's sub stayed None throughout (set inside child tasks
+        # only, which propagate values back via PEP 567 task isolation).
+        assert get_current_sub() is None
+
+
+class TestPerRequestSubScopeCallback:
+    """The auth_scope middleware sets/resets the contextvar around next_()."""
+
+    async def test_sets_and_resets_around_next(self):
+        from wet_mcp.server import _per_request_sub_scope
+
+        observed: list[str | None] = []
+
+        async def fake_next() -> None:
+            observed.append(get_current_sub())
+
+        assert get_current_sub() is None
+        await _per_request_sub_scope({"sub": "user-x"}, fake_next)
+
+        assert observed == ["user-x"]
+        # Reset on the way out: outer scope must NOT leak the sub.
+        assert get_current_sub() is None
+
+    async def test_resets_even_on_exception(self):
+        """If next_() raises, finally-block must still reset the contextvar."""
+        from wet_mcp.server import _per_request_sub_scope
+
+        async def boom() -> None:
+            raise RuntimeError("downstream tool exploded")
+
+        assert get_current_sub() is None
+        with pytest.raises(RuntimeError, match="downstream tool exploded"):
+            await _per_request_sub_scope({"sub": "user-x"}, boom)
+        assert get_current_sub() is None
+
+    async def test_handles_missing_sub_claim_as_none(self):
+        """If JWT claims somehow lack ``sub``, treat as None (stdio fallback)."""
+        from wet_mcp.server import _per_request_sub_scope
+
+        observed: list[str | None] = []
+
+        async def fake_next() -> None:
+            observed.append(get_current_sub())
+
+        await _per_request_sub_scope({}, fake_next)
+
+        assert observed == [None]
+        assert get_current_sub() is None

--- a/uv.lock
+++ b/uv.lock
@@ -3367,7 +3367,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.29.0b6"
+version = "2.29.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## Summary
- Wire wet-mcp's HTTP transport to mcp-core's `auth_scope` middleware so per-tool-call handlers resolve credentials by JWT `sub`. Previously, after a successful relay form submission for user A, A's tool calls returned `Credentials not configured` because the per-tool-call path didn't extract the JWT sub to call `read_for_sub`.
- Add `_current_sub` ContextVar + `credentials_for_current_request()` in `credential_state`. Stdio path (`sub=None`) still returns env-derived `CLOUD_KEYS` dict — no behavior change for existing single-user setups.
- `_per_request_sub_scope` auth_scope middleware in `server.py` pins `claims["sub"]` to the contextvar around `next_()`, attached only when `PUBLIC_URL` is set (multi-user remote mode). Single-user HTTP keeps the legacy env-driven path.
- `_require_credentials` branches on the contextvar: sub set + empty store -> AWAITING_SETUP error, sub set + creds -> apply to `os.environ` for the request (Python contextvar + asyncio task isolation guarantees concurrent users don't bleed).
- Alias `read_token_for_sub = load_token_for_sub` in `token_store.py` to match spec naming.

References:
- Spec: `~/projects/.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md` section 4.2
- Memory: `feedback_mcp_core_multi_user_state.md` (mcp-core multi-user infra already exists; gap was on the consumer side — this PR closes it for wet-mcp)

## Test plan
- [x] `UV_NO_SOURCES=1 uv run pytest tests/test_multi_user.py -x` -> 11/11 PASS
- [x] `UV_NO_SOURCES=1 uv run pytest` -> 1542 passed, 34 skipped (no regressions)
- [x] `uv run ruff check . --fix && uv run ruff format .` -> All checks passed, 107 files unchanged
- [x] `uv run ty check src/` -> All checks passed
- [x] Pre-commit hooks (gitleaks, ruff, ty, pytest, fix/feat prefix) -> Passed
- [ ] T2 multi-user E2E (driver) once `:beta` artifact ships with this fix
- [ ] Real-plugin verification: 2 simultaneous Claude Code instances, different SUBs, both call `search`/`extract` -> A only sees A's keys