### PR TITLE
[FIX] Excessively long line in server.py

### DIFF
--- a/long_line_fix.patch
+++ b/long_line_fix.patch
@@ -1,0 +1,17 @@
+diff --git a/src/wet_mcp/server.py b/src/wet_mcp/server.py
+index 20ff7ec..813c93a 100644
+--- a/src/wet_mcp/server.py
++++ b/src/wet_mcp/server.py
+@@ -2373,7 +2373,11 @@ async def _do_docs_search(
+     return json.dumps(
+         {
+             "status": "indexing_in_progress",
+-            "message": f"Library '{library}' is currently being downloaded and indexed in the background (this may take 3-5 minutes). In the meantime, here are temporary web search results.",
++            "message": (
++                f"Library '{library}' is currently being downloaded and indexed in the "
++                "background (this may take 3-5 minutes). In the meantime, here are "
++                "temporary web search results."
++            ),
+             "temporary_results": fallback_data.get("results", []),
+             "library": library,
+             "docs_url": docs_url,

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2373,7 +2373,11 @@ async def _do_docs_search(
     return json.dumps(
         {
             "status": "indexing_in_progress",
-            "message": f"Library '{library}' is currently being downloaded and indexed in the background (this may take 3-5 minutes). In the meantime, here are temporary web search results.",
+            "message": (
+                f"Library '{library}' is currently being downloaded and indexed in the "
+                "background (this may take 3-5 minutes). In the meantime, here are "
+                "temporary web search results."
+            ),
             "temporary_results": fallback_data.get("results", []),
             "library": library,
             "docs_url": docs_url,


### PR DESCRIPTION
This PR addresses an excessively long line in `src/wet_mcp/server.py` at line 2376. 

The line contained a long f-string message returned in a JSON response. While the project's Ruff configuration ignores E501, breaking such lines improves readability. 

Changes:
- Split the long f-string into three parts using implicit concatenation within parentheses.
- Verified that the resulting JSON output remains identical in content.
- Ran `ruff check` and `ruff format` to ensure compliance.
- Ran `tests/test_server_comprehensive.py`, `tests/test_phase2_dispatch.py`, and `tests/test_server.py` to ensure no regressions.

---
*PR created automatically by Jules for task [3918142508687430093](https://jules.google.com/task/3918142508687430093) started by @n24q02m*