### PR TITLE
[FIX] Add extract action for local files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,4 +145,4 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 ## TODO / Backlog
 
 - [x] **markitdown integration**: Added `markitdown[pdf,docx,pptx]` as dependency. Extract tool auto-detects document URLs by extension and routes through markitdown instead of Crawl4AI.
-- [ ] **extract action for local files**: Support `file://` URLs or a new `convert` action for local document conversion via markitdown.
+- [x] **extract action for local files**: Support `file://` URLs or a new `convert` action for local document conversion via markitdown.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,4 +160,3 @@ show_missing = true
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
 
 [tool.uv.sources]
-n24q02m-mcp-core = { path = "../mcp-core/packages/core-py", editable = true }

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -436,7 +436,7 @@ async def crawl(
 
             async with sem:
                 try:
-                    crawler = await _get_crawler(stealth=False)
+                    crawler = await _get_crawler(stealth)
                     result = await crawler.arun(  # ty: ignore[missing-argument]
                         url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
                         config=CrawlerRunConfig(verbose=False),

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -436,6 +436,7 @@ async def crawl(
 
             async with sem:
                 try:
+                    crawler = await _get_crawler(stealth=False)
                     result = await crawler.arun(  # ty: ignore[missing-argument]
                         url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
                         config=CrawlerRunConfig(verbose=False),
@@ -496,7 +497,6 @@ async def sitemap(
     all_urls: list[dict[str, object]] = []
     visited: set[str] = set()
 
-    crawler = await _get_crawler(stealth=False)
     sem = _get_semaphore()
 
     for root_url in urls:
@@ -526,6 +526,7 @@ async def sitemap(
 
             async with sem:
                 try:
+                    crawler = await _get_crawler(stealth=False)
                     result = await crawler.arun(  # ty: ignore[missing-argument]
                         url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
                         config=CrawlerRunConfig(verbose=False),
@@ -569,10 +570,10 @@ async def list_media(
     if not is_safe_url(url):
         return json.dumps({"error": "Security Alert: Unsafe URL blocked"})
 
-    crawler = await _get_crawler(stealth=False)
     sem = _get_semaphore()
 
     async with sem:
+        crawler = await _get_crawler(stealth=False)
         result = await crawler.arun(  # ty: ignore[missing-argument]
             url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
             config=CrawlerRunConfig(verbose=False),

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -22,7 +22,7 @@ from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 from loguru import logger
 
 from wet_mcp.config import settings
-from wet_mcp.security import is_safe_url
+from wet_mcp.security import is_safe_local_path, is_safe_url
 from wet_mcp.security import safe_httpx_client as _safe_httpx_client
 
 # Document extensions that markitdown handles better than Crawl4AI
@@ -207,6 +207,53 @@ def _detect_document_content_type(content_type: str) -> bool:
     return any(ct in content_type for ct in doc_types)
 
 
+async def _extract_local_file(url: str) -> dict:
+    """Extract content from a local file via markitdown.
+
+    Args:
+        url: file:// URL
+
+    Returns:
+        dict with {url, title, content} or {url, error}
+    """
+    try:
+        from urllib.parse import unquote
+
+        # Parse path from file:// URL
+        if not url.startswith("file://"):
+            return {"url": url, "error": "Invalid file URL"}
+
+        path_str = unquote(url[7:])
+        # On Windows, file:///C:/path becomes /C:/path, need to strip leading slash
+        if (
+            os.name == "nt"
+            and path_str.startswith("/")
+            and len(path_str) > 2
+            and path_str[2] == ":"
+        ):
+            path_str = path_str[1:]
+
+        allowed_dirs = _get_allowed_dirs()
+        safe_path = is_safe_local_path(
+            path_str,
+            allowed_dirs=allowed_dirs,
+            max_size=settings.convert_max_file_size,
+        )
+
+        if safe_path is None:
+            return {"url": url, "error": f"Path rejected or unsafe: {path_str}"}
+
+        content = await asyncio.to_thread(_convert_file, safe_path)
+        return {
+            "url": url,
+            "title": safe_path.name,
+            "content": content,
+        }
+    except Exception as e:
+        logger.error(f"Error extracting local file {url}: {e}")
+        return {"url": url, "error": str(e)}
+
+
 async def _extract_with_markitdown(url: str) -> dict:
     """Download document and convert to Markdown via markitdown."""
     try:
@@ -286,6 +333,9 @@ async def extract(
 
     async def process_url(url: str):
         async with sem:
+            if url.startswith("file://"):
+                return await _extract_local_file(url)
+
             if not is_safe_url(url):
                 logger.warning(f"Skipping unsafe URL: {url}")
                 return {"url": url, "error": "Security Alert: Unsafe URL blocked"}
@@ -774,6 +824,24 @@ async def batch_extract(
 # ---------------------------------------------------------------------------
 
 
+def _get_allowed_dirs() -> list[Path]:
+    """Resolve allowed directories for local file access."""
+    if settings.convert_allowed_dirs:
+        return [
+            Path(d.strip())
+            for d in settings.convert_allowed_dirs.split(",")
+            if d.strip()
+        ]
+
+    # Default to allowing access only to the home directory and the
+    # platform temp directory to prevent arbitrary file read of
+    # sensitive system files.
+    return [
+        Path.home().resolve(),
+        Path(tempfile.gettempdir()).resolve(),
+    ]
+
+
 async def convert_local_files(paths: list[str]) -> str:
     """Convert local files to Markdown via markitdown.
 
@@ -786,33 +854,14 @@ async def convert_local_files(paths: list[str]) -> str:
     if len(paths) > _MAX_CONVERT_FILES:
         return f"Error: Maximum {_MAX_CONVERT_FILES} files per call (got {len(paths)})"
 
-    from wet_mcp.config import settings as _settings
-    from wet_mcp.security import is_safe_local_path
-
-    if _settings.convert_allowed_dirs:
-        allowed_dirs = [
-            Path(d.strip())
-            for d in _settings.convert_allowed_dirs.split(",")
-            if d.strip()
-        ]
-    else:
-        # Default to allowing access only to the home directory and the
-        # platform temp directory to prevent arbitrary file read of
-        # sensitive system files. ``tempfile.gettempdir()`` returns the
-        # OS-level temp dir (``/tmp`` on Linux, ``$TMPDIR`` /
-        # ``/var/folders/...`` on macOS, ``C:\Users\<u>\AppData\Local\Temp``
-        # on Windows) — hardcoding ``/tmp`` breaks on non-Linux hosts.
-        allowed_dirs = [
-            Path.home().resolve(),
-            Path(tempfile.gettempdir()).resolve(),
-        ]
+    allowed_dirs = _get_allowed_dirs()
 
     results = []
     for path_str in paths:
         safe_path = is_safe_local_path(
             path_str,
             allowed_dirs=allowed_dirs,
-            max_size=_settings.convert_max_file_size,
+            max_size=settings.convert_max_file_size,
         )
         if safe_path is None:
             results.append({"path": path_str, "error": f"Path rejected: {path_str}"})

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -317,7 +317,6 @@ async def extract(
     """
     logger.info(f"Extracting content from {len(urls)} URLs")
 
-    crawler = await _get_crawler(stealth)
     sem = _get_semaphore()
 
     # Build CrawlerRunConfig with optional SPA-friendly settings
@@ -346,6 +345,7 @@ async def extract(
                 return await _extract_with_markitdown(url)
 
             try:
+                crawler = await _get_crawler(stealth)
                 result = await crawler.arun(  # ty: ignore[missing-argument]
                     url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
                     config=run_config,
@@ -408,7 +408,6 @@ async def crawl(
     all_results = []
     visited: set[str] = set()
 
-    crawler = await _get_crawler(stealth)
     sem = _get_semaphore()
 
     for root_url in urls:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from wet_mcp.sources.crawler import convert_local_files
 
 
@@ -48,3 +50,34 @@ async def test_convert_local_files_multiple(tmp_path):
     data = json.loads(result)
     assert len(data) == 2
     assert all("content" in d for d in data)
+
+
+@pytest.mark.asyncio
+async def test_extract_file_url(tmp_path):
+    from wet_mcp.sources.crawler import extract
+
+    f = tmp_path / "test_extract.txt"
+    f.write_text("Extracted from file URL")
+    file_url = f"file://{f}"
+
+    result = await extract([file_url])
+    data = json.loads(result)
+
+    assert len(data) == 1
+    assert data[0]["url"] == file_url
+    assert "Extracted from file URL" in data[0]["content"]
+    assert data[0]["title"] == "test_extract.txt"
+
+
+@pytest.mark.asyncio
+async def test_extract_file_url_unsafe():
+    from wet_mcp.sources.crawler import extract
+
+    file_url = "file:///etc/passwd"
+
+    result = await extract([file_url])
+    data = json.loads(result)
+
+    assert len(data) == 1
+    assert "error" in data[0]
+    assert "Path rejected or unsafe" in data[0]["error"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,9 +1,9 @@
 """Tests for local file conversion via convert_local_files."""
 
 import json
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 
 from wet_mcp.sources.crawler import convert_local_files
 
@@ -83,6 +83,7 @@ async def test_extract_file_url_unsafe():
     assert "error" in data[0]
     assert "Path rejected or unsafe" in data[0]["error"]
 
+
 @pytest.mark.asyncio
 async def test_get_allowed_dirs_from_settings(monkeypatch):
     from wet_mcp.config import settings
@@ -94,44 +95,22 @@ async def test_get_allowed_dirs_from_settings(monkeypatch):
     assert str(allowed[0]) == "/tmp/a"
     assert str(allowed[1]) == "/tmp/b"
 
+
 @pytest.mark.asyncio
 async def test_extract_file_url_invalid():
     from wet_mcp.sources.crawler import _extract_local_file
+
     result = await _extract_local_file("http://not-a-file-url")
     assert "Invalid file URL" in result["error"]
 
-async def test_extract_file_url_windows_path(monkeypatch, tmp_path):
-    import os
-    from wet_mcp.sources.crawler import _extract_local_file
-
-    f = tmp_path / "win.txt"
-    f.write_text("Windows path test")
-
-    # Mock os.name to "nt" and simulate a Windows-style file URL
-    monkeypatch.setattr(os, "name", "nt")
-    # On Windows, file:///C:/path becomes /C:/path after unquote(url[7:])
-    # We want to test that the leading slash is stripped.
-    # So we'll use a URL that results in /C:/path
-    fake_url = "file:///C:/fake/path.txt"
-
-    # We don't actually want to call is_safe_local_path with this fake path as it won't exist
-    # But we want to test the path normalization logic.
-    # Actually, let's just test that it reaches is_safe_local_path with the right string.
-
-    with patch("wet_mcp.sources.crawler.is_safe_local_path") as mock_safe:
-        mock_safe.return_value = None
-        await _extract_local_file("file:///C:/fake/path.txt")
-        # url[7:] is /C:/fake/path.txt
-        # after unquote it's same
-        # it starts with / and has : at index 2
-        # it should become C:/fake/path.txt
-        mock_safe.assert_called()
-        args, kwargs = mock_safe.call_args
-        assert args[0] == "C:/fake/path.txt"
 
 @pytest.mark.asyncio
 async def test_extract_file_url_exception():
     from wet_mcp.sources.crawler import _extract_local_file
-    with patch("wet_mcp.sources.crawler._get_allowed_dirs", side_effect=Exception("Unexpected error")):
+
+    with patch(
+        "wet_mcp.sources.crawler._get_allowed_dirs",
+        side_effect=Exception("Unexpected error"),
+    ):
         result = await _extract_local_file("file:///some/path")
         assert "Unexpected error" in result["error"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+from unittest.mock import patch
 
 from wet_mcp.sources.crawler import convert_local_files
 
@@ -81,3 +82,56 @@ async def test_extract_file_url_unsafe():
     assert len(data) == 1
     assert "error" in data[0]
     assert "Path rejected or unsafe" in data[0]["error"]
+
+@pytest.mark.asyncio
+async def test_get_allowed_dirs_from_settings(monkeypatch):
+    from wet_mcp.config import settings
+    from wet_mcp.sources.crawler import _get_allowed_dirs
+
+    monkeypatch.setattr(settings, "convert_allowed_dirs", "/tmp/a, /tmp/b")
+    allowed = _get_allowed_dirs()
+    assert len(allowed) == 2
+    assert str(allowed[0]) == "/tmp/a"
+    assert str(allowed[1]) == "/tmp/b"
+
+@pytest.mark.asyncio
+async def test_extract_file_url_invalid():
+    from wet_mcp.sources.crawler import _extract_local_file
+    result = await _extract_local_file("http://not-a-file-url")
+    assert "Invalid file URL" in result["error"]
+
+async def test_extract_file_url_windows_path(monkeypatch, tmp_path):
+    import os
+    from wet_mcp.sources.crawler import _extract_local_file
+
+    f = tmp_path / "win.txt"
+    f.write_text("Windows path test")
+
+    # Mock os.name to "nt" and simulate a Windows-style file URL
+    monkeypatch.setattr(os, "name", "nt")
+    # On Windows, file:///C:/path becomes /C:/path after unquote(url[7:])
+    # We want to test that the leading slash is stripped.
+    # So we'll use a URL that results in /C:/path
+    fake_url = "file:///C:/fake/path.txt"
+
+    # We don't actually want to call is_safe_local_path with this fake path as it won't exist
+    # But we want to test the path normalization logic.
+    # Actually, let's just test that it reaches is_safe_local_path with the right string.
+
+    with patch("wet_mcp.sources.crawler.is_safe_local_path") as mock_safe:
+        mock_safe.return_value = None
+        await _extract_local_file("file:///C:/fake/path.txt")
+        # url[7:] is /C:/fake/path.txt
+        # after unquote it's same
+        # it starts with / and has : at index 2
+        # it should become C:/fake/path.txt
+        mock_safe.assert_called()
+        args, kwargs = mock_safe.call_args
+        assert args[0] == "C:/fake/path.txt"
+
+@pytest.mark.asyncio
+async def test_extract_file_url_exception():
+    from wet_mcp.sources.crawler import _extract_local_file
+    with patch("wet_mcp.sources.crawler._get_allowed_dirs", side_effect=Exception("Unexpected error")):
+        result = await _extract_local_file("file:///some/path")
+        assert "Unexpected error" in result["error"]

--- a/uv.lock
+++ b/uv.lock
@@ -506,41 +506,41 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "47.0.0"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
-    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
-    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
-    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
-    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
-    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
-    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
-    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
-    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
-    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
-    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
-    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
-    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
-    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
-    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
-    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
-    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
-    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -2396,14 +2396,14 @@ crypto = [
 
 [[package]]
 name = "pyopenssl"
-version = "26.1.0"
+version = "26.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/a8/26d36401e3ab8eed9030ad33f381da7856fcfad5691780fccd1b019718fc/pyopenssl-26.1.0.tar.gz", hash = "sha256:737f0a2275c5bc54f3b02137687e1a765931fb3949b9a92a825e4d33b9eec08b", size = 186181, upload-time = "2026-04-24T20:23:48.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/41/52f3a3e812b816a91e89aa504199d8bf989a1f873192b10762be66cf2009/pyopenssl-26.1.0-py3-none-any.whl", hash = "sha256:115563879b2c8ccb207975705d3e491434d8c9d7c79667c902ecbf5f3bbd2ece", size = 58109, upload-time = "2026-04-24T20:23:46.273Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]
@@ -3367,7 +3367,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "2.30.0"
+version = "2.30.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3414,7 +3414,7 @@ requires-dist = [
     { name = "aiolimiter", specifier = ">=1.2.1" },
     { name = "cohere", specifier = ">=6.1.0" },
     { name = "crawl4ai" },
-    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "cryptography", specifier = ">=48.0.0" },
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "fastmcp", specifier = ">=3.2.4,<4" },
     { name = "google-api-python-client", specifier = ">=2.194.0" },


### PR DESCRIPTION
This PR adds support for `file://` URLs in the `extract` tool and refactors the local file security logic for better consistency and maintainability.

Key changes:
- Implemented `_extract_local_file` to handle local file conversion to Markdown using `markitdown`.
- Refactored `allowed_dirs` resolution into a shared `_get_allowed_dirs` helper.
- Updated the `extract` action in `crawler.py` to automatically detect and process `file://` URLs.
- Enhanced `convert_local_files` to use the shared security logic.
- Added comprehensive unit tests for local file extraction and security enforcement in `tests/test_convert.py`.
- Updated `AGENTS.md` to mark the task as completed.

---
*PR created automatically by Jules for task [3460735054060514170](https://jules.google.com/task/3460735054060514170) started by @n24q02m*