### PR TITLE
[TEST] Missing error test for check_health exception

### DIFF
--- a/tests.diff
+++ b/tests.diff
@@ -1,0 +1,26 @@
+diff --git a/tests/test_sync_coverage.py b/tests/test_sync_coverage.py
+index 9497722..6e60eea 100644
+--- a/tests/test_sync_coverage.py
++++ b/tests/test_sync_coverage.py
+@@ -193,3 +193,21 @@ def test_auth_fails(self, mock_settings):
+             pytest.raises(SystemExit),
+         ):
+             setup_sync()
++
++class TestCheckHealthCoverage:
++    """Cover check_health exception paths."""
++
++    @pytest.mark.asyncio
++    async def test_health_httpx_exception(self):
++        from wet_mcp.sync import check_health
++        import httpx
++
++        with (
++            patch("wet_mcp.sync._get_valid_token", return_value={"access_token": "t"}),
++            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client
++        ):
++            mock_instance = AsyncMock()
++            mock_instance.request.side_effect = httpx.ReadTimeout("timeout")
++            mock_client.return_value.__aenter__.return_value = mock_instance
++
++            assert await check_health() is False

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -194,17 +194,19 @@ class TestSetupSyncTokenSuccess:
         ):
             setup_sync()
 
+
 class TestCheckHealthCoverage:
     """Cover check_health exception paths."""
 
     @pytest.mark.asyncio
     async def test_health_httpx_exception(self):
-        from wet_mcp.sync import check_health
         import httpx
+
+        from wet_mcp.sync import check_health
 
         with (
             patch("wet_mcp.sync._get_valid_token", return_value={"access_token": "t"}),
-            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
         ):
             mock_instance = AsyncMock()
             mock_instance.request.side_effect = httpx.ReadTimeout("timeout")

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -193,3 +193,21 @@ class TestSetupSyncTokenSuccess:
             pytest.raises(SystemExit),
         ):
             setup_sync()
+
+class TestCheckHealthCoverage:
+    """Cover check_health exception paths."""
+
+    @pytest.mark.asyncio
+    async def test_health_httpx_exception(self):
+        from wet_mcp.sync import check_health
+        import httpx
+
+        with (
+            patch("wet_mcp.sync._get_valid_token", return_value={"access_token": "t"}),
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client
+        ):
+            mock_instance = AsyncMock()
+            mock_instance.request.side_effect = httpx.ReadTimeout("timeout")
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            assert await check_health() is False

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Added a targeted test case `test_health_httpx_exception` in `tests/test_sync_coverage.py` to verify that `check_health` correctly handles exceptions raised during the Google Drive API request (e.g., httpx timeouts) and returns `False`. This improves test coverage for the error handling logic in `src/wet_mcp/sync/gdrive.py`.

---
*PR created automatically by Jules for task [5671962015587892809](https://jules.google.com/task/5671962015587892809) started by @n24q02m*