### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in token_store.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Path Traversal in Token Storage
+**Vulnerability:** The `token_store.py` module constructed file paths by directly concatenating user-controlled inputs (`provider`, `sub`) via `pathlib.Path` without validation. This allowed path traversal (e.g., using `../` or absolute paths) to read or write arbitrary files on the system with the application's permissions.
+**Learning:** Even when using higher-level path abstractions like `pathlib`, string concatenation or `/` division with unvalidated user input is unsafe because the underlying OS resolution still respects traversal sequences.
+**Prevention:** Always explicitly validate path components for dangerous characters (like `/`, `\`, and `..`) using an explicit string validation helper before passing them to file I/O operations or path constructors.

--- a/src/wet_mcp/token_store.py
+++ b/src/wet_mcp/token_store.py
@@ -25,6 +25,14 @@ from loguru import logger
 from wet_mcp.config import settings
 
 
+def _validate_safe_name(name: str) -> None:
+    """Validate that a name does not contain path separators or traversal sequences."""
+    if not name:
+        raise ValueError("Name cannot be empty")
+    if "/" in name or "\\" in name or ".." in name:
+        raise ValueError(f"Invalid path component: {name}")
+
+
 def _get_token_dir() -> Path:
     """Get directory for token storage (~/.wet-mcp/tokens/).
 
@@ -37,6 +45,7 @@ def _get_token_dir() -> Path:
 
 def get_token_path(provider: str) -> Path:
     """Get path for a provider's token file."""
+    _validate_safe_name(provider)
     return _get_token_dir() / f"{provider}.json"
 
 
@@ -47,11 +56,14 @@ def _get_token_dir_for_sub(sub: str) -> Path:
     JWT ``sub`` so user A's GDrive refresh-token is not visible to
     user B sharing the same wet-mcp deployment.
     """
+    _validate_safe_name(sub)
     return settings.get_data_dir() / "subs" / sub / "tokens"
 
 
 def get_token_path_for_sub(sub: str, provider: str) -> Path:
     """Get path for a provider's token file scoped to a specific JWT sub."""
+    _validate_safe_name(sub)
+    _validate_safe_name(provider)
     return _get_token_dir_for_sub(sub) / f"{provider}.json"
 
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -46,6 +46,24 @@ def test_get_token_path(token_dir):
     assert get_token_path("drive") == token_dir / "drive.json"
 
 
+def test_path_traversal_validation(token_dir):
+    """Test that path traversal sequences are blocked."""
+    with pytest.raises(ValueError, match="Invalid path component"):
+        get_token_path("../drive")
+
+    with pytest.raises(ValueError, match="Invalid path component"):
+        get_token_path("drive/something")
+
+    with pytest.raises(ValueError, match="Invalid path component"):
+        get_token_path_for_sub("../user", "drive")
+
+    with pytest.raises(ValueError, match="Invalid path component"):
+        get_token_path_for_sub("user", "../drive")
+
+    with pytest.raises(ValueError, match="Name cannot be empty"):
+        get_token_path("")
+
+
 def test_load_missing_token(token_dir):
     """load_token returns None if file doesn't exist."""
     assert load_token("drive") is None


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `token_store.py` module constructed file paths by directly concatenating user-provided or caller-provided variables (`provider`, `sub`) without validation. This allowed path traversal (e.g., using `../` or `/`) to read or overwrite arbitrary files on the system with the application's permissions.
🎯 Impact: An attacker who can control the `provider` or `sub` inputs could potentially access sensitive configuration files or overwrite critical files on the host filesystem.
🔧 Fix: Introduced a `_validate_safe_name` helper function that explicitly checks and blocks path separators (`/`, `\`) and traversal sequences (`..`). This validation is now enforced in `get_token_path`, `_get_token_dir_for_sub`, and `get_token_path_for_sub` before any `pathlib.Path` construction occurs. Also added comprehensive unit tests for these traversal payloads.
✅ Verification: Ensure the test suite passes (`uv run pytest`), specifically `tests/test_token_store.py::test_path_traversal_validation` which verifies `ValueError` is correctly raised for traversal sequences.

---
*PR created automatically by Jules for task [4351484000567167640](https://jules.google.com/task/4351484000567167640) started by @n24q02m*