### PR TITLE
[CLEANUP] Inefficient Suboptimal Dictionary Keys Parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2024-05-18 - String uniform validation
 **Learning:** For uniform string validation (where `len(set(text)) == 1`), replacing an O(N) generator check like `all(c in ALLOWED for c in text)` with a simple O(1) index check `text[0] in ALLOWED` significantly improves iteration overhead.
 **Action:** Always prefer array indexing to generator comprehensions when validating a uniformly matching string, and ensure that the stripped result is cached to avoid redundant allocations.
+
+## 2026-05-28 - Caching Schema Metadata
+**Learning:** Checking dynamic schema metadata via `PRAGMA table_info` continuously in database insert loops or frequent update calls limits throughput due to redundant database roundtrips. Since the schema is stable after initialization, caching these results in memory avoids this overhead.
+**Action:** Cache table column names on first access for the lifetime of the database connection to improve performance in high-frequency database operations like `add_chunks`.

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -153,6 +153,7 @@ class DocsDB:
     """SQLite-backed docs storage with FTS5 hybrid search."""
 
     def __init__(self, db_path: Path, embedding_dims: int = 0):
+        self._table_columns: dict[str, set[str]] = {}
         self._db_path = db_path
         if (
             type(embedding_dims) is not int
@@ -193,6 +194,19 @@ class DocsDB:
 
         self._create_tables()
         logger.debug(f"DocsDB initialized at {db_path} (vec={self._vec_enabled})")
+
+    def _get_table_columns(self, table: str) -> set[str]:
+        """Get column names for a table, cached for the lifetime of DocsDB."""
+        if table not in self._table_columns:
+            # PRAGMAs don't support parameters; we use a safe allowlist
+            if table not in ("libraries", "doc_chunks", "versions", "project_context"):
+                raise ValueError(f"Unknown table for column detection: {table}")
+
+            self._table_columns[table] = {
+                r["name"]
+                for r in self._conn.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+        return self._table_columns[table]
 
     def _create_tables(self) -> None:
         self._create_libraries_table()
@@ -455,10 +469,7 @@ class DocsDB:
 
         # Phase 2 columns may be absent on a pre-Alembic legacy DB. Detect
         # presence once per call so we don't crash on older schemas.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
             if package_managers is not None
@@ -585,10 +596,7 @@ class DocsDB:
         Silently no-ops on pre-Alembic legacy databases that lack the
         ``last_indexed_at`` / ``total_versions`` columns.
         """
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         sets: list[str] = []
         params: list = []
         if "last_indexed_at" in existing_cols:
@@ -712,10 +720,7 @@ class DocsDB:
         chunk_ids = [uuid.uuid4().hex[:12] for _ in chunks]
 
         # Detect optional columns once so we can branch on a single INSERT.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
-        }
+        existing_cols = self._get_table_columns("doc_chunks")
         phase2_cols = [
             c
             for c in (


### PR DESCRIPTION
Optimized database performance by caching table column metadata (schema info) instead of repeatedly querying it via PRAGMA table_info during insert and update operations.

This change reduces database roundtrips for frequent operations like `add_chunks` and `upsert_library`. The column names are cached for the lifetime of the `DocsDB` instance. A safe allowlist is used for table names to prevent SQL injection in the PRAGMA call.

---
*PR created automatically by Jules for task [14419650788766041346](https://jules.google.com/task/14419650788766041346) started by @n24q02m*