### PR TITLE
🎨 Palette: Update relay schema to reflect removed media analysis feature

### DIFF
--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -24,7 +24,7 @@ RELAY_SCHEMA: dict[str, Any] = {
             "type": "password",
             "placeholder": "AIza...",
             "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": "LLM (structured extraction, media analysis) + Embedding. Free tier available.",
+            "helpText": "LLM (structured extraction) + Embedding. Free tier available.",
             "required": False,
         },
         {
@@ -77,9 +77,9 @@ RELAY_SCHEMA: dict[str, Any] = {
             "description": "Re-ranks search results for accuracy. Local mode uses Qwen3-Reranker (0.6B ONNX).",
         },
         {
-            "label": "LLM / Vision",
+            "label": "LLM",
             "priority": "Gemini > OpenAI",
-            "description": "Used for structured extraction and media analysis. Without a key, these features are limited.",
+            "description": "Used for structured extraction. Without a key, these features are limited.",
         },
     ],
 }

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -54,7 +54,7 @@ class TestRelaySchema:
         assert "Extraction" in labels
         assert "Embedding" in labels
         assert "Reranking" in labels
-        assert "LLM / Vision" in labels
+        assert "LLM" in labels
 
 
 class TestLoadConfigFromFile:


### PR DESCRIPTION
💡 **What:** Removed deprecated references to "media analysis" and "Vision" in the capability information within `relay_schema.py`.
🎯 **Why:** The `media.analyze` feature was removed in v2.0.0 per the `README.md`. Having outdated descriptions in the setup UI can be confusing to users who might expect those features to exist. This micro-UX improvement ensures the configuration UI is accurate.
♿ **Accessibility:** Reduces cognitive load by eliminating confusing, incorrect options in the setup UI schema.

---
*PR created automatically by Jules for task [3829983845663738287](https://jules.google.com/task/3829983845663738287) started by @n24q02m*