### PR TITLE
⚡ Bolt: Cache PRAGMA table_info schema results

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2024-05-18 - String uniform validation
 **Learning:** For uniform string validation (where `len(set(text)) == 1`), replacing an O(N) generator check like `all(c in ALLOWED for c in text)` with a simple O(1) index check `text[0] in ALLOWED` significantly improves iteration overhead.
 **Action:** Always prefer array indexing to generator comprehensions when validating a uniformly matching string, and ensure that the stripped result is cached to avoid redundant allocations.
+
+## 2024-05-18 - Caching `PRAGMA table_info` Results
+**Learning:** Frequent database schema inspections using `PRAGMA table_info` inside heavily used database methods (`add_chunks`, `upsert_library`, `mark_library_indexed`) cause noticeable overhead, especially when inserting large amounts of data.
+**Action:** When working with SQLite, cache table schemas after the first query inside the class instance so subsequent operations can reuse the schema information without re-querying the database.

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -201,6 +201,7 @@ class DocsDB:
             )
         self._embedding_dims = embedding_dims
         self._vec_enabled = False
+        self._table_columns: dict[str, set[str]] = {}
 
         db_path.parent.mkdir(parents=True, exist_ok=True)
         # check_same_thread=False allows the connection to be used from
@@ -230,6 +231,17 @@ class DocsDB:
 
         self._create_tables()
         logger.debug(f"DocsDB initialized at {db_path} (vec={self._vec_enabled})")
+
+    def _get_table_columns(self, table: str) -> set[str]:
+        """Cache table columns to avoid redundant PRAGMA queries."""
+        if table not in ("libraries", "versions", "doc_chunks"):
+            raise ValueError(f"Unauthorized table name: {table}")
+        if table not in self._table_columns:
+            self._table_columns[table] = {
+                r["name"]
+                for r in self._conn.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+        return self._table_columns[table]
 
     def _create_tables(self) -> None:
         self._create_libraries_table()
@@ -492,10 +504,7 @@ class DocsDB:
 
         # Phase 2 columns may be absent on a pre-Alembic legacy DB. Detect
         # presence once per call so we don't crash on older schemas.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
             if package_managers is not None
@@ -615,10 +624,7 @@ class DocsDB:
         Silently no-ops on pre-Alembic legacy databases that lack the
         ``last_indexed_at`` / ``total_versions`` columns.
         """
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         sets: list[str] = []
         params: list = []
         if "last_indexed_at" in existing_cols:
@@ -748,10 +754,7 @@ class DocsDB:
         chunk_ids = [uuid.uuid4().hex[:12] for _ in chunks]
 
         # Detect optional columns once so we can branch on a single INSERT.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
-        }
+        existing_cols = self._get_table_columns("doc_chunks")
         phase2_cols = [
             c
             for c in (


### PR DESCRIPTION
💡 What: Caches the results of `PRAGMA table_info` in `DocsDB` to avoid redundant database calls.
🎯 Why: `upsert_library`, `mark_library_indexed` and `add_chunks` query the database's schema for table column existence inside loops or heavily hit methods, which causes unnecessary database overhead.
📊 Impact: Speeds up heavy database batch inserts/updates by avoiding repetitive SQLite hits on the schema metadata.
🔬 Measurement: Verified locally using full suite tests and performance checks. Speeds up data ingestion significantly by replacing DB execution with simple dictionary lookups.

---
*PR created automatically by Jules for task [10371578514826565447](https://jules.google.com/task/10371578514826565447) started by @n24q02m*