### PR TITLE
[FIX] Overly long function search in db.py

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -629,52 +629,35 @@ class DocsDB:
         scored.sort(key=lambda x: x[1], reverse=True)
         return scored
 
-    def search(
-        self,
-        query: str,
-        library_name: str | None = None,
-        version: str | None = None,
-        limit: int = 10,
-        query_embedding: list[float] | None = None,
-    ) -> list[dict]:
-        """Hybrid search: FTS5 + optional vector + quality scoring.
-
-        Uses tiered FTS5 queries (AND -> OR fallback), BM25 column weights
-        (boosting title/heading matches), min-max score normalization,
-        and RRF fusion when vector search is available.
-        Recency is intentionally excluded -- all doc chunks share the same
-        indexing timestamp, making recency meaningless for static docs.
-
-        Args:
-            query: Search query text
-            library_name: Filter by library name
-            version: Filter by version
-            limit: Max results
-            query_embedding: Optional embedding vector for semantic search
+    def _resolve_search_filters(
+        self, library_name: str | None, version: str | None
+    ) -> tuple[str | None, str | None] | None:
+        """Resolve library name and version string to internal IDs.
 
         Returns:
-            List of chunk dicts sorted by relevance score
+            Tuple of (library_id, version_id) or None if library not found.
         """
-        # Resolve library/version filters
         library_id = None
         version_id = None
         if library_name:
             lib = self.get_library(library_name)
             if not lib:
-                return []
+                return None
             library_id = lib["id"]
             if version:
                 ver = self.get_best_version(library_id, version)
                 if ver:
                     version_id = ver["id"]
+        return library_id, version_id
 
-        candidate_limit = limit * 3
-
-        # --- FTS5 search with tiered queries + BM25 column weights ---
-        # Weights: id(0), content(2), title(3), heading_path(2)
-        # Flattened: content is the primary signal, title gets a moderate
-        # boost, heading_path gets minimal boost (BM25 already naturally
-        # up-weights matches in short fields via tf-idf).
+    def _do_fts_search(
+        self,
+        query: str,
+        library_id: str | None,
+        version_id: str | None,
+        candidate_limit: int,
+    ) -> tuple[dict[str, float], dict[str, dict]]:
+        """Perform FTS5 tiered search and return normalized scores."""
         fts_queries = _build_fts_queries(query)
         fts_scores: dict[str, float] = {}
         fts_chunks: dict[str, dict] = {}
@@ -728,53 +711,57 @@ class DocsDB:
             else:
                 fts_scores = dict.fromkeys(fts_scores, 1.0)
 
-        # --- Vector search ---
+        return fts_scores, fts_chunks
+
+    def _do_vector_search(
+        self,
+        query_embedding: list[float],
+        library_id: str | None,
+        version_id: str | None,
+        candidate_limit: int,
+        fts_chunks: dict[str, dict],
+    ) -> dict[str, float]:
+        """Perform vector search and update fts_chunks with missing data."""
         vec_scores: dict[str, float] = {}
-        if self._vec_enabled and query_embedding:
-            try:
-                vec_sql = """
-                    SELECT v.id, v.distance, c.*, l.name AS _library_name
-                    FROM doc_chunks_vec v
-                    JOIN doc_chunks c ON v.id = c.id
-                    LEFT JOIN libraries l ON c.library_id = l.id
-                    WHERE v.embedding MATCH ?
-                """
-                vec_params: list = [_serialize_f32(query_embedding)]
+        try:
+            vec_sql = """
+                SELECT v.id, v.distance, c.*, l.name AS _library_name
+                FROM doc_chunks_vec v
+                JOIN doc_chunks c ON v.id = c.id
+                LEFT JOIN libraries l ON c.library_id = l.id
+                WHERE v.embedding MATCH ?
+            """
+            vec_params: list = [_serialize_f32(query_embedding)]
 
-                if library_id:
-                    vec_sql += " AND c.library_id = ?"
-                    vec_params.append(library_id)
-                if version_id:
-                    vec_sql += " AND c.version_id = ?"
-                    vec_params.append(version_id)
+            if library_id:
+                vec_sql += " AND c.library_id = ?"
+                vec_params.append(library_id)
+            if version_id:
+                vec_sql += " AND c.version_id = ?"
+                vec_params.append(version_id)
 
-                vec_sql += " ORDER BY v.distance LIMIT ?"
-                vec_params.append(candidate_limit)
+            vec_sql += " ORDER BY v.distance LIMIT ?"
+            vec_params.append(candidate_limit)
 
-                vec_rows = self._conn.execute(vec_sql, vec_params).fetchall()
-                for vr in vec_rows:
-                    chunk_id = vr["id"]
-                    vec_scores[chunk_id] = max(0.0, 1.0 - vr["distance"])
+            vec_rows = self._conn.execute(vec_sql, vec_params).fetchall()
+            for vr in vec_rows:
+                chunk_id = vr["id"]
+                vec_scores[chunk_id] = max(0.0, 1.0 - vr["distance"])
 
-                    # ⚡ Bolt Optimization: Use pre-fetched chunk data from the JOIN
-                    # instead of executing a SELECT query per row (fixes N+1 query problem).
-                    if chunk_id not in fts_chunks:
-                        chunk_data = dict(vr)
-                        chunk_data.pop("distance", None)
-                        fts_chunks[chunk_id] = chunk_data
-            except Exception as e:
-                logger.debug(f"Vector search error: {e}")
+                # ⚡ Bolt Optimization: Use pre-fetched chunk data from the JOIN
+                # instead of executing a SELECT query per row (fixes N+1 query problem).
+                if chunk_id not in fts_chunks:
+                    chunk_data = dict(vr)
+                    chunk_data.pop("distance", None)
+                    fts_chunks[chunk_id] = chunk_data
+        except Exception as e:
+            logger.debug(f"Vector search error: {e}")
+        return vec_scores
 
-        # --- Combine scores ---
-        scored = self._combine_scores(fts_scores, vec_scores, fts_chunks)
-
-        # Build results with cross-chunk context + URL diversity limit
-        # Cap results per URL to avoid returning 4-5 chunks from the same page
-        max_per_url = 2
-        url_counts: dict[str, int] = {}
-        results = []
-
-        # ---- Prefetch adjacent chunks in one batch query ----
+    def _prefetch_adjacent_chunks(
+        self, scored: list[tuple[str, float]], fts_chunks: dict[str, dict]
+    ) -> dict[tuple[str, str, int], str]:
+        """Batch fetch adjacent chunks for context."""
         _adj_keys: list[tuple[str, str, int]] = []
         for _cid, _sc in scored:
             _ch = fts_chunks.get(_cid)
@@ -788,31 +775,88 @@ class DocsDB:
                 _adj_keys.append((_url, _ver, _idx + 1))
 
         _adj_map: dict[tuple[str, str, int], str] = {}
-        if _adj_keys:
-            # ⚡ Bolt Optimization: Use row-value IN to fetch all adjacent chunks in a single query.
-            # This avoids the N+1 query problem by batching multiple (url, version_id, chunk_index) tuples.
-            # We use sorted(set()) to ensure uniqueness and improve cache locality.
-            _unique_keys = sorted(set(_adj_keys))
-            _batch_size = (
-                32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
-            ) // 3
+        if not _adj_keys:
+            return _adj_map
 
-            for i in range(0, len(_unique_keys), _batch_size):
-                _batch = _unique_keys[i : i + _batch_size]
-                _placeholders = ",".join(["(?,?,?)"] * len(_batch))
-                _params = [item for key_tuple in _batch for item in key_tuple]
+        # ⚡ Bolt Optimization: Use row-value IN to fetch all adjacent chunks in a single query.
+        # This avoids the N+1 query problem by batching multiple (url, version_id, chunk_index) tuples.
+        # We use sorted(set()) to ensure uniqueness and improve cache locality.
+        _unique_keys = sorted(set(_adj_keys))
+        _batch_size = (32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999) // 3
 
-                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                rows = self._conn.execute(
-                    f"""SELECT url, version_id, chunk_index, content
-                        FROM doc_chunks
-                        WHERE (url, version_id, chunk_index) IN ({_placeholders})""",
-                    _params,
-                ).fetchall()
-                for r in rows:
-                    _adj_map[(r["url"], r["version_id"], r["chunk_index"])] = r[
-                        "content"
-                    ]
+        for i in range(0, len(_unique_keys), _batch_size):
+            _batch = _unique_keys[i : i + _batch_size]
+            _placeholders = ",".join(["(?,?,?)"] * len(_batch))
+            _params = [item for key_tuple in _batch for item in key_tuple]
+
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+            rows = self._conn.execute(
+                f"""SELECT url, version_id, chunk_index, content
+                    FROM doc_chunks
+                    WHERE (url, version_id, chunk_index) IN ({_placeholders})""",
+                _params,
+            ).fetchall()
+            for r in rows:
+                _adj_map[(r["url"], r["version_id"], r["chunk_index"])] = r["content"]
+        return _adj_map
+
+    def search(
+        self,
+        query: str,
+        library_name: str | None = None,
+        version: str | None = None,
+        limit: int = 10,
+        query_embedding: list[float] | None = None,
+    ) -> list[dict]:
+        """Hybrid search: FTS5 + optional vector + quality scoring.
+
+        Uses tiered FTS5 queries (AND -> OR fallback), BM25 column weights
+        (boosting title/heading matches), min-max score normalization,
+        and RRF fusion when vector search is available.
+        Recency is intentionally excluded -- all doc chunks share the same
+        indexing timestamp, making recency meaningless for static docs.
+
+        Args:
+            query: Search query text
+            library_name: Filter by library name
+            version: Filter by version
+            limit: Max results
+            query_embedding: Optional embedding vector for semantic search
+
+        Returns:
+            List of chunk dicts sorted by relevance score
+        """
+        # Resolve library/version filters
+        filters = self._resolve_search_filters(library_name, version)
+        if filters is None:
+            return []
+        library_id, version_id = filters
+
+        candidate_limit = limit * 3
+
+        # --- FTS5 search ---
+        fts_scores, fts_chunks = self._do_fts_search(
+            query, library_id, version_id, candidate_limit
+        )
+
+        # --- Vector search ---
+        vec_scores: dict[str, float] = {}
+        if self._vec_enabled and query_embedding:
+            vec_scores = self._do_vector_search(
+                query_embedding, library_id, version_id, candidate_limit, fts_chunks
+            )
+
+        # --- Combine scores ---
+        scored = self._combine_scores(fts_scores, vec_scores, fts_chunks)
+
+        # Build results with cross-chunk context + URL diversity limit
+        # Cap results per URL to avoid returning 4-5 chunks from the same page
+        max_per_url = 2
+        url_counts: dict[str, int] = {}
+        results = []
+
+        # ---- Prefetch adjacent chunks in one batch query ----
+        _adj_map = self._prefetch_adjacent_chunks(scored, fts_chunks)
 
         for cid, score in scored:
             if len(results) >= limit:


### PR DESCRIPTION
The search method in src/wet_mcp/db.py was refactored into modular private helpers: _resolve_search_filters, _do_fts_search, _do_vector_search, and _prefetch_adjacent_chunks. This decomposition reduces the complexity of the core search method from ~220 lines to a high-level orchestration, improving readability and maintainability while preserving all functionality and performance optimizations.

---
*PR created automatically by Jules for task [8912412012172603959](https://jules.google.com/task/8912412012172603959) started by @n24q02m*