### PR TITLE
[FIX] Fix existing test to use safe httpx client

### DIFF
--- a/tests/test_docs_comprehensive.py
+++ b/tests/test_docs_comprehensive.py
@@ -162,14 +162,11 @@ async def test_probe_docs_url():
 
 @pytest.mark.asyncio
 async def test_try_llms_txt():
-    # Fix existing test to use the safe httpx client and return sufficient text
     with patch("wet_mcp.sources.docs._safe_httpx_client") as MockClient:
         mock_instance = AsyncMock()
         MockClient.return_value.__aenter__.return_value = mock_instance
 
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.text = "A" * 201
+        mock_response = httpx.Response(200, text="A" * 201)
         mock_instance.get.return_value = mock_response
 
         res = await try_llms_txt("https://docs.test")
@@ -186,34 +183,29 @@ async def test_try_llms_txt_edge_cases():
         MockClient.return_value.__aenter__.return_value = mock_instance
 
         # Test < 200 chars
-        mock_response_short = MagicMock()
-        mock_response_short.status_code = 200
-        mock_response_short.text = "Short text"
+        mock_response_short = httpx.Response(200, text="Short text")
         mock_instance.get.return_value = mock_response_short
         assert await try_llms_txt("https://docs.test") is None
 
         # Test DOCTYPE start
-        mock_response_doctype = MagicMock()
-        mock_response_doctype.status_code = 200
-        mock_response_doctype.text = "<!DOCTYPE html>\n<html>" + "A" * 200
+        mock_response_doctype = httpx.Response(
+            200, text="<!DOCTYPE html>\n<html>" + "A" * 200
+        )
         mock_instance.get.return_value = mock_response_doctype
         assert await try_llms_txt("https://docs.test") is None
 
         # Test non-200 status code
-        mock_response_err = MagicMock()
-        mock_response_err.status_code = 404
+        mock_response_err = httpx.Response(404, text="Not Found")
         mock_instance.get.return_value = mock_response_err
         assert await try_llms_txt("https://docs.test") is None
 
         # Test toc only (for llms.txt)
         with patch("wet_mcp.sources.docs._is_toc_only", return_value=True):
-            mock_response_toc = MagicMock()
-            mock_response_toc.status_code = 200
-            mock_response_toc.text = "TOC links" + "A" * 200
+            mock_response_toc = httpx.Response(200, text="TOC links" + "A" * 200)
 
             # First request (llms-full.txt) fails/not found, second request (llms.txt) returns TOC
             mock_instance.get.side_effect = [
-                MagicMock(status_code=404),
+                httpx.Response(404, text="Not Found"),
                 mock_response_toc,
             ]
             assert await try_llms_txt("https://docs.test") is None

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Updated `test_try_llms_txt` and `test_try_llms_txt_edge_cases` in `tests/test_docs_comprehensive.py` to use `httpx.Response` instead of `MagicMock` for mock responses, following the TODO instructions in the test file. Ensured sufficient text (> 200 chars) for the successful case. Verified with pytest and formatted with ruff.

---
*PR created automatically by Jules for task [16244010346858262844](https://jules.google.com/task/16244010346858262844) started by @n24q02m*