### PR TITLE
feat: declare userConfig schema and document install prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,22 @@
   "name": "wet-mcp",
   "description": "Web search, content extraction, and media download",
   "version": "2.29.0",
+  "userConfig": {
+    "JINA_AI_API_KEY": {
+      "type": "string",
+      "title": "Jina AI API key (optional)",
+      "description": "Optional cloud reranker key. Without it, server uses local ONNX rerank. https://jina.ai/api-dashboard/",
+      "sensitive": true,
+      "required": false
+    },
+    "GEMINI_API_KEY": {
+      "type": "string",
+      "title": "Gemini API key (optional)",
+      "description": "Optional cloud embedding fallback. https://ai.google.dev/",
+      "sensitive": true,
+      "required": false
+    }
+  },
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -25,7 +41,9 @@
         "wet-mcp"
       ],
       "env": {
-        "MCP_TRANSPORT": "stdio"
+        "MCP_TRANSPORT": "stdio",
+        "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}",
+        "GEMINI_API_KEY": "${user_config.GEMINI_API_KEY}"
       }
     }
   }

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -25,29 +25,32 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 For Claude Code users, the plugin approach is the simplest. Plugin install uses **stdio mode** -- basic SearXNG web search works **without any env vars**. Advanced features require optional API keys.
 
-1. Open Claude Code
-2. Run the following commands:
+### Step 0: Credential prompt
+
+When you run `/plugin install wet-mcp@n24q02m-plugins`, Claude Code prompts for the optional fields declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Notes |
+|:------|:---------|:----------|:------|
+| `JINA_AI_API_KEY` | No | Yes | Optional cloud reranker. Without it, the server uses local ONNX. https://jina.ai/api-dashboard/ |
+| `GEMINI_API_KEY` | No | Yes | Optional cloud embedding fallback / Gemini LLM analysis. https://ai.google.dev/ |
+
+You may leave both empty -- wet-mcp falls back to bundled local ONNX embedding/reranking. Sensitive values are kept in the system keychain (or `~/.claude/.credentials.json` fallback) and persist across `/plugin update`. Claude Code substitutes each value into the `mcpServers.wet.env` block via `${user_config.<KEY>}` -- you do not edit `env` manually.
+
+> Other optional env vars (`BRAVE_API_KEY`, `SERPER_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `GITHUB_TOKEN`, `SYNC_ENABLED`, etc.) are not part of the install prompt; if you need them, add them manually to `mcpServers.wet.env` in your settings.
+
+### Steps
+
+1. Open Claude Code.
+2. Install the plugin (Claude Code prompts for `JINA_AI_API_KEY` + `GEMINI_API_KEY` -- press Enter to skip):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install wet-mcp@n24q02m-plugins
    ```
-3. (Optional) Set env vars for advanced features in `~/.claude/settings.local.json`:
-   ```json
-   {
-     "mcpServers": {
-       "wet-mcp": {
-         "env": {
-           "BRAVE_API_KEY": "your-brave-key",
-           "SERPER_API_KEY": "your-serper-key",
-           "GEMINI_API_KEY": "AIza..."
-         }
-       }
-     }
-   }
-   ```
-4. Restart Claude Code -- the server starts automatically when CC launches
+3. Restart Claude Code -- the server starts automatically when CC launches with the values injected.
 
 Without env vars: basic SearXNG metasearch, content extraction, library docs, ONNX local embedding/reranking all work. With env vars: cloud embedding/reranking (faster), Gemini LLM analysis, premium search providers.
+
+> **HTTP transport (Method 3)** is a separate install path; the `userConfig` prompt only covers stdio Method 1.
 
 ## Method 2: Docker stdio (fallback)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -21,27 +21,26 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin install uses **stdio mode**. Basic SearXNG web search works **without any env vars** -- ONNX local embedding and reranking are bundled. Advanced features require optional API keys.
 
+### Step 0: Credential prompt
+
+When the install command runs, Claude Code prompts for the optional fields declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Source |
+|:------|:---------|:----------|:-------|
+| `JINA_AI_API_KEY` | No | Yes | https://jina.ai/api-dashboard/ |
+| `GEMINI_API_KEY` | No | Yes | https://ai.google.dev/ |
+
+Press Enter to skip either field; the server falls back to local ONNX. Claude Code substitutes the values into `mcpServers.wet.env` via `${user_config.<KEY>}` and stores the sensitive values in the system keychain (persists across `/plugin update`). You do not edit `env` manually.
+
+### Steps
+
 ```bash
 # Install from marketplace (includes skills: /fact-check, /compare)
 /plugin marketplace add n24q02m/claude-plugins
 /plugin install wet-mcp@n24q02m-plugins
 ```
 
-Optional env vars in `~/.claude/settings.local.json`:
-
-```json
-{
-  "mcpServers": {
-    "wet-mcp": {
-      "env": {
-        "BRAVE_API_KEY": "your-brave-key",
-        "SERPER_API_KEY": "your-serper-key",
-        "GEMINI_API_KEY": "AIza..."
-      }
-    }
-  }
-}
-```
+> Other optional env vars (`BRAVE_API_KEY`, `SERPER_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `GITHUB_TOKEN`, `SYNC_ENABLED`, etc.) are not part of the `userConfig` prompt; add them manually to `mcpServers.wet.env` in your settings if needed.
 
 Without env vars: SearXNG metasearch + content extraction + library docs + ONNX embedding work out of the box. With env vars: cloud embedding/reranking, Gemini LLM analysis, premium search providers.
 


### PR DESCRIPTION
## Summary

- Add `userConfig` with optional sensitive fields `JINA_AI_API_KEY` and `GEMINI_API_KEY` so `/plugin install` prompts for them. Both are skippable; the server falls back to bundled local ONNX embedding/reranking.
- Substitute via `${user_config.<KEY>}` into `mcpServers.wet.env`.
- Other env vars (`BRAVE_API_KEY`, `SERPER_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `GITHUB_TOKEN`, `SYNC_ENABLED`) remain manual `mcpServers` config -- not part of the install prompt.
- Update `setup-manual.md` and `setup-with-agent.md` Method 1 with Step 0 prompt section.

## Test plan
- [ ] CI green
- [ ] `/plugin install` prompts for both keys (skippable)
- [ ] Local ONNX path works when both prompts are skipped

Generated with [Claude Code](https://claude.com/claude-code)