### PR TITLE
🎨 Palette: Remove outdated media analysis references from config UI

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Configuration UI Synchronization
+**Learning:** Removing deprecated features (like `media.analyze`) from code without updating the corresponding configuration UI (`relay_schema.py`) leaves stale help text that confuses users about available API capabilities.
+**Action:** When deprecating or removing features, always audit configuration schemas, help texts, and capability lists (e.g., `capabilityInfo`) to ensure the UI accurately reflects the current feature set. Update associated unit tests that assert these UI labels.

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -24,7 +24,7 @@ RELAY_SCHEMA: dict[str, Any] = {
             "type": "password",
             "placeholder": "AIza...",
             "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": "LLM (structured extraction, media analysis) + Embedding. Free tier available.",
+            "helpText": "LLM (structured extraction) + Embedding. Free tier available.",
             "required": False,
         },
         {
@@ -77,9 +77,9 @@ RELAY_SCHEMA: dict[str, Any] = {
             "description": "Re-ranks search results for accuracy. Local mode uses Qwen3-Reranker (0.6B ONNX).",
         },
         {
-            "label": "LLM / Vision",
+            "label": "LLM",
             "priority": "Gemini > OpenAI",
-            "description": "Used for structured extraction and media analysis. Without a key, these features are limited.",
+            "description": "Used for structured extraction. Without a key, these features are limited.",
         },
     ],
 }

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -54,7 +54,7 @@ class TestRelaySchema:
         assert "Extraction" in labels
         assert "Embedding" in labels
         assert "Reranking" in labels
-        assert "LLM / Vision" in labels
+        assert "LLM" in labels
 
 
 class TestLoadConfigFromFile:


### PR DESCRIPTION
This PR removes outdated references to the removed `media.analyze` feature from the `relay_schema.py` configuration UI schema.
    
    *   **💡 What:** Removed "Vision" and "media analysis" from the capability label and description for Gemini in the relay setup form.
    *   **🎯 Why:** `media(action="analyze")` was removed in v2.0.0. Keeping these references in the UI confuses users about the current capabilities of the system.
    *   **♿ Accessibility:** Improves cognitive accessibility by providing accurate, up-to-date descriptions of API key features in the setup form, reducing cognitive load and potential errors.

---
*PR created automatically by Jules for task [11432091889634255012](https://jules.google.com/task/11432091889634255012) started by @n24q02m*