### PR TITLE
🎨 Palette: Update media tool help description to reflect removed analyze action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## 2025-05-16 - Outdated Help Documentation
+
+**Learning**: The `help` tool's description contains outdated information regarding the `media` tool's capabilities. It incorrectly states that `media` can "analyze images/videos/audio", even though the `media.analyze` action was removed in v2.0.0. This causes confusion for users relying on the `help` documentation.
+**Action**: Always verify that summary documentation (like the "Quick guide" in tool docstrings) stays perfectly synchronized with breaking API changes (like feature removals) to prevent sending users down dead-end interaction paths.

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1425,7 +1425,7 @@ async def help(tool_name: str = "search") -> str:
     Quick guide -- which tool to use:
     - Need to FIND information? Use `search` (returns result listings with URLs)
     - Need to READ a page? Use `extract` (returns full page content from a URL)
-    - Need media files? Use `media` (discover, download, analyze images/videos/audio)
+    - Need media files? Use `media` (discover, download images/videos/audio)
     - Need server settings? Use `config` (status, cache, settings, warmup, sync setup)
     """
     allowed_tools = {"search", "extract", "media", "config"}


### PR DESCRIPTION
💡 What: Removed the phrase ", analyze images/videos/audio" from the Quick Guide section for the `media` tool in `help` docstring.
🎯 Why: The `media(action="analyze")` feature was completely removed in v2.0.0. The help tool's text was outdated and falsely advertised this capability, leading to confusion and dead-end user interactions.
📸 Before/After: Visual change not applicable (docstring text change).
♿ Accessibility: Improves clarity and usability of documentation for developers and LLMs relying on the help tool.

---
*PR created automatically by Jules for task [8222795464696312653](https://jules.google.com/task/8222795464696312653) started by @n24q02m*