### PR TITLE
fix: bump web-core to 1.3.10b2 for SearXNG doi_resolver fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1769,7 +1769,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-web-core"
-version = "1.3.9"
+version = "1.3.10b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "browserforge" },
@@ -1783,9 +1783,9 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/4f/d96c8b45ea5c3edf92c9f27818eead72af002bae283d91def35aa5a72cc4/n24q02m_web_core-1.3.9.tar.gz", hash = "sha256:3b1faa571b88ee69875e2b474692e520631f00e4277d4c54d97603035aa5690f", size = 203782, upload-time = "2026-04-29T04:49:57.04Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/ca/b505e1cb05a2f03b1b0e24a692864dfa1bfa37892535ab9e5ca915770f88/n24q02m_web_core-1.3.10b2.tar.gz", hash = "sha256:e4ef5f36f9d3c9edf49f22c2ec6a6b7a12d06ebf988523e1088c9ddc08f28def", size = 206002, upload-time = "2026-05-05T03:25:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d6/a7307c9f076155d777db7d348b078c985454ab5e226f7a3dd8c51c4026e5/n24q02m_web_core-1.3.9-py3-none-any.whl", hash = "sha256:4f7ef790b02a621ccb1fdbed7c4f8c6c3ffd26e748937d76c7d22f238b295b4d", size = 55648, upload-time = "2026-04-29T04:49:55.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a5/066b30c77cd00a3c31d0dd9ced8bc464079a2621f25d7ee79cfeecf37522/n24q02m_web_core-1.3.10b2-py3-none-any.whl", hash = "sha256:7965ef3d5a272fc0b19121f453862f4f5f40c2aa0aed767ad2fb4b24c4c62e49", size = 56360, upload-time = "2026-05-05T03:25:04.956Z" },
 ]
 
 [[package]]
@@ -3367,7 +3367,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.29.0b14"
+version = "2.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Pulls in web-core PR #220 (use_default_settings: true). Unblocks auto-SearXNG path inside container so wet.search works without external workaround.