### PR TITLE
[FIX] Redundant DB table info fetch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,18 +1,3 @@
-## 2023-10-27 - Fast Whitespace Evaluation
-**Learning:** Checking `if not ln or ln.isspace():` is more performant than `if ln.strip():` in hot loops because `str.strip()` forces memory allocation for a new string slice, even when simply validating whitespace.
-**Action:** Avoid `str.strip()` as a boolean truthiness check in line-by-line parsing loops; use the allocation-free `.isspace()` check instead.
-
-## 2023-10-27 - Prefix Matching Performance
-**Learning:** Using `line.lstrip().startswith('...')` is significantly faster (~1.75x) than `_RE.match(line.strip())` because it avoids regex compilation, execution overhead, and allocates less memory compared to full `.strip()` when evaluating prefix patterns.
-**Action:** Prefer `lstrip().startswith()` for simple prefix checks (e.g., matching markdown code fences or headers) over regex matches on stripped lines.
-## 2023-11-20 - Redundant JSON parsing
-**Learning:** Bypassing redundant `json.loads` followed by `json.dumps` in MCP tool handlers significantly reduces CPU overhead when the source functions already return pretty-printed JSON.
-**Action:** Ensure that JSON parsing is only done when data modification is necessary. If a function returns an already correctly formatted JSON string, return it directly to the caller.
-
-## 2023-10-27 - str.split() redundant strip operations
-**Learning:** `str.split()` without arguments automatically splits by arbitrary whitespace and discards empty strings. Using list comprehensions with `strip()` and truthiness checks (e.g., `[w.strip() for w in text.split() if w.strip()]`) creates unnecessary intermediate allocations.
-**Action:** Use `text.split()` directly when arbitrary whitespace splitting is desired without empty elements.
-
-## 2024-05-18 - String uniform validation
-**Learning:** For uniform string validation (where `len(set(text)) == 1`), replacing an O(N) generator check like `all(c in ALLOWED for c in text)` with a simple O(1) index check `text[0] in ALLOWED` significantly improves iteration overhead.
-**Action:** Always prefer array indexing to generator comprehensions when validating a uniformly matching string, and ensure that the stripped result is cached to avoid redundant allocations.
+## 2025-05-15 - Redundant DB table info fetch
+**Learning:** Repeatedly querying `PRAGMA table_info` for schema detection in SQLite can be optimized by caching column names at the instance level.
+**Action:** Use a private helper method like `_get_table_columns(table_name)` with an internal `_table_columns` cache to avoid redundant schema lookups in methods called frequently during indexing or updates.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,22 @@
+## 2023-10-27 - Fast Whitespace Evaluation
+**Learning:** Checking `if not ln or ln.isspace():` is more performant than `if ln.strip():` in hot loops because `str.strip()` forces memory allocation for a new string slice, even when simply validating whitespace.
+**Action:** Avoid `str.strip()` as a boolean truthiness check in line-by-line parsing loops; use the allocation-free `.isspace()` check instead.
+
+## 2023-10-27 - Prefix Matching Performance
+**Learning:** Using `line.lstrip().startswith('...')` is significantly faster (~1.75x) than `_RE.match(line.strip())` because it avoids regex compilation, execution overhead, and allocates less memory compared to full `.strip()` when evaluating prefix patterns.
+**Action:** Prefer `lstrip().startswith()` for simple prefix checks (e.g., matching markdown code fences or headers) over regex matches on stripped lines.
+## 2023-11-20 - Redundant JSON parsing
+**Learning:** Bypassing redundant `json.loads` followed by `json.dumps` in MCP tool handlers significantly reduces CPU overhead when the source functions already return pretty-printed JSON.
+**Action:** Ensure that JSON parsing is only done when data modification is necessary. If a function returns an already correctly formatted JSON string, return it directly to the caller.
+
+## 2023-10-27 - str.split() redundant strip operations
+**Learning:** `str.split()` without arguments automatically splits by arbitrary whitespace and discards empty strings. Using list comprehensions with `strip()` and truthiness checks (e.g., `[w.strip() for w in text.split() if w.strip()]`) creates unnecessary intermediate allocations.
+**Action:** Use `text.split()` directly when arbitrary whitespace splitting is desired without empty elements.
+
+## 2024-05-18 - String uniform validation
+**Learning:** For uniform string validation (where `len(set(text)) == 1`), replacing an O(N) generator check like `all(c in ALLOWED for c in text)` with a simple O(1) index check `text[0] in ALLOWED` significantly improves iteration overhead.
+**Action:** Always prefer array indexing to generator comprehensions when validating a uniformly matching string, and ensure that the stripped result is cached to avoid redundant allocations.
+
 ## 2025-05-15 - Redundant DB table info fetch
 **Learning:** Repeatedly querying `PRAGMA table_info` for schema detection in SQLite can be optimized by caching column names at the instance level.
 **Action:** Use a private helper method like `_get_table_columns(table_name)` with an internal `_table_columns` cache to avoid redundant schema lookups in methods called frequently during indexing or updates.

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -190,6 +190,7 @@ class DocsDB:
     """SQLite-backed docs storage with FTS5 hybrid search."""
 
     def __init__(self, db_path: Path, embedding_dims: int = 0):
