### PR TITLE
[FIX] Excessively long line

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1369,7 +1369,11 @@ async def media(  # noqa: PLR0913
     match action:
         case "list":
             if not url:
-                return 'Error: url is required for list action. Example: media(action="list", url="https://example.com/gallery", media_type="images")'
+                return (
+                    "Error: url is required for list action. Example: "
+                    'media(action="list", url="https://example.com/gallery", '
+                    'media_type="images")'
+                )
             return await _with_timeout(
                 list_media(url=url, media_type=media_type, max_items=max_items),
                 "media.list",
@@ -1377,7 +1381,11 @@ async def media(  # noqa: PLR0913
 
         case "download":
             if not media_urls:
-                return 'Error: media_urls is required for download action. Example: media(action="download", media_urls=["https://example.com/image.jpg"]). Use media(action="list", url="...") first to discover media URLs.'
+                return (
+                    "Error: media_urls is required for download action. Example: "
+                    'media(action="download", media_urls=["https://example.com/image.jpg"]). '
+                    'Use media(action="list", url="...") first to discover media URLs.'
+                )
 
             # Security: validate output_dir is within the configured
             # download directory to prevent arbitrary file writes.


### PR DESCRIPTION
Modified `src/wet_mcp/server.py` to break long error strings for "list" and "download" actions in the `media` tool into multiple lines using implicit string concatenation. This ensures compliance with the 88-character line length goal and improves readability.

Verified with ruff format and existing media tool tests.

---
*PR created automatically by Jules for task [16628122897659749918](https://jules.google.com/task/16628122897659749918) started by @n24q02m*