### PR TITLE
[PERF] Synchronous File Read in Async Function

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1462,7 +1462,7 @@ async def help(tool_name: str = "search") -> str:
 
     try:
         doc_file = files("wet_mcp.docs").joinpath(f"{tool_name}.md")
-        return doc_file.read_text()
+        return await asyncio.to_thread(doc_file.read_text)
     except FileNotFoundError:
         return f"Error: No documentation found for tool '{tool_name}'"
     except Exception as e:

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Wrapped the synchronous `doc_file.read_text()` call in `asyncio.to_thread` within the `help` function in `src/wet_mcp/server.py` to prevent blocking the async event loop. Verified with existing tests and manual check.

---
*PR created automatically by Jules for task [8017426963904985570](https://jules.google.com/task/8017426963904985570) started by @n24q02m*