### PR TITLE
Add supply-chain security test & update GitHub Actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,13 +41,13 @@ jobs:
       is_prerelease: ${{ steps.release.outputs.is_prerelease || steps.forced.outputs.is_prerelease }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_KEY }}
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -265,13 +265,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: matrix.os == 'ubuntu-latest'
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: coverage.xml
 
@@ -84,7 +84,7 @@ jobs:
       contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -92,12 +92,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
 
   docs-sync-check:
     name: Docs Sync Check (CLAUDE.md <-> AGENTS.md)
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -24,7 +24,7 @@ RELAY_SCHEMA: dict[str, Any] = {
             "type": "password",
             "placeholder": "AIza...",
             "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": "LLM (structured extraction, media analysis) + Embedding. Free tier available.",
+            "helpText": "LLM (structured extraction) + Embedding. Free tier available.",
             "required": False,
         },
         {
@@ -77,9 +77,9 @@ RELAY_SCHEMA: dict[str, Any] = {
             "description": "Re-ranks search results for accuracy. Local mode uses Qwen3-Reranker (0.6B ONNX).",
         },
         {
-            "label": "LLM / Vision",
+            "label": "LLM",
             "priority": "Gemini > OpenAI",
-            "description": "Used for structured extraction and media analysis. Without a key, these features are limited.",
+            "description": "Used for structured extraction. Without a key, these features are limited.",
         },
     ],
 }

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1425,7 +1425,7 @@ async def help(tool_name: str = "search") -> str:
     Quick guide -- which tool to use:
     - Need to FIND information? Use `search` (returns result listings with URLs)
     - Need to READ a page? Use `extract` (returns full page content from a URL)
-    - Need media files? Use `media` (discover, download, analyze images/videos/audio)
+    - Need media files? Use `media` (discover, download images/videos/audio)
     - Need server settings? Use `config` (status, cache, settings, warmup, sync setup)
     """
     allowed_tools = {"search", "extract", "media", "config"}

--- a/tests/test_dependency_security.py
+++ b/tests/test_dependency_security.py
@@ -1,0 +1,42 @@
+"""Supply-chain guard: security-pinned dependencies must stay patched.
+
+Several dependencies carry explicit CVE-driven floors in ``pyproject.toml``
+(see the inline comments there). A lock regeneration that silently dropped
+or weakened a pin would reintroduce the vulnerability, so the resolved
+``uv.lock`` versions are asserted here.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+_LOCK = Path(__file__).resolve().parent.parent / "uv.lock"
+
+# package name -> minimum patched version (the CVE is closed at/above this).
+_SECURITY_FLOORS = {
+    "urllib3": "2.7.0",  # GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j (2 high)
+    "langsmith": "0.8.0",  # GHSA-3644-q5cj-c5c7 (high)
+    "fastmcp": "3.2.4",  # keep off CVE-vulnerable 2.x line
+}
+
+
+def _locked_versions() -> dict[str, str]:
+    data = tomllib.loads(_LOCK.read_text(encoding="utf-8"))
+    return {pkg["name"]: pkg["version"] for pkg in data["package"]}
+
+
+def test_uv_lock_exists():
+    assert _LOCK.is_file(), f"uv.lock not found at {_LOCK}"
+
+
+@pytest.mark.parametrize(("name", "floor"), sorted(_SECURITY_FLOORS.items()))
+def test_security_pinned_dependency_meets_floor(name: str, floor: str):
+    locked = _locked_versions()
+    assert name in locked, f"{name} missing from uv.lock"
+    assert Version(locked[name]) >= Version(floor), (
+        f"{name} {locked[name]} is below the security floor {floor}"
+    )

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -54,7 +54,7 @@ class TestRelaySchema:
         assert "Extraction" in labels
         assert "Embedding" in labels
         assert "Reranking" in labels
-        assert "LLM / Vision" in labels
+        assert "LLM" in labels
 
 
 class TestLoadConfigFromFile:

--- a/uv.lock
+++ b/uv.lock
@@ -3574,7 +3574,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.0.0b3"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## Description

This PR adds a supply-chain security guard test to ensure CVE-driven dependency pins in `pyproject.toml` remain enforced in the lock file, preventing silent vulnerability reintroduction during lock regeneration. Also updates GitHub Actions to latest pinned versions.

## Changes

- **New test**: `tests/test_dependency_security.py` — Parametrized test that verifies security-pinned dependencies (urllib3, langsmith, fastmcp) meet their CVE-driven version floors when resolved in `uv.lock`
- **GitHub Actions updates**: Bump `step-security/harden-runner` to `ab7a9404c0f3da075243ca237b5fac12c98deaa5` (v2), `codecov/codecov-action` to `e79a6962e0d4c0c17b229090214935d2e33f8354` (v6), `github/codeql-action` to `9e0d7b8d25671d64c341c19c0152d693099fb5ba` (v4), and `actions/create-github-app-token` to `bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3) across CI and CD workflows
- **Documentation updates**: Remove references to "media analysis" and "Vision" from relay schema and server help text (feature scope clarification)

## Type of Change

- [x] New feature (supply-chain security test)
- [x] Chore (GitHub Actions updates, documentation clarification)

## Testing

- Added new parametrized test `test_security_pinned_dependency_meets_floor` covering urllib3, langsmith, and fastmcp
- Added `test_uv_lock_exists` to verify lock file presence
- Existing tests pass; no breaking changes

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation (relay schema, server help text)
- [x] My changes generate no new warnings

https://claude.ai/code/session_01PzV7YsKsqjqBYXyw3D2R2W