### PR TITLE
[TEST] Add unit test for _find_available_port

### DIFF
--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -4,11 +4,11 @@ Tests the wet-mcp wrapper layer that bridges settings to web-core's API.
 Internal SearXNG process management is tested in web-core's test suite.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from wet_mcp.searxng_runner import ensure_searxng, stop_searxng
+from wet_mcp.searxng_runner import _find_available_port, ensure_searxng, stop_searxng
 
 
 @pytest.fixture
@@ -106,3 +106,57 @@ def test_patched_installer_skips_patches_on_failure():
         assert result is False
         mock_version.assert_not_called()
         mock_windows.assert_not_called()
+
+
+def test_find_available_port_success():
+    """Verify _find_available_port returns a port when bind succeeds."""
+    with (
+        patch("socket.socket") as mock_socket,
+        patch("random.shuffle"),
+    ):
+        # mock_socket() returns a context manager that returns mock_s
+        mock_s = MagicMock()
+        mock_socket.return_value.__enter__.return_value = mock_s
+
+        # Success on first try (offset 0 if shuffle is mocked to do nothing)
+        port = _find_available_port(8080, max_tries=1)
+
+        assert port == 8080
+        mock_s.bind.assert_called_once_with(("127.0.0.1", 8080))
+
+
+def test_find_available_port_retry():
+    """Verify _find_available_port retries when bind fails."""
+    with (
+        patch("socket.socket") as mock_socket,
+        patch("random.shuffle"),
+    ):
+        mock_s = MagicMock()
+        mock_socket.return_value.__enter__.return_value = mock_s
+
+        # Fail first try, succeed second
+        mock_s.bind.side_effect = [OSError("Port in use"), None]
+
+        # Use max_tries=2 and ensure deterministic order by mocking shuffle
+        # Default offsets are [0, 1]
+        port = _find_available_port(8080, max_tries=2)
+
+        assert port in [8080, 8081]
+        assert mock_s.bind.call_count == 2
+
+
+def test_find_available_port_failure():
+    """Verify _find_available_port raises RuntimeError when no ports available."""
+    with (
+        patch("socket.socket") as mock_socket,
+        patch("random.shuffle"),
+    ):
+        mock_s = MagicMock()
+        mock_socket.return_value.__enter__.return_value = mock_s
+
+        mock_s.bind.side_effect = OSError("Port in use")
+
+        with pytest.raises(RuntimeError, match="No available port found"):
+            _find_available_port(8080, max_tries=5)
+
+        assert mock_s.bind.call_count == 5

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR adds unit tests for the `_find_available_port` function in `src/wet_mcp/searxng_runner.py`.

The following tests were added to `tests/test_searxng_runner.py`:
- `test_find_available_port_success`: Ensures the function returns the starting port when it's available.
- `test_find_available_port_retry`: Verifies that the function retries other ports if the starting port is in use.
- `test_find_available_port_failure`: Confirms that a `RuntimeError` is raised if no ports are available within the specified `max_tries`.

Tests use mocking for `socket.socket` to simulate port availability and `random.shuffle` to ensure deterministic behavior during testing.

All tests passed successfully.

---
*PR created automatically by Jules for task [4804594388150480570](https://jules.google.com/task/4804594388150480570) started by @n24q02m*