### PR TITLE
🎨 Palette: Document backend-only UI constraint in journal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Aborted UX Enhancement
+**Learning:** Evaluated the repository for micro-UX opportunities but found none applicable, as the codebase consists entirely of backend Python modules and integration test files without any graphical user interface (GUI) or frontend artifacts (HTML/JS/CSS). The only user-facing configuration is a schema-driven static definition (`relay_schema.py`), which already implements standard placeholders and help text.
+**Action:** In identical backend-only contexts without frontend components, skip searching for structural UX/ARIA enhancements, and immediately transition to "no suitable enhancement" conclusion to save investigation cycles.

--- a/uv.lock
+++ b/uv.lock
@@ -3528,7 +3528,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.0.0b2"
+version = "3.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Explored the codebase for micro-UX enhancements as requested by the Palette persona. Since the repository is exclusively backend Python code with no HTML/CSS/JS frontend components, no UI modifications could be made. Instead, documented this constraint in the UX journal at `.Jules/palette.md` as per the persona's instructions and stopped without modifying application logic.

---
*PR created automatically by Jules for task [15455507024754405299](https://jules.google.com/task/15455507024754405299) started by @n24q02m*