### PR TITLE
[TEST] Add unit test for setup_api_keys configuration logic

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,39 @@ def test_setup_api_keys_whitespace():
         assert os.environ["OTHER"] == "key2"
 
 
+def test_setup_api_keys_aliases():
+    """Test that GOOGLE_API_KEY is aliased to GEMINI_API_KEY."""
+    settings = Settings(api_keys=SecretStr("GOOGLE_API_KEY:google-key"))
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        keys = settings.setup_api_keys()
+        assert os.environ["GOOGLE_API_KEY"] == "google-key"
+        assert os.environ["GEMINI_API_KEY"] == "google-key"
+        assert keys["GOOGLE_API_KEY"] == ["google-key"]
+
+
+def test_setup_api_keys_alias_no_overwrite():
+    """Test that alias is not overwritten if already in environment."""
+    settings = Settings(api_keys=SecretStr("GOOGLE_API_KEY:new-key"))
+
+    with mock.patch.dict(os.environ, {"GEMINI_API_KEY": "existing-key"}, clear=True):
+        settings.setup_api_keys()
+        assert os.environ["GOOGLE_API_KEY"] == "new-key"
+        assert os.environ["GEMINI_API_KEY"] == "existing-key"
+
+
+def test_setup_api_keys_complex_whitespace():
+    """Test complex whitespace and empty parts."""
+    settings = Settings(api_keys=SecretStr("  KEY1 : val1 , , KEY2:val2  , KEY3:  "))
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        keys = settings.setup_api_keys()
+        assert keys == {"KEY1": ["val1"], "KEY2": ["val2"]}
+        assert os.environ["KEY1"] == "val1"
+        assert os.environ["KEY2"] == "val2"
+        assert "KEY3" not in os.environ
+
+
 # -----------------------------------------------------------------------
 # Embedding backend resolution
 # -----------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `setup_api_keys` logic in `src/wet_mcp/config.py`. The added tests cover API key aliasing (specifically `GOOGLE_API_KEY` to `GEMINI_API_KEY`), protection against overwriting existing environment variables, and robust parsing of whitespace-heavy or malformed `API_KEYS` strings. These tests ensure the configuration logic behaves correctly across various input scenarios.

---
*PR created automatically by Jules for task [9435684769962810352](https://jules.google.com/task/9435684769962810352) started by @n24q02m*