### PR TITLE
[TEST] Missing test for `uvx_searxng_blocked_error`

### DIFF
--- a/tests/test_transport_check.py
+++ b/tests/test_transport_check.py
@@ -217,3 +217,11 @@ async def test_extract_action_works_regardless_of_uvx(monkeypatch):
 
         assert "Extracted Content" in result
         mock_extract.assert_called_once()
+
+
+def test_uvx_searxng_blocked_error():
+    """uvx_searxng_blocked_error() formats the message correctly."""
+    result = tc.uvx_searxng_blocked_error("search")
+    assert "Error: action 'search' requires SearXNG" in result
+    assert "stdio uvx mode" in result
+    assert "https://github.com/n24q02m/wet-mcp#setup" in result


### PR DESCRIPTION
Adds unit test coverage for the `uvx_searxng_blocked_error` formatter in `src/wet_mcp/transport_check.py`.

The test verifies that the error message correctly interpolates the action name and contains required context such as the setup URL and the "stdio uvx mode" identifier.

---
*PR created automatically by Jules for task [768103805554616920](https://jules.google.com/task/768103805554616920) started by @n24q02m*