### PR TITLE
🎨 Palette: Add actionable suggestions for invalid config keys

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1497,9 +1497,13 @@ def _handle_config_set(key: str | None, value: str | None) -> str:
         "sync_interval",
     }
     if key not in valid_keys:
+        import difflib
+
+        closest = difflib.get_close_matches(key, sorted(valid_keys), n=1) if key is not None else []
+        suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
         return json.dumps(
             {
-                "error": f"Invalid key: {key}",
+                "error": f"Invalid key: {key}.{suggestion}",
                 "valid_keys": sorted(valid_keys),
             }
         )

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1499,7 +1499,11 @@ def _handle_config_set(key: str | None, value: str | None) -> str:
     if key not in valid_keys:
         import difflib
 
-        closest = difflib.get_close_matches(key, sorted(valid_keys), n=1) if key is not None else []
+        closest = (
+            difflib.get_close_matches(key, sorted(valid_keys), n=1)
+            if key is not None
+            else []
+        )
         suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
         return json.dumps(
             {


### PR DESCRIPTION
💡 **What:**
Added a "Did you mean 'X'?" suggestion to the JSON error response when an invalid configuration key is provided to the `config` tool.

🎯 **Why:**
To improve the Developer Experience (DX) for users interacting with the MCP server API. Instead of just failing with "Invalid key", it helps guide them to the correct spelling (e.g., if they typo `wet_cach` instead of `wet_cache`), reducing frustration and saving time.

📸 **Before/After:**
*Before:* `{"error": "Invalid key: wet_cach", "valid_keys": ["log_level", "tool_timeout", "wet_cache", "sync_enabled", "sync_folder", "sync_interval"]}`
*After:* `{"error": "Invalid key: wet_cach. Did you mean 'wet_cache'?", "valid_keys": ["log_level", "tool_timeout", "wet_cache", "sync_enabled", "sync_folder", "sync_interval"]}`

♿ **Accessibility/UX Impact:**
Improves error recoverability and the overall developer interface by offering actionable suggestions rather than generic failures.

---
*PR created automatically by Jules for task [1126466623170165049](https://jules.google.com/task/1126466623170165049) started by @n24q02m*