+        self._table_columns: dict[str, set[str]] = {}
         self._db_path = db_path
         if (
             type(embedding_dims) is not int
@@ -230,6 +231,18 @@ class DocsDB:
 
         self._create_tables()
         logger.debug(f"DocsDB initialized at {db_path} (vec={self._vec_enabled})")
+
+    def _get_table_columns(self, table: str) -> set[str]:
+        """Get column names for a table, with caching."""
+        if table not in {"libraries", "doc_chunks"}:
+            raise ValueError(f"Invalid table for column lookup: {table}")
+        if table not in self._table_columns:
+            cols = {
+                r["name"]
+                for r in self._conn.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            self._table_columns[table] = cols
+        return self._table_columns[table]
 
     def _create_tables(self) -> None:
         self._create_libraries_table()
@@ -492,10 +505,7 @@ class DocsDB:
 
         # Phase 2 columns may be absent on a pre-Alembic legacy DB. Detect
         # presence once per call so we don't crash on older schemas.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
             if package_managers is not None
@@ -615,10 +625,7 @@ class DocsDB:
         Silently no-ops on pre-Alembic legacy databases that lack the
         ``last_indexed_at`` / ``total_versions`` columns.
         """
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         sets: list[str] = []
         params: list = []
         if "last_indexed_at" in existing_cols:
@@ -748,10 +755,7 @@ class DocsDB:
         chunk_ids = [uuid.uuid4().hex[:12] for _ in chunks]
 
         # Detect optional columns once so we can branch on a single INSERT.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
-        }
+        existing_cols = self._get_table_columns("doc_chunks")
         phase2_cols = [
             c
             for c in (

--- a/tests/test_db_cache.py
+++ b/tests/test_db_cache.py
@@ -1,7 +1,9 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+
 from wet_mcp.db import DocsDB
+
 
 def test_get_table_columns_caching(tmp_path):
     db_path = tmp_path / "test.db"
@@ -28,10 +30,12 @@ def test_get_table_columns_caching(tmp_path):
         # call_count should still be 1 if cached
         assert mock_conn.execute.call_count == 1
 
+
 def test_get_table_columns_invalid_table(tmp_path):
     db = DocsDB(tmp_path / "test.db")
     with pytest.raises(ValueError, match="Invalid table for column lookup"):
         db._get_table_columns("non_existent_table")
+
 
 def test_get_table_columns_doc_chunks(tmp_path):
     db = DocsDB(tmp_path / "test.db")

--- a/tests/test_db_cache.py
+++ b/tests/test_db_cache.py
@@ -1,0 +1,40 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from wet_mcp.db import DocsDB
+
+def test_get_table_columns_caching(tmp_path):
+    db_path = tmp_path / "test.db"
+    db = DocsDB(db_path)
+
+    # We can't mock sqlite3.Connection.execute directly because it's read-only.
+    # Instead, we mock _get_table_columns if we want to test its usage,
+    # but here we want to test that _get_table_columns itself caches.
+
+    # Let's patch the connection object entirely or use a simpler approach.
+    with patch.object(db, "_conn") as mock_conn:
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [{"name": "id"}, {"name": "name"}]
+        mock_conn.execute.return_value = mock_cursor
+
+        # First call
+        cols1 = db._get_table_columns("libraries")
+        assert "id" in cols1
+        assert mock_conn.execute.call_count == 1
+
+        # Second call
+        cols2 = db._get_table_columns("libraries")
+        assert cols1 == cols2
+        # call_count should still be 1 if cached
+        assert mock_conn.execute.call_count == 1
+
+def test_get_table_columns_invalid_table(tmp_path):
+    db = DocsDB(tmp_path / "test.db")
+    with pytest.raises(ValueError, match="Invalid table for column lookup"):
+        db._get_table_columns("non_existent_table")
+
+def test_get_table_columns_doc_chunks(tmp_path):
+    db = DocsDB(tmp_path / "test.db")
+    cols = db._get_table_columns("doc_chunks")
+    assert "id" in cols
+    assert "content" in cols

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR addresses the issue of redundant database schema queries in `DocsDB`. 

Key changes:
- Initialized `self._table_columns` cache in `DocsDB.__init__`.
- Implemented `_get_table_columns(table)` private helper to fetch and cache column names using `PRAGMA table_info`, including an allowlist for table names to ensure safety.
- Updated `upsert_library`, `mark_library_indexed`, and `add_chunks` to utilize this cache instead of querying the schema on every call.
- Added unit tests in `tests/test_db_cache.py` to verify that the schema is queried only once per table and then retrieved from the cache.
- Verified that existing tests in `tests/test_db_coverage.py` continue to pass.
- Ensured code formatting and linting standards are met.

---
*PR created automatically by Jules for task [476963273659241768](https://jules.google.com/task/476963273659241768) started by @n24q02m*