### PR TITLE
[CLEANUP] Inline import: importlib.util

### DIFF
--- a/src/wet_mcp/setup.py
+++ b/src/wet_mcp/setup.py
@@ -8,7 +8,9 @@ This module handles automatic first-run setup:
 Setup runs automatically on first server start.
 """
 
+import importlib.util
 import platform
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -27,8 +29,6 @@ _SEARXNG_INSTALL_URL = (
 def _find_searx_package_dir() -> Path | None:
     """Find SearXNG package directory via importlib."""
     try:
-        import importlib.util
-
         spec = importlib.util.find_spec("searx")
         if spec and spec.submodule_search_locations:
             return Path(spec.submodule_search_locations[0])
@@ -123,8 +123,6 @@ def needs_setup() -> bool:
 
 def _get_pip_command() -> list[str]:
     """Get cross-platform pip install command."""
-    import shutil
-
     uv_path = shutil.which("uv")
     if uv_path:
         return [uv_path, "pip", "install", "--python", sys.executable]
@@ -219,9 +217,6 @@ def _setup_crawl4ai() -> bool:
     """
     logger.info("Running crawl4ai setup (browsers + system deps)...")
     try:
-        import subprocess
-        import sys
-
         # 1. Setup home directory and run migration safely in a subprocess
         subprocess.run(
             [

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR moves several inline imports to the top level in `src/wet_mcp/setup.py`.

Changes:
- Moved `import importlib.util` from `_find_searx_package_dir` to the top level.
- Moved `import shutil` from `_get_pip_command` to the top level.
- Removed redundant `import subprocess` and `import sys` from `_setup_crawl4ai`.
- Cleaned up indentation and applied `ruff` formatting/linting.

Rationale:
Standard library imports should generally be at the top level to follow PEP 8 and ensure consistency throughout the codebase.

---
*PR created automatically by Jules for task [14753496068070204664](https://jules.google.com/task/14753496068070204664) started by @n24q02m*