### PR TITLE
fix: bump mcp-core floor to 1.13.0b7 for /login gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # Per-domain rate limiting for batch operations
     "aiolimiter>=1.2.1",
     # Relay setup (zero-env-config)
-    "n24q02m-mcp-core>=1.13.0b4",
+    "n24q02m-mcp-core>=1.13.0b7",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance
     # downgrading to CVE-vulnerable 2.x (5 CVEs including critical SSRF).
     # Must stay >=3.2.3,<4 until mcp-core bumps its own floor past 3.x.

--- a/uv.lock
+++ b/uv.lock
@@ -1748,7 +1748,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.13.0b5"
+version = "1.13.0b7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1762,9 +1762,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/5a/34fb2a2494e9d00edd041a1054bb814eb9ed76da8868d3b21c9d98803187/n24q02m_mcp_core-1.13.0b5.tar.gz", hash = "sha256:467b3eabbfb8c2a87262288ef3eed35c11f635b4b37ea0de79237bb450cec8eb", size = 185546, upload-time = "2026-05-02T06:52:04.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/46/e60f6a535043caf93df0ba91086bc613ce8205b4776508b3d0972f972f1e/n24q02m_mcp_core-1.13.0b7.tar.gz", hash = "sha256:5b39457b638f19a463ddae388b8d2e8767e78a33fcf424383730e3043e6e4c38", size = 188748, upload-time = "2026-05-03T12:08:07.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/64/b7cfff730a47b9520d7a8cbe39f8362cbe517c06828639fd0e0331f3c246/n24q02m_mcp_core-1.13.0b5-py3-none-any.whl", hash = "sha256:db0d395aefdb5c5d6599bf93f90da9c21c225c36c10f84703a5357a4fce018d7", size = 118638, upload-time = "2026-05-02T06:52:06.14Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2a/250105b2bef539a91968f60a4493c52be970e9179b7380d6897734831c51/n24q02m_mcp_core-1.13.0b7-py3-none-any.whl", hash = "sha256:06b74ddf4f1847b81665487ca69e463b13b73214fa79d9800a12af571d1b1d9c", size = 121709, upload-time = "2026-05-03T12:08:05.608Z" },
 ]
 
 [[package]]
@@ -3367,7 +3367,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.29.0b10"
+version = "2.29.0b12"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3427,7 +3427,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b4" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b7" },
     { name = "n24q02m-web-core", specifier = ">=1.3.8" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pillow", specifier = ">=12.2.0" },


### PR DESCRIPTION
Cascade fix — the prior bump-mcp-core PR (#1027) was empty (no pyproject change), so wet-mcp container shipped with mcp-core 1.13.0b5 (no /login route). This bumps floor to 1.13.0b7 explicitly and regenerates uv.lock. Verified mnemo/imagine /login gate works end-to-end at https://<plugin>.n24q02m.com/login.