### PR TITLE
[SECURITY] Dynamic SQL Execution via String Formatting (Versions Migration)

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -285,20 +285,35 @@ class DocsDB:
         # Idempotent column adds for legacy DBs that pre-date Alembic.
         # Each ALTER is wrapped in a try/except so re-running on a fresh
         # head-shape table does not raise.
-        for col_ddl in (
-            "discovery_version INTEGER DEFAULT 0",
-            "canonical_name TEXT",
-            "homepage TEXT",
-            "github_url TEXT",
-            "package_managers TEXT",
-            "tier INTEGER NOT NULL DEFAULT 2",
-            "last_indexed_at REAL",
-            "total_versions INTEGER NOT NULL DEFAULT 0",
-        ):
+        migrations = [
+            (
+                "discovery_version",
+                "ALTER TABLE libraries ADD COLUMN discovery_version INTEGER DEFAULT 0",
+            ),
+            ("canonical_name", "ALTER TABLE libraries ADD COLUMN canonical_name TEXT"),
+            ("homepage", "ALTER TABLE libraries ADD COLUMN homepage TEXT"),
+            ("github_url", "ALTER TABLE libraries ADD COLUMN github_url TEXT"),
+            (
+                "package_managers",
+                "ALTER TABLE libraries ADD COLUMN package_managers TEXT",
+            ),
+            (
+                "tier",
+                "ALTER TABLE libraries ADD COLUMN tier INTEGER NOT NULL DEFAULT 2",
+            ),
+            (
+                "last_indexed_at",
+                "ALTER TABLE libraries ADD COLUMN last_indexed_at REAL",
+            ),
+            (
+                "total_versions",
+                "ALTER TABLE libraries ADD COLUMN total_versions INTEGER NOT NULL DEFAULT 0",
+            ),
+        ]
+        for col_name, sql in migrations:
             try:
-                self._conn.execute(f"ALTER TABLE libraries ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
-                col_name = col_ddl.split()[0]
                 logger.debug(f"Migrated libraries table: added {col_name}")
             except sqlite3.OperationalError:
                 pass  # Column already exists
@@ -322,9 +337,12 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in ("release_date REAL", "source_url TEXT"):
+        for sql in (
+            "ALTER TABLE versions ADD COLUMN release_date REAL",
+            "ALTER TABLE versions ADD COLUMN source_url TEXT",
+        ):
             try:
-                self._conn.execute(f"ALTER TABLE versions ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass
@@ -351,14 +369,14 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in (
-            "section TEXT",
-            "topic TEXT",
-            "content_hash TEXT",
-            "token_count INTEGER",
+        for sql in (
+            "ALTER TABLE doc_chunks ADD COLUMN section TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN topic TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN content_hash TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN token_count INTEGER",
         ):
             try:
-                self._conn.execute(f"ALTER TABLE doc_chunks ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass


### PR DESCRIPTION
Refactored database migration scripts in src/wet_mcp/db.py to use static SQL strings instead of dynamic formatting. This covers `_create_libraries_table`, `_create_versions_table`, and `_create_doc_chunks_table`. Functional logic remains identical, but safety is improved by avoiding string concatenation for SQL execution. verified with `tests/test_db.py`, `tests/test_db_coverage.py`, and `tests/test_security_sql.py`.

---
*PR created automatically by Jules for task [5937111832220002780](https://jules.google.com/task/5937111832220002780) started by @n24q02m*