### PR TITLE
feat: align userConfig with relay_schema fields

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,27 @@
       "description": "Optional cloud embedding fallback. https://ai.google.dev/",
       "sensitive": true,
       "required": false
+    },
+    "OPENAI_API_KEY": {
+      "type": "string",
+      "title": "OpenAI API key (optional)",
+      "description": "Optional cloud LLM + embedding fallback (lower priority than Gemini). https://platform.openai.com/api-keys",
+      "sensitive": true,
+      "required": false
+    },
+    "COHERE_API_KEY": {
+      "type": "string",
+      "title": "Cohere API key (optional)",
+      "description": "Optional cloud embedding + reranking fallback. https://dashboard.cohere.com/api-keys",
+      "sensitive": true,
+      "required": false
+    },
+    "GITHUB_TOKEN": {
+      "type": "string",
+      "title": "GitHub personal access token (optional)",
+      "description": "Optional. Bumps GitHub API rate limit (60->5000 req/hr) for library docs discovery. https://github.com/settings/tokens",
+      "sensitive": true,
+      "required": false
     }
   },
   "author": {
@@ -43,7 +64,10 @@
       "env": {
         "MCP_TRANSPORT": "stdio",
         "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}",
-        "GEMINI_API_KEY": "${user_config.GEMINI_API_KEY}"
+        "GEMINI_API_KEY": "${user_config.GEMINI_API_KEY}",
+        "OPENAI_API_KEY": "${user_config.OPENAI_API_KEY}",
+        "COHERE_API_KEY": "${user_config.COHERE_API_KEY}",
+        "GITHUB_TOKEN": "${user_config.GITHUB_TOKEN}"
       }
     }
   }

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -45,6 +45,15 @@ RELAY_SCHEMA: dict[str, Any] = {
             "helpText": "Embedding + Reranking.",
             "required": False,
         },
+        {
+            "key": "GITHUB_TOKEN",
+            "label": "GitHub Personal Access Token",
+            "type": "password",
+            "placeholder": "ghp_...",
+            "helpUrl": "https://github.com/settings/tokens",
+            "helpText": "Optional. Bumps GitHub API rate limit (60->5000 req/hr) for library docs discovery.",
+            "required": False,
+        },
     ],
     "capabilityInfo": [
         {

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -24,9 +24,9 @@ class TestRelaySchema:
         assert "fields" in RELAY_SCHEMA
         assert "modes" not in RELAY_SCHEMA
 
-    def test_schema_has_four_provider_fields(self):
+    def test_schema_has_five_provider_fields(self):
         fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 4
+        assert len(fields) == 5
 
     def test_schema_field_keys(self):
         field_keys = [f["key"] for f in RELAY_SCHEMA["fields"]]
@@ -34,6 +34,7 @@ class TestRelaySchema:
         assert "GEMINI_API_KEY" in field_keys
         assert "OPENAI_API_KEY" in field_keys
         assert "COHERE_API_KEY" in field_keys
+        assert "GITHUB_TOKEN" in field_keys
 
     def test_schema_server_name(self):
         assert RELAY_SCHEMA["server"] == "wet-mcp"


### PR DESCRIPTION
## Summary
- Add GITHUB_TOKEN to relay_schema.py (bug fix — was missing; library docs use it for GitHub API rate limit 60->5000 req/hr).
- Sync .claude-plugin/plugin.json userConfig + mcpServers.wet.env with relay_schema 1:1: JINA_AI_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, COHERE_API_KEY, GITHUB_TOKEN.
- Update tests/test_relay_setup.py: 4->5 provider fields + assert GITHUB_TOKEN key.

## Test plan
- [x] pre-commit hooks pass (ruff, ty, pytest, gitleaks, json-check)
- [x] pytest tests/test_relay_setup.py — schema field count + keys
- [ ] CI green