### PR TITLE
[FIX] Overly long function import_jsonl in db.py

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -1077,7 +1077,6 @@ class DocsDB:
         self._conn.commit()
         return stats
 
-
     def close(self) -> None:
         """Close database connection."""
         try:

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -902,30 +902,27 @@ class DocsDB:
 
         return "\n".join(lines)
 
-    def import_jsonl(self, data: str, mode: str = "merge") -> dict:
-        """Import JSONL data. mode: merge (skip existing) or replace (clear first)."""
-        stats = {"libraries": 0, "versions": 0, "chunks": 0, "skipped": 0}
+    def _clear_for_import(self) -> None:
+        """Clear database tables before replacement import."""
+        if self._vec_enabled:
+            try:
+                self._conn.execute("DELETE FROM doc_chunks_vec")
+            except Exception:
+                logger.warning(
+                    "Failed to clear vector table during import replace",
+                    exc_info=True,
+                )
+        self._conn.execute("DELETE FROM doc_chunks")
+        self._conn.execute("DELETE FROM versions")
+        self._conn.execute("DELETE FROM libraries")
 
-        if mode == "replace":
-            if self._vec_enabled:
-                try:
-                    self._conn.execute("DELETE FROM doc_chunks_vec")
-                except Exception:
-                    logger.warning(
-                        "Failed to clear vector table during import replace",
-                        exc_info=True,
-                    )
-            self._conn.execute("DELETE FROM doc_chunks")
-            self._conn.execute("DELETE FROM versions")
-            self._conn.execute("DELETE FROM libraries")
-
-        lines = data.split("\n")
-
+    def _parse_jsonl_data(self, data: str) -> tuple[list[dict], list[dict], list[dict]]:
+        """Parse JSONL data into libraries, versions, and chunks."""
         libraries = []
         versions = []
         chunks = []
 
-        for line in lines:
+        for line in data.split("\n"):
             # ⚡ Bolt Optimization: Use `not line or line.isspace()` for truthiness
             # checking instead of `.strip()` to avoid allocating memory for new string slices.
             if not line or line.isspace():
@@ -939,32 +936,36 @@ class DocsDB:
                 versions.append(obj)
             elif obj_type == "chunk":
                 chunks.append(obj)
+        return libraries, versions, chunks
 
-        def _get_existing(table: str, items: list) -> set:
-            allowed_queries = {
-                "libraries": "SELECT id FROM libraries WHERE id IN ({})",
-                "versions": "SELECT id FROM versions WHERE id IN ({})",
-                "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN ({})",
-            }
-            if table not in allowed_queries:
-                raise ValueError(f"Invalid table name: {table}")
-            if not items:
-                return set()
-            ids = [obj["id"] for obj in items]
-            existing = set()
-            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
-            for i in range(0, len(ids), batch_size):
-                batch = ids[i : i + batch_size]
-                placeholders = ",".join("?" * len(batch))
-                # Safe because table is strictly validated against allowlist
-                # and placeholders string contains only static "?" and ",".
-                query = allowed_queries[table].format(placeholders)
-                res = self._conn.execute(query, batch).fetchall()
-                existing.update(r[0] for r in res)
-            return existing
+    def _get_existing_ids(self, table: str, items: list[dict]) -> set[str]:
+        """Generic helper to find existing IDs in the database."""
+        allowed_queries = {
+            "libraries": "SELECT id FROM libraries WHERE id IN ({})",
+            "versions": "SELECT id FROM versions WHERE id IN ({})",
+            "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN ({})",
+        }
+        if table not in allowed_queries:
+            raise ValueError(f"Invalid table name: {table}")
+        if not items:
+            return set()
+        ids = [obj["id"] for obj in items]
+        existing = set()
+        batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+        for i in range(0, len(ids), batch_size):
+            batch = ids[i : i + batch_size]
+            placeholders = ",".join("?" * len(batch))
+            # Safe because table is strictly validated against allowlist
+            # and placeholders string contains only static "?" and ",".
+            query = allowed_queries[table].format(placeholders)
+            res = self._conn.execute(query, batch).fetchall()
+            existing.update(r[0] for r in res)
+        return existing
 
+    def _import_libraries(self, libraries: list[dict], mode: str, stats: dict) -> None:
+        """Process and insert library records."""
         existing_libs = (
-            _get_existing("libraries", libraries) if mode == "merge" else set()
+            self._get_existing_ids("libraries", libraries) if mode == "merge" else set()
         )
         to_insert_libs = []
         for obj in libraries:
@@ -993,8 +994,10 @@ class DocsDB:
             )
             stats["libraries"] += len(to_insert_libs)
 
+    def _import_versions(self, versions: list[dict], mode: str, stats: dict) -> None:
+        """Process and insert version records."""
         existing_vers = (
-            _get_existing("versions", versions) if mode == "merge" else set()
+            self._get_existing_ids("versions", versions) if mode == "merge" else set()
         )
         to_insert_vers = []
         for obj in versions:
@@ -1024,8 +1027,10 @@ class DocsDB:
             )
             stats["versions"] += len(to_insert_vers)
 
+    def _import_chunks(self, chunks: list[dict], mode: str, stats: dict) -> None:
+        """Process and insert chunk records."""
         existing_chunks = (
-            _get_existing("doc_chunks", chunks) if mode == "merge" else set()
+            self._get_existing_ids("doc_chunks", chunks) if mode == "merge" else set()
         )
         to_insert_chunks = []
         for obj in chunks:
@@ -1056,8 +1061,22 @@ class DocsDB:
             )
             stats["chunks"] += len(to_insert_chunks)
 
+    def import_jsonl(self, data: str, mode: str = "merge") -> dict:
+        """Import JSONL data. mode: merge (skip existing) or replace (clear first)."""
+        stats = {"libraries": 0, "versions": 0, "chunks": 0, "skipped": 0}
+
+        if mode == "replace":
+            self._clear_for_import()
+
+        libraries, versions, chunks = self._parse_jsonl_data(data)
+
+        self._import_libraries(libraries, mode, stats)
+        self._import_versions(versions, mode, stats)
+        self._import_chunks(chunks, mode, stats)
+
         self._conn.commit()
         return stats
+
 
     def close(self) -> None:
         """Close database connection."""


### PR DESCRIPTION
This PR refactors the monolithic `import_jsonl` method in `src/wet_mcp/db.py` into a modular pipeline of private helpers.

### Changes:
- Extracted logic for table cleanup into `_clear_for_import`.
- Extracted JSONL parsing and type grouping into `_parse_jsonl_data`.
- Promoted the internal `_get_existing` function to a class-level `_get_existing_ids` helper.
- Decomposed insertion logic into domain-specific helpers: `_import_libraries`, `_import_versions`, and `_import_chunks`.
- Updated `import_jsonl` to orchestrate these helpers.

### Benefits:
- **Maintainability:** Smaller, focused methods are easier to test and modify.
- **Readability:** The high-level flow of the import process is now clear at a glance.
- **Preserved Logic:** All performance optimizations (truthiness-based line skipping, batched lookups) and safety checks (SQL injection protection, vector table handling) are maintained.

Verification:
- Ran `ruff check` and `ty check` (all passed).
- Ran `pytest tests/test_db.py` (all 87 tests passed).

---
*PR created automatically by Jules for task [14580170702147169158](https://jules.google.com/task/14580170702147169158) started by @n24q02m*