### PR TITLE
[CLEANUP] Missing check in subprocess.run

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -179,11 +179,11 @@ def _detect_gh_token() -> str | None:
             capture_output=True,
             text=True,
             timeout=5,
+            check=True,
         )
-        if result.returncode == 0:
-            token = result.stdout.strip()
-            if token:
-                return token
+        token = result.stdout.strip()
+        if token:
+            return token
     except Exception:
         pass
     return None

--- a/src/wet_mcp/setup.py
+++ b/src/wet_mcp/setup.py
@@ -153,7 +153,7 @@ def _install_searxng() -> bool:
     try:
         # Pre-install build dependencies
         pip_cmd = _get_pip_command()
-        deps_result = subprocess.run(
+        subprocess.run(
             [
                 *pip_cmd,
                 "--quiet",
@@ -167,13 +167,11 @@ def _install_searxng() -> bool:
             encoding="utf-8",
             text=True,
             timeout=120,
+            check=True,
         )
-        if deps_result.returncode != 0:
-            logger.error(f"Build deps install failed: {deps_result.stderr[:300]}")
-            return False
 
         # Install SearXNG with --no-build-isolation
-        result = subprocess.run(
+        subprocess.run(
             [
                 *pip_cmd,
                 "--quiet",
@@ -185,15 +183,15 @@ def _install_searxng() -> bool:
             encoding="utf-8",
             text=True,
             timeout=300,
+            check=True,
         )
-        if result.returncode == 0:
-            logger.info("SearXNG installed successfully")
-            patch_searxng_version()
-            patch_searxng_windows()
-            return True
-        else:
-            logger.error(f"SearXNG install failed: {result.stderr[:300]}")
-            return False
+        logger.info("SearXNG installed successfully")
+        patch_searxng_version()
+        patch_searxng_windows()
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error(f"SearXNG install failed (exit {e.returncode}): {e.stderr[:300]}")
+        return False
     except subprocess.TimeoutExpired:
         logger.error("SearXNG installation timed out")
         return False
@@ -230,16 +228,18 @@ def _setup_crawl4ai() -> bool:
                 "from crawl4ai.install import setup_home_directory, run_migration; setup_home_directory(); run_migration()",
             ],
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            check=True,
         )
 
         # 2. Run playwright install safely
         subprocess.run(
             [sys.executable, "-m", "playwright", "install", "chromium", "--with-deps"],
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            check=True,
         )
 
         logger.info("crawl4ai setup completed successfully")

--- a/tests/test_setup_comprehensive.py
+++ b/tests/test_setup_comprehensive.py
@@ -261,7 +261,7 @@ def test_install_searxng_success(
 @patch("wet_mcp.setup._get_pip_command", return_value=["pip", "install"])
 @patch("subprocess.run")
 def test_install_searxng_deps_fail(mock_run, mock_get_pip, _mock_find):
-    mock_run.return_value = MagicMock(returncode=1, stderr="deps failed")
+    mock_run.side_effect = subprocess.CalledProcessError(1, ["cmd"], stderr="deps failed")
 
     assert _install_searxng() is False
     assert mock_run.call_count == 1
@@ -274,7 +274,7 @@ def test_install_searxng_main_fail(mock_run, mock_get_pip, _mock_find):
     # First call (deps) succeeds, second call (main) fails
     mock_run.side_effect = [
         MagicMock(returncode=0),
-        MagicMock(returncode=1, stderr="main failed"),
+        subprocess.CalledProcessError(1, ["cmd"], stderr="main failed"),
     ]
 
     assert _install_searxng() is False

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Updated `src/wet_mcp/setup.py` and `src/wet_mcp/server.py` to use `check=True` in `subprocess.run` calls, following the project's convention for robust error handling.

Changes:
- In `src/wet_mcp/setup.py`:
  - Updated `_install_searxng` to use `check=True` and catch `subprocess.CalledProcessError`.
  - Updated `_setup_crawl4ai` to use `check=True`, `capture_output=True`, and `text=True` for better error reporting.
- In `src/wet_mcp/server.py`:
  - Updated `_detect_gh_token` to use `check=True` for consistency.
- Updated `tests/test_setup_comprehensive.py` to correctly mock `subprocess.CalledProcessError` for the new `check=True` usage.

Ensures that failures in external tool execution (pip, playwright, gh CLI) are properly caught and logged.

---
*PR created automatically by Jules for task [1576849631350649771](https://jules.google.com/task/1576849631350649771) started by @n24q02m*