### PR TITLE
🎨 Palette: Add suggestions for invalid configuration keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Suggest valid parameters in JSON errors for backend MCP tools
+**Learning:** In backend MCP tools without traditional UIs, enhancing the developer experience by adding actionable suggestions (e.g., using `difflib.get_close_matches`) to JSON error responses for invalid parameters (like configuration keys) makes the interface much more pleasant and intuitive to use.
+**Action:** Always consider adding "Did you mean '...'?" suggestions to error messages when a user inputs an invalid command, key, or option from a known list.

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1497,9 +1497,13 @@ def _handle_config_set(key: str | None, value: str | None) -> str:
         "sync_interval",
     }
     if key not in valid_keys:
+        import difflib
+
+        closest = difflib.get_close_matches(key, valid_keys, n=1) if key is not None else []
+        suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
         return json.dumps(
             {
-                "error": f"Invalid key: {key}",
+                "error": f"Invalid key: {key}.{suggestion}",
                 "valid_keys": sorted(valid_keys),
             }
         )

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1499,7 +1499,9 @@ def _handle_config_set(key: str | None, value: str | None) -> str:
     if key not in valid_keys:
         import difflib
 
-        closest = difflib.get_close_matches(key, valid_keys, n=1) if key is not None else []
+        closest = (
+            difflib.get_close_matches(key, valid_keys, n=1) if key is not None else []
+        )
         suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
         return json.dumps(
             {


### PR DESCRIPTION
This PR adds a small developer experience (DX/UX) enhancement to the backend MCP configuration tool.

**💡 What:** 
When a user provides an invalid configuration key to the `config(action="set", key="...", value="...")` tool, the JSON error response now includes an actionable suggestion like "Did you mean 'log_level'?" using `difflib.get_close_matches`.

**🎯 Why:**
Backend tools often return opaque error messages. In the context of MCP, a model might hallucinate or mistype a key. Providing the closest valid match makes the feedback immediately actionable for both humans and AI models driving the interface, reducing friction.

**♿ Accessibility / DX:**
Improves error recoverability and intuitiveness of the API.

An entry documenting this DX pattern has been added to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [9724762547296570074](https://jules.google.com/task/9724762547296570074) started by @n24q02m*