### PR TITLE
[FIX] Arbitrary File Read via Path Traversal in analyze_media

### DIFF
--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from loguru import logger
 
 from wet_mcp.config import settings
+from wet_mcp.security import is_safe_local_path
 
 # ---------------------------------------------------------------------------
 # Capability maps (vision / audio support detection)
@@ -376,13 +377,10 @@ async def analyze_media(
     """Analyze media file using configured LLM with auto-capability detection."""
     if not _has_llm_provider():
         return "Error: LLM analysis requires API keys (GEMINI_API_KEY, OPENAI_API_KEY, or XAI_API_KEY) to be configured."
-
-    path_obj = Path(media_path).resolve()
     download_dir = Path(settings.download_dir).expanduser().resolve()
-    if not path_obj.is_relative_to(download_dir):
-        return f"Error: Access denied — file must be within download directory ({download_dir})"
-    if not path_obj.exists():
-        return f"Error: File not found at {media_path}"
+    safe_path = is_safe_local_path(media_path, allowed_dirs=[download_dir])
+    if not safe_path:
+        return f"Error: Access denied or file not found at {media_path}. Ensure it is within the download directory ({download_dir}) and is not a sensitive or oversized file."
 
     # Determine mime type
     mime_type, _ = mimetypes.guess_type(media_path)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -145,7 +145,7 @@ def test_analyze_media_file_not_found(mock_settings, tmp_path):
     settings.download_dir = str(tmp_path)
     with patch("wet_mcp.llm._has_llm_provider", return_value=True):
         result = asyncio.run(analyze_media(str(tmp_path / "non_existent_file.jpg")))
-    assert "Error: File not found" in result
+    assert "Error: Access denied or file not found" in result
 
 
 @patch("wet_mcp.llm.acompletion")

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Replaced manual path validation in analyze_media with the is_safe_local_path security helper to prevent arbitrary file reads, sensitive file access, and resource exhaustion. Verified with unit and security tests.

---
*PR created automatically by Jules for task [5204448509653554193](https://jules.google.com/task/5204448509653554193) started by @n24q02m*