### PR TITLE
🎨 Palette: Add contextual suggestions to config set action

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1497,9 +1497,15 @@ def _handle_config_set(key: str | None, value: str | None) -> str:
         "sync_interval",
     }
     if key not in valid_keys:
+        import difflib
+
+        suggestion = ""
+        if key and isinstance(key, str):
+            closest = difflib.get_close_matches(key, valid_keys, n=1)
+            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
         return json.dumps(
             {
-                "error": f"Invalid key: {key}",
+                "error": f"Invalid key: {key}.{suggestion}",
                 "valid_keys": sorted(valid_keys),
             }
         )


### PR DESCRIPTION
💡 **What:** Added a "Did you mean ...?" suggestion using `difflib.get_close_matches` when a user or LLM client provides an invalid configuration key to the `config` tool's `set` action.
🎯 **Why:** To improve the developer experience and make the backend MCP interface more intuitive. When a typo occurs, suggesting the closest valid key helps users correct their input immediately without needing to cross-reference documentation, similar to an autocomplete experience.
📸 **Before/After:**
- *Before*: `{"error": "Invalid key: tool_timout", "valid_keys": [...]}`
- *After*: `{"error": "Invalid key: tool_timout. Did you mean 'tool_timeout'?", "valid_keys": [...]}`
♿ **Accessibility/UX:** Reduces cognitive load and frustration when interacting with the API by providing actionable feedback directly within the error message.

---
*PR created automatically by Jules for task [4008033735645811980](https://jules.google.com/task/4008033735645811980) started by @n24q02m*