### PR TITLE
[FIX] Complete path traversal security test

### DIFF
--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,7 +15,8 @@ async def test_download_media_path_traversal(tmp_path):
     mock_response = MagicMock()
     mock_response.content = b"fake content"
     mock_response.raise_for_status = MagicMock()
-    mock_response.is_redirect = False  # Important for manual redirect loop
+    mock_response.is_redirect = False
+    mock_response.headers = {"content-type": "image/png"}
 
     # Mock httpx client context manager
     mock_client = AsyncMock()
@@ -21,25 +24,44 @@ async def test_download_media_path_traversal(tmp_path):
     mock_client.__aenter__.return_value = mock_client
     mock_client.__aexit__.return_value = None
 
-    # We need to simulate is_safe_url passing for these URLs, or mock it.
-    # Since we are testing path traversal, we assume the URL is "safe" network-wise but malicious filename-wise.
-    # But wait, is_safe_url checks scheme and IP.
-    # "http://example.com/.." is safe network-wise (resolves to example.com IP).
-
     with patch("wet_mcp.sources.crawler.is_safe_url", return_value=True):
         with patch(
             "wet_mcp.sources.crawler.httpx.AsyncClient", return_value=mock_client
         ):
             # 1. Traversal attempt with '..' as filename
-            # This simulates a URL where split('/')[-1] is '..'
             url1 = "http://example.com/.."
-            res1 = await download_media([url1], str(tmp_path))
+            res1_raw = await download_media([url1], str(tmp_path))
+            res1 = json.loads(res1_raw)
+            assert any("Security Alert" in r.get("error", "") for r in res1)
 
-            # Should fail with "Security Alert" because '..' resolves to parent dir
-            assert "Security Alert" in res1
+            # 2. Traversal attempt with URL-encoded '..'
+            url2 = "http://example.com/%2e%2e"
+            res2_raw = await download_media([url2], str(tmp_path))
+            res2 = json.loads(res2_raw)
+            assert any("Security Alert" in r.get("error", "") for r in res2)
 
-            # Verify no files were written in parent
-            pass
+            # 3. Attempt with encoded multiple traversals and absolute path
+            # This should be neutralized by .name and confirmed by is_relative_to
+            url3 = "http://example.com/%2e%2e%2f%2e%2e%2fetc%2fpasswd"
+            res3_raw = await download_media([url3], str(tmp_path))
+            res3 = json.loads(res3_raw)
+            p3 = Path(res3[0]["path"])
+            assert p3.is_relative_to(tmp_path.resolve())
+            assert p3.name == "passwd.png"
+
+            # 4. Attempt with null byte - should be rejected or error
+            url4 = "http://example.com/test.png%00.php"
+            res4_raw = await download_media([url4], str(tmp_path))
+            res4 = json.loads(res4_raw)
+            assert "error" in res4[0]
+            assert "null character" in res4[0]["error"].lower()
+
+            # 5. Very long filename (DOS attempt)
+            url5 = "http://example.com/" + ("a" * 300)
+            res5_raw = await download_media([url5], str(tmp_path))
+            res5 = json.loads(res5_raw)
+            assert "error" in res5[0]
+            assert "too long" in res5[0]["error"].lower()
 
 
 @pytest.mark.asyncio
@@ -47,7 +69,8 @@ async def test_download_media_safe(tmp_path):
     mock_response = MagicMock()
     mock_response.content = b"safe content"
     mock_response.raise_for_status = MagicMock()
-    mock_response.is_redirect = False  # Important for manual redirect loop
+    mock_response.is_redirect = False
+    mock_response.headers = {"content-type": "image/png"}
 
     mock_client = AsyncMock()
     mock_client.get.return_value = mock_response

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR completes the path traversal security test in tests/test_security_path_traversal.py.

Key changes:
- Added test cases for various path traversal payloads, including .., URL-encoded %2e%2e, and encoded absolute paths.
- Added assertions to verify that "Security Alert" is returned in the result JSON when a traversal is detected.
- Verified that the current implementation in src/wet_mcp/sources/crawler.py successfully neutralizes or rejects these attempts.
- Added edge case tests for null bytes and overly long filenames.

The tests ensure that the media download functionality is secure against file system escape vulnerabilities.

---
*PR created automatically by Jules for task [12688213617090574092](https://jules.google.com/task/12688213617090574092) started by @n24q02m*