### PR TITLE
[TEST] Untested public function get_token_path_for_sub

### DIFF
--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -265,3 +265,12 @@ def test_load_token_for_sub_oserror(token_dir):
     """load_token_for_sub handles OSError during read."""
     with patch.object(Path, "exists", side_effect=OSError("disk error")):
         assert load_token_for_sub("user1", "drive") is None
+
+
+def test_get_token_path_for_sub_simple_assertion(token_dir, tmp_path):
+    """Simple assertion matching the output path for get_token_path_for_sub."""
+    sub = "test-user"
+    provider = "google"
+    expected = tmp_path / "subs" / sub / "tokens" / f"{provider}.json"
+    result = get_token_path_for_sub(sub, provider)
+    assert result == expected


### PR DESCRIPTION
The public function `get_token_path_for_sub` in `src/wet_mcp/token_store.py` was identified as untested. While it was partially covered by existing tests, this PR adds a direct, explicit unit test `test_get_token_path_for_sub_simple_assertion` in `tests/test_token_store.py`. This test performs a simple assertion matching the output path structure, ensuring correctness and absolute coverage of the function as requested. Verified with 100% line coverage for the target function on Linux.

---
*PR created automatically by Jules for task [1096212817708792884](https://jules.google.com/task/1096212817708792884) started by @n24q02m*