### PR TITLE
[FIX] Function 'import_jsonl' is too long

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -1139,79 +1139,74 @@ class DocsDB:
 
         return "\n".join(lines)
 
-    def import_jsonl(self, data: str, mode: str = "merge") -> dict:
-        """Import JSONL data. mode: merge (skip existing) or replace (clear first)."""
-        stats = {"libraries": 0, "versions": 0, "chunks": 0, "skipped": 0}
+    def _clear_for_import(self) -> None:
+        """Clear all library-related tables before replace-mode import."""
+        if self._vec_enabled:
+            try:
+                self._conn.execute("DELETE FROM doc_chunks_vec")
+            except Exception:
+                logger.warning(
+                    "Failed to clear vector table during import replace",
+                    exc_info=True,
+                )
+        self._conn.execute("DELETE FROM doc_chunks")
+        self._conn.execute("DELETE FROM versions")
+        self._conn.execute("DELETE FROM libraries")
 
-        if mode == "replace":
-            if self._vec_enabled:
-                try:
-                    self._conn.execute("DELETE FROM doc_chunks_vec")
-                except Exception:
-                    logger.warning(
-                        "Failed to clear vector table during import replace",
-                        exc_info=True,
-                    )
-            self._conn.execute("DELETE FROM doc_chunks")
-            self._conn.execute("DELETE FROM versions")
-            self._conn.execute("DELETE FROM libraries")
-
-        lines = data.split("\n")
-
-        libraries = []
-        versions = []
-        chunks = []
-
-        for line in lines:
-            # ⚡ Bolt Optimization: Use `not line or line.isspace()` for truthiness
-            # checking instead of `.strip()` to avoid allocating memory for new string slices.
+    def _parse_jsonl_data(self, data: str) -> tuple[list, list, list]:
+        """Parse raw JSONL data into typed lists (libraries, versions, chunks)."""
+        libraries, versions, chunks = [], [], []
+        for line in data.split("\n"):
             if not line or line.isspace():
                 continue
             obj = json.loads(line)
             obj_type = obj.pop("_type", None)
-
             if obj_type == "library":
                 libraries.append(obj)
             elif obj_type == "version":
                 versions.append(obj)
             elif obj_type == "chunk":
                 chunks.append(obj)
+        return libraries, versions, chunks
 
-        def _get_existing(table: str, items: list) -> set:
-            allowed_queries = {
-                "libraries": "SELECT id FROM libraries WHERE id IN ({})",
-                "versions": "SELECT id FROM versions WHERE id IN ({})",
-                "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN ({})",
-            }
-            if table not in allowed_queries:
-                raise ValueError(f"Invalid table name: {table}")
-            if not items:
-                return set()
-            ids = [obj["id"] for obj in items]
-            existing = set()
-            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
-            for i in range(0, len(ids), batch_size):
-                batch = ids[i : i + batch_size]
-                placeholders = ",".join("?" * len(batch))
-                # Safe because table is strictly validated against allowlist
-                # and placeholders string contains only static "?" and ",".
-                query = allowed_queries[table].replace("{}", placeholders)
-                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                res = self._conn.execute(query, batch).fetchall()
-                existing.update(r[0] for r in res)
-            return existing
+    def _get_existing_ids(self, table: str, items: list) -> set[str]:
+        """Check which item IDs already exist in the database in batches."""
+        allowed_queries = {
+            "libraries": "SELECT id FROM libraries WHERE id IN ({})",
+            "versions": "SELECT id FROM versions WHERE id IN ({})",
+            "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN ({})",
+        }
+        if table not in allowed_queries:
+            raise ValueError(f"Invalid table name: {table}")
+        if not items:
+            return set()
 
