### PR TITLE
fix: make Windows console handle Unicode output without cp1252 crash

### DIFF
--- a/scripts/preserve-diacritics.py
+++ b/scripts/preserve-diacritics.py
@@ -21,12 +21,9 @@ import sys
 import unicodedata
 from pathlib import Path
 
-# Force UTF-8 on stderr so Vietnamese / Unicode chars display correctly on
-# Windows (default cp1252 otherwise replaces non-ASCII chars with '?').
-if hasattr(sys.stderr, "buffer"):
-    sys.stderr = io.TextIOWrapper(
-        sys.stderr.buffer, encoding="utf-8", errors="replace", line_buffering=True
-    )
+if sys.platform == "win32":
+    if isinstance(sys.stderr, io.TextIOWrapper):
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 # Unicode char -> candidate ASCII replacements frequently produced by AI rewrites.
 UNICODE_REPLACEMENTS: dict[str, list[str]] = {

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2,9 +2,17 @@
 
 import asyncio
 import functools
+import io
 import json
 import os
 import sys
+
+# Fix Windows console encoding for Unicode output
+if sys.platform == "win32":
+    for _s in (sys.stdin, sys.stdout, sys.stderr):
+        if isinstance(_s, io.TextIOWrapper):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
 from contextlib import asynccontextmanager
 from importlib.resources import files
 from pathlib import Path

--- a/tests/run_benchmark.py
+++ b/tests/run_benchmark.py
@@ -9,6 +9,7 @@ Results are saved incrementally (after each library) to avoid data loss.
 """
 
 import asyncio
+import io
 import json
 import os
 import sys
@@ -18,8 +19,9 @@ from typing import Any
 
 # Fix Windows console encoding for Unicode output
 if sys.platform == "win32":
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    for _s in (sys.stdin, sys.stdout, sys.stderr):
+        if isinstance(_s, io.TextIOWrapper):
+            _s.reconfigure(encoding="utf-8", errors="replace")
 
 # Suppress noisy ResourceWarnings from SearXNG subprocess cleanup
 warnings.filterwarnings("ignore", category=ResourceWarning)

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -1,0 +1,81 @@
+"""Windows console Unicode encoding guard in wet_mcp.server.
+
+Bug: on Windows the default console encoding is cp1252, so emitting
+Vietnamese / non-ASCII text on stdout/stderr raises UnicodeEncodeError and
+crashes the server. Fix: at import time, on win32, reconfigure stdin/stdout/
+stderr to utf-8 (errors="replace").
+
+This test exercises the exact module-level guard against real TextIOWrapper
+streams under both a simulated win32 and a non-win32 platform, so it runs
+identically on every OS and fails if the guard is removed.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+from pathlib import Path
+
+
+def _extract_win32_guard() -> str:
+    """Return the source of the module-level ``if sys.platform == "win32"``
+    guard from wet_mcp/server.py.
+
+    Fails loudly if the guard is missing (mutation sanity: deleting the fix
+    makes this raise, so every test below fails too).
+    """
+    src = (
+        Path(__file__).resolve().parent.parent / "src" / "wet_mcp" / "server.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in tree.body:
+        if isinstance(node, ast.If):
+            cond = node.test
+            if (
+                isinstance(cond, ast.Compare)
+                and isinstance(cond.left, ast.Attribute)
+                and cond.left.attr == "platform"
+                and isinstance(cond.comparators[0], ast.Constant)
+                and cond.comparators[0].value == "win32"
+            ):
+                return ast.get_source_segment(src, node) or ""
+    raise AssertionError("win32 console-encoding guard missing from wet_mcp/server.py")
+
+
+def _make_stream() -> io.TextIOWrapper:
+    """A real TextIOWrapper pinned to a non-utf-8 (cp1252) encoding."""
+    return io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+
+
+def _run_guard(platform: str) -> dict[str, io.TextIOWrapper]:
+    """Execute the real guard with real cp1252 streams under a sim platform."""
+    guard = _extract_win32_guard()
+    streams = {
+        "stdin": _make_stream(),
+        "stdout": _make_stream(),
+        "stderr": _make_stream(),
+    }
+
+    class _FakeSys:
+        pass
+
+    fake_sys = _FakeSys()
+    fake_sys.platform = platform
+    fake_sys.stdin = streams["stdin"]
+    fake_sys.stdout = streams["stdout"]
+    fake_sys.stderr = streams["stderr"]
+    exec(guard, {"sys": fake_sys, "io": io})  # noqa: S102 - trusted project source
+    return streams
+
+
+def test_win32_reconfigures_all_three_streams_to_utf8() -> None:
+    streams = _run_guard("win32")
+    for name, stream in streams.items():
+        assert stream.encoding == "utf-8", name
+        assert stream.errors == "replace", name
+
+
+def test_non_win32_leaves_stream_encoding_untouched() -> None:
+    streams = _run_guard("linux")
+    for name, stream in streams.items():
+        assert stream.encoding == "cp1252", name


### PR DESCRIPTION
## What

Re-lands the source fix from #1148 cleanly on a fresh branch off current `main`, **dropping** the smuggled `uv.lock` / `mcp-core` / `web-core` / `qwen3-embed` / self-version dependency bumps that blocked the original PR.

## Source change

- `src/wet_mcp/server.py` — on `win32`, reconfigure `sys.stdin/stdout/stderr` to `utf-8` (`errors="replace"`) at import, so Vietnamese / non-ASCII output no longer raises `UnicodeEncodeError` under the default cp1252 console.
- `scripts/preserve-diacritics.py` — switch the stderr UTF-8 hardening to `reconfigure` guarded by `win32` (drops the `io.TextIOWrapper` rewrap).
- `tests/run_benchmark.py` — harden the existing reconfigure to loop over all three streams with a `hasattr` guard.

## Test

- `tests/test_console_encoding.py` — exercises the real module-level guard against fake streams under simulated `win32` and non-`win32` platforms (OS-agnostic). Mutation-checked: fails when the `server.py` guard is removed.

## Diff scope

Exactly source `.py` + test `.py`. No `uv.lock` / `pyproject.toml` dependency-bump hunks.

Supersedes #1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)