### PR TITLE
🎨 Palette: Simplify LLM capability label in relay schema

### DIFF
--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -24,7 +24,7 @@ RELAY_SCHEMA: dict[str, Any] = {
             "type": "password",
             "placeholder": "AIza...",
             "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": "LLM (structured extraction, media analysis) + Embedding. Free tier available.",
+            "helpText": "LLM (structured extraction) + Embedding. Free tier available.",
             "required": False,
         },
         {
@@ -77,9 +77,9 @@ RELAY_SCHEMA: dict[str, Any] = {
             "description": "Re-ranks search results for accuracy. Local mode uses Qwen3-Reranker (0.6B ONNX).",
         },
         {
-            "label": "LLM / Vision",
+            "label": "LLM",
             "priority": "Gemini > OpenAI",
-            "description": "Used for structured extraction and media analysis. Without a key, these features are limited.",
+            "description": "Used for structured extraction. Without a key, these features are limited.",
         },
     ],
 }

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -54,7 +54,7 @@ class TestRelaySchema:
         assert "Extraction" in labels
         assert "Embedding" in labels
         assert "Reranking" in labels
-        assert "LLM / Vision" in labels
+        assert "LLM" in labels
 
 
 class TestLoadConfigFromFile:


### PR DESCRIPTION
🎨 Palette: Simplify LLM capability label in relay schema

**What:** Simplified the label from "LLM / Vision" to "LLM" and removed "media analysis" from the tool's descriptions in `src/wet_mcp/relay_schema.py`. Also updated the corresponding assertions in the test suite.
**Why:** The `media.analyze` feature was previously deprecated and removed in v2.0.0. Keeping references to it in the configuration setup schema caused user confusion, so updating the text improves the micro-UX and aligns the copy with the actual application capabilities.
**Accessibility:** N/A (Visual/Copy polish)

---
*PR created automatically by Jules for task [2286947029968084885](https://jules.google.com/task/2286947029968084885) started by @n24q02m*