### PR TITLE
[PERF] Blocking File Read in Async Context

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1462,7 +1462,7 @@ async def help(tool_name: str = "search") -> str:
 
     try:
         doc_file = files("wet_mcp.docs").joinpath(f"{tool_name}.md")
-        return doc_file.read_text()
+        return await asyncio.to_thread(doc_file.read_text)
     except FileNotFoundError:
         return f"Error: No documentation found for tool '{tool_name}'"
     except Exception as e:

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR addresses a performance issue where documentation files were being read synchronously within the asynchronous `help` tool handler. By wrapping the `read_text()` call in `asyncio.to_thread()`, we ensure that these file operations do not block the event loop, maintaining server responsiveness.

---
*PR created automatically by Jules for task [10570843390538861221](https://jules.google.com/task/10570843390538861221) started by @n24q02m*