### PR TITLE
[TEST] Missing edge case test for export_jsonl with empty database

### DIFF
--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -706,3 +706,17 @@ class TestMarkLibraryIndexed:
             # If it didn't return early, there would be a second call with UPDATE
             assert mock_conn.execute.call_count == 1
             assert "PRAGMA table_info" in mock_conn.execute.call_args[0][0]
+
+# ---------------------------------------------------------------------------
+# export_jsonl with empty database (edge case)
+# ---------------------------------------------------------------------------
+
+
+class TestExportJsonlEmpty:
+    def test_export_jsonl_empty_db(self, tmp_path):
+        """export_jsonl returns an empty string for a clean database."""
+        db = DocsDB(tmp_path / "empty.db", embedding_dims=0)
+        try:
+            assert db.export_jsonl() == ""
+        finally:
+            db.close()


### PR DESCRIPTION
This PR adds an edge case test for the `export_jsonl` method in `src/wet_mcp/db.py`.
It ensures that calling `export_jsonl()` on a clean/empty database returns an empty JSONL string.

Changes:
- Added `TestExportJsonlEmpty` class to `tests/test_db_coverage.py`.
- Verified the test passes and does not introduce regressions.

---
*PR created automatically by Jules for task [11414092039021773933](https://jules.google.com/task/11414092039021773933) started by @n24q02m*