-        existing_libs = (
-            _get_existing("libraries", libraries) if mode == "merge" else set()
+        ids = [obj["id"] for obj in items]
+        existing = set()
+        batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+
+        for i in range(0, len(ids), batch_size):
+            batch = ids[i : i + batch_size]
+            placeholders = ",".join("?" * len(batch))
+            query = allowed_queries[table].replace("{}", placeholders)
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+            res = self._conn.execute(query, batch).fetchall()
+            existing.update(r[0] for r in res)
+        return existing
+
+    def _import_libraries(self, libraries: list, mode: str, stats: dict) -> set[str]:
+        """Import library objects into the database."""
+        existing = (
+            self._get_existing_ids("libraries", libraries) if mode == "merge" else set()
         )
-        to_insert_libs = []
+        to_insert = []
         for obj in libraries:
-            if mode == "merge" and obj["id"] in existing_libs:
+            if mode == "merge" and obj["id"] in existing:
                 stats["skipped"] += 1
                 continue
             if mode == "merge":
-                existing_libs.add(obj["id"])
-            to_insert_libs.append(
+                existing.add(obj["id"])
+            to_insert.append(
                 (
                     obj["id"],
                     obj["name"],
@@ -1222,26 +1217,29 @@ class DocsDB:
                     obj["updated_at"],
                 )
             )
-        if to_insert_libs:
+        if to_insert:
             self._conn.executemany(
                 """INSERT OR REPLACE INTO libraries
                    (id, name, docs_url, registry, description, created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                to_insert_libs,
+                to_insert,
             )
-            stats["libraries"] += len(to_insert_libs)
+            stats["libraries"] += len(to_insert)
+        return existing
 
-        existing_vers = (
-            _get_existing("versions", versions) if mode == "merge" else set()
+    def _import_versions(self, versions: list, mode: str, stats: dict) -> None:
+        """Import version objects into the database."""
+        existing = (
+            self._get_existing_ids("versions", versions) if mode == "merge" else set()
         )
-        to_insert_vers = []
+        to_insert = []
         for obj in versions:
-            if mode == "merge" and obj["id"] in existing_vers:
+            if mode == "merge" and obj["id"] in existing:
                 stats["skipped"] += 1
                 continue
             if mode == "merge":
-                existing_vers.add(obj["id"])
-            to_insert_vers.append(
+                existing.add(obj["id"])
+            to_insert.append(
                 (
                     obj["id"],
                     obj["library_id"],
@@ -1253,26 +1251,28 @@ class DocsDB:
                     obj.get("status", "indexed"),
                 )
             )
-        if to_insert_vers:
+        if to_insert:
             self._conn.executemany(
                 """INSERT OR REPLACE INTO versions
                    (id, library_id, version, docs_url, indexed_at, page_count, chunk_count, status)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                to_insert_vers,
+                to_insert,
             )
-            stats["versions"] += len(to_insert_vers)
+            stats["versions"] += len(to_insert)
 
-        existing_chunks = (
-            _get_existing("doc_chunks", chunks) if mode == "merge" else set()
+    def _import_chunks(self, chunks: list, mode: str, stats: dict) -> None:
+        """Import documentation chunk objects into the database."""
+        existing = (
+            self._get_existing_ids("doc_chunks", chunks) if mode == "merge" else set()
         )
-        to_insert_chunks = []
+        to_insert = []
         for obj in chunks:
-            if mode == "merge" and obj["id"] in existing_chunks:
+            if mode == "merge" and obj["id"] in existing:
                 stats["skipped"] += 1
                 continue
             if mode == "merge":
-                existing_chunks.add(obj["id"])
-            to_insert_chunks.append(
+                existing.add(obj["id"])
+            to_insert.append(
                 (
                     obj["id"],
                     obj["version_id"],
@@ -1285,14 +1285,28 @@ class DocsDB:
                     obj["created_at"],
                 )
             )
-        if to_insert_chunks:
+        if to_insert:
             self._conn.executemany(
                 """INSERT OR REPLACE INTO doc_chunks
                    (id, version_id, library_id, url, title, chunk_index, content, heading_path, created_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                to_insert_chunks,
+                to_insert,
             )
-            stats["chunks"] += len(to_insert_chunks)
+            stats["chunks"] += len(to_insert)
+
+    def import_jsonl(self, data: str, mode: str = "merge") -> dict:
+        """Import JSONL data. mode: merge (skip existing) or replace (clear first)."""
+        stats = {"libraries": 0, "versions": 0, "chunks": 0, "skipped": 0}
+
+        if mode == "replace":
+            self._clear_for_import()
+
+        libraries, versions, chunks = self._parse_jsonl_data(data)
+
+        # Batch import by type
+        self._import_libraries(libraries, mode, stats)
+        self._import_versions(versions, mode, stats)
+        self._import_chunks(chunks, mode, stats)
 
         self._conn.commit()
         return stats

--- a/uv.lock
+++ b/uv.lock
@@ -218,30 +218,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.14"
+version = "1.43.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/4b/616367e871ce3f1cb3e8545a97736b6331b9fb081497f2d44c5b2aa6959d/boto3-1.43.14.tar.gz", hash = "sha256:5c0a994b3182061ee101812e721100717a4d664f9f4ceaf4a86b6d032ce9fc2d", size = 113142, upload-time = "2026-05-22T19:28:47.861Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/4f/f13d80d377b54dd2973e243e4eb7ce748706cd53876361cc72506006fd8b/boto3-1.43.16.tar.gz", hash = "sha256:6c337bbe608aacc7d335c79e671f0c893870293b74d652f7a7af22ccd0dfef16", size = 113152, upload-time = "2026-05-27T19:31:39.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/00/59cb9329c18e2d3aa23062ceaa87d065f2e81e7d2931df24d64e9a7815aa/boto3-1.43.14-py3-none-any.whl", hash = "sha256:574335744656cfed0b362a0a0467aaf2eb2bf15526edcd02d31d3c661f4b09e4", size = 140536, upload-time = "2026-05-22T19:28:46.49Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c0/7d687e40f4b7046ede66026ecd1b0a93d47afe26d9170f5926a1605c8641/boto3-1.43.16-py3-none-any.whl", hash = "sha256:dffc8a3cd3edbc0ad95b9c6b983e873b76ede46d3aa0709f94db253f2ff2388f", size = 140537, upload-time = "2026-05-27T19:31:36.453Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.14"
+version = "1.43.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz", hash = "sha256:b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516", size = 15382604, upload-time = "2026-05-22T19:28:36.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/74/140451a1fe027cb5e387cc7b1ec56224616ca742c330f1492f71c5cba3fb/botocore-1.43.16.tar.gz", hash = "sha256:813dae233d8b365c19aaf7865b32070e34d7e793654881bf86ecbbef3f4ad5c6", size = 15388648, upload-time = "2026-05-27T19:31:25.172Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/7e/6e64821077cd2efc4aa51b7d638fb6d48e1c7c450201c529fbaf1de8bfd3/botocore-1.43.14-py3-none-any.whl", hash = "sha256:1f4a2a95ea78c10398e78431e98c1fe47adb54a7b10a32975144c1f541186658", size = 15061424, upload-time = "2026-05-22T19:28:32.682Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8f/25933240485c0662bb3fa430ed0c6b8b8124ab3bc136154c07ce12644cb0/botocore-1.43.16-py3-none-any.whl", hash = "sha256:8ab05b1346d26a3c6d69c7338051f07bd4739a090f414d2cff43c0dbc1e18ca7", size = 15067437, upload-time = "2026-05-27T19:31:19.212Z" },
 ]
 
 [[package]]
@@ -1152,9 +1152,10 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.16.1"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
@@ -1165,9 +1166,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/65/9826515abb600b5722bcf53f8b4a2fb58340b1f8bfcaee19f83561c13a44/huggingface_hub-1.17.0.tar.gz", hash = "sha256:fad842b6763ef70ebc3919665b1b9273645203185400a7d6c5eddc2323cc3435", size = 797082, upload-time = "2026-05-28T15:12:13.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+    { url = "https://files.pythonhosted.org/packages/02/28/d7cef5e477b855c25d415b8f57e5bc7347c7a90cad3acf1725d0c92ca294/huggingface_hub-1.17.0-py3-none-any.whl", hash = "sha256:3b8156d23118e87f6a587648bfbc04f04a12a757ccb4ed298b35c4ae638bf24c", size = 671546, upload-time = "2026-05-28T15:12:11.441Z" },
 ]
 
 [[package]]
@@ -1473,7 +1474,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1483,9 +1484,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/8e/34a57e338a319e3b32c1bd183c2a9a04f7f35d683d3f3d8f597f6eacbc4e/langgraph-1.2.1.tar.gz", hash = "sha256:28314f844678d9d307cbd63e7b48b0145bf17177d84b40ee2921061e07b6f966", size = 693750, upload-time = "2026-05-21T18:33:07.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/5a/ffc12434ee8aecab830d58b4d204ddea45073eae7639c963310f671a5bf5/langgraph-1.2.2.tar.gz", hash = "sha256:f54a98458976b3ff0774683867df125fb52d8dbedeb2441d0b0656a51331cee5", size = 695730, upload-time = "2026-05-26T18:07:28.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/8c/313912e26866893bd15be9b4ea3442dc86f69270b0ad01a4961d1eba7118/langgraph-1.2.1-py3-none-any.whl", hash = "sha256:5cc4020de8f1e2a048d773f6e9128646a2af8c68a8067ab9cab177a2fcc8d221", size = 235317, upload-time = "2026-05-21T18:33:05.687Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9b/b08d578bba73e25351152dfd3d6d21e81210a5fff1b6f26e56f33197c8f5/langgraph-1.2.2-py3-none-any.whl", hash = "sha256:0a851bf4ba5939c5474a2fd57e6b439b5315283e254e42943bd392c2d71a5e03", size = 236376, upload-time = "2026-05-26T18:07:26.577Z" },
 ]
 
 [[package]]
@@ -1854,7 +1855,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.15.0b3"
+version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1868,14 +1869,14 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/ae/bc537b34cb0a1a79deca1ff536d4eb5d8f449e261fbfe1f13b9c90ed60d6/n24q02m_mcp_core-1.15.0b3.tar.gz", hash = "sha256:9b7baf3c4a91787051a53d72e8edf65ea142d1c7d49c9858a262cf168756a62c", size = 195053, upload-time = "2026-05-26T07:01:53.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/8f/8ca2ec184fdcef215adcf5b83655b1239ec1cbd57b3428a061c767d336a9/n24q02m_mcp_core-1.16.0.tar.gz", hash = "sha256:25577706f46f0993a5c244d70e059f0cd9c91031a00d4c7c473b7343d6bb550c", size = 195030, upload-time = "2026-05-28T08:38:53.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/96/3c261c481f912db42d3ef1b609d0ff9ef6190774aec559926d4b3f0a3e01/n24q02m_mcp_core-1.15.0b3-py3-none-any.whl", hash = "sha256:cb1bb5458ddfb416e10068852f5d0984af768ae27109f3f05185ff2a764678a1", size = 125591, upload-time = "2026-05-26T07:01:54.469Z" },
+    { url = "https://files.pythonhosted.org/packages/78/51/be21adff3aebdc64d6b9cd9e6248f7e86611c8d5e1da1131c753517d1887/n24q02m_mcp_core-1.16.0-py3-none-any.whl", hash = "sha256:622494742b85f591eaa57bf0fb1ca24593429a4271c7b2e7b704a28810993323", size = 125599, upload-time = "2026-05-28T08:38:54.756Z" },
 ]
 
 [[package]]
 name = "n24q02m-web-core"
-version = "2.0.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "browserforge" },
@@ -1889,9 +1890,9 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/06/67583d81ceb029debc928ce8dcffc50db5f3aca64e36a2d6fa68b8aa2dc4/n24q02m_web_core-2.0.1.tar.gz", hash = "sha256:0e8e4aa2e8d4bf44ac060243e822d56c9e541c1324c148928dfa0b3d7f6cdd48", size = 218985, upload-time = "2026-05-09T09:02:51.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/f8/6932603e866bb0f79fbef4df5e6481419123c9a034bb011771f8da2c607e/n24q02m_web_core-2.1.1.tar.gz", hash = "sha256:fe92b099dded528593d9e8af92bd40407f11ac061bf38eeaa905d39be53eae17", size = 221039, upload-time = "2026-05-28T09:51:21.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/c1/bda1a831ab3a43f68cc386ea0076673ddfe3aba37b71ad596f13fdec508f/n24q02m_web_core-2.0.1-py3-none-any.whl", hash = "sha256:06e2b2c82bafc29bceb043fd1643d68623709ca8d3c8333934408015f160e8aa", size = 59283, upload-time = "2026-05-09T09:02:51.992Z" },
+    { url = "https://files.pythonhosted.org/packages/72/32/63b62e907f7c5341ecbe11089a2a43d6645977de8c9c71989c4ef5254949/n24q02m_web_core-2.1.1-py3-none-any.whl", hash = "sha256:7a2d65fddafd2ff9b1f72c801915541a6cf7514f64564277febf8ce6a4a27faa", size = 60174, upload-time = "2026-05-28T09:51:20.413Z" },
 ]
 
 [[package]]
@@ -2420,7 +2421,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.5"
+version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -2428,9 +2429,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
 [package.optional-dependencies]
@@ -2440,27 +2441,28 @@ email = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.5"
+version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
-    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
-    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
 ]
 
 [[package]]
@@ -2753,7 +2755,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.9.2"
+version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2764,9 +2766,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ab/e50fcc6bc124278cb3708bb44633cc9ef800f26fe5e3bf625d7da49a9052/qwen3_embed-1.9.2.tar.gz", hash = "sha256:3fe0c9b3c67423ff3c859a915a1115b9c92c4a510ae31bd2762d57fdef11912b", size = 183003, upload-time = "2026-05-06T13:01:18.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/26/344bd0f1c289f2c52c0a31f04f7ccbda4098e2c340429954b4e1b592e5dd/qwen3_embed-1.10.1.tar.gz", hash = "sha256:c1b55916737bbd25a0cdbb8121a8483e430fd5223d06e5ace410f4f95a06146e", size = 184996, upload-time = "2026-05-28T09:51:18.947Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/bc/5dbf669c4bc786966a8fa9e61588583b1b5bf553577a02a3f9f8975f9d84/qwen3_embed-1.9.2-py3-none-any.whl", hash = "sha256:eb8edbcd87acb5fe3d95160a7879e9def833312faccf4a0ee31276545cb6bf85", size = 59437, upload-time = "2026-05-06T13:01:17.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e1/defca94f70e52ba1a28b1a2306d85bebead76f61e9ddc9247ed9ae52ff1f/qwen3_embed-1.10.1-py3-none-any.whl", hash = "sha256:4da2c9bdc5c6382ecb16d0271ecc8efca4a91e1425ed5dcb416cbd79a9bc9a71", size = 60403, upload-time = "2026-05-28T09:51:17.792Z" },
 ]
 
 [[package]]
@@ -3561,7 +3563,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.0b1"
+version = "3.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3611,7 +3613,7 @@ dev = [
 requires-dist = [
     { name = "aiolimiter", specifier = ">=1.2.1" },
     { name = "alembic", specifier = ">=1.18.4" },
-    { name = "boto3", specifier = ">=1.43.13" },
+    { name = "boto3", specifier = ">=1.43.16" },
     { name = "cohere", specifier = ">=7.0.0" },
     { name = "cryptography", specifier = ">=48.0.0" },
     { name = "diskcache", specifier = ">=5.6.3" },
@@ -3628,12 +3630,12 @@ requires-dist = [
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
     { name = "n24q02m-mcp-core", specifier = ">=1.15.0b3,<2" },
-    { name = "n24q02m-web-core", specifier = ">=2.0.1" },
+    { name = "n24q02m-web-core", specifier = ">=2.1.0" },
     { name = "openai", specifier = ">=2.38.0" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
+    { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },
-    { name = "qwen3-embed", specifier = ">=1.9.2" },
+    { name = "qwen3-embed", specifier = ">=1.10.0" },
     { name = "sqlite-vec" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "waitress", marker = "sys_platform == 'win32'", specifier = ">=3.0.2" },


### PR DESCRIPTION
Refactored the `import_jsonl` method in `src/wet_mcp/db.py` to improve maintainability and readability. The logic was decomposed into modular private helper methods:
- `_clear_for_import`: Handles table cleanup for replace mode.
- `_parse_jsonl_data`: Parses and groups JSONL data by type.
- `_get_existing_ids`: Performs batched existence checks for IDs.
- `_import_libraries`, `_import_versions`, `_import_chunks`: Contain domain-specific insertion logic for each entity type.

This refactoring reduces the complexity of the core `import_jsonl` method while preserving all existing functionality and performance optimizations (such as batched lookups and memory-efficient whitespace checks). Verified with the full test suite.

---
*PR created automatically by Jules for task [13884695679251877491](https://jules.google.com/task/13884695679251877491) started by @n24q02m*