### PR TITLE
[PERF] Sequential async API calls instead of gather

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -355,13 +355,13 @@ class CloudEmbeddingBackend:
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
-            batch_num = i // self.MAX_BATCH_SIZE + 1
-            logger.debug(
-                f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
-            )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(self._embed_batch_inner(batch, dimensions))
+
+        batch_results = await asyncio.gather(*tasks)
+        for batch_result in batch_results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings

--- a/tests/test_embedder_perf.py
+++ b/tests/test_embedder_perf.py
@@ -1,0 +1,42 @@
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from wet_mcp.embedder import CloudEmbeddingBackend
+
+
+@pytest.mark.asyncio
+async def test_embed_texts_parallel_execution():
+    """Verify that multiple batches are executed in parallel."""
+    backend = CloudEmbeddingBackend("text-embedding-3-small")
+    # Set a small batch size to trigger multiple batches easily
+    backend.MAX_BATCH_SIZE = 2
+
+    texts = ["text1", "text2", "text3", "text4"]
+    # 4 texts / 2 per batch = 2 batches
+
+    delay = 0.5
+
+    async def mocked_embed_batch(batch, dimensions=None):
+        await asyncio.sleep(delay)
+        return [[0.1] for _ in batch]
+
+    with patch.object(
+        backend, "_embed_batch_inner", side_effect=mocked_embed_batch
+    ) as mock_batch:
+        start_time = time.perf_counter()
+        results = await backend.embed_texts(texts)
+        end_time = time.perf_counter()
+
+        duration = end_time - start_time
+
+        # If sequential, duration would be >= 1.0s (2 * 0.5s)
+        # If parallel, duration would be >= 0.5s but < 1.0s
+        assert len(results) == 4
+        assert mock_batch.call_count == 2
+        assert (
+            duration < delay * 1.5
+        )  # Allow some overhead but should be much less than 2 * delay
+        assert duration >= delay

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Parallelize embedding batch calls in `CloudEmbeddingBackend.embed_texts` using `asyncio.gather`. This replaces sequential execution of `_embed_batch_inner`, significantly improving throughput when processing multiple text batches. Added a performance verification test to confirm concurrent execution.

---
*PR created automatically by Jules for task [4945065294966384796](https://jules.google.com/task/4945065294966384796) started by @n24q02m*