### PR TITLE
[FIX] Excessively long line

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2373,7 +2373,11 @@ async def _do_docs_search(
     return json.dumps(
         {
             "status": "indexing_in_progress",
-            "message": f"Library '{library}' is currently being downloaded and indexed in the background (this may take 3-5 minutes). In the meantime, here are temporary web search results.",
+            "message": (
+                f"Library '{library}' is currently being downloaded and indexed "
+                "in the background (this may take 3-5 minutes). In the meantime, "
+                "here are temporary web search results."
+            ),
             "temporary_results": fallback_data.get("results", []),
             "library": library,
             "docs_url": docs_url,

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Broke an excessively long line (191 characters) in `src/wet_mcp/server.py` at line 2376 into multiple lines using parentheses and implicit string concatenation to improve readability and comply with the 88-character limit. Verified with `ruff` and existing tests.

---
*PR created automatically by Jules for task [6078221613013856441](https://jules.google.com/task/6078221613013856441) started by @n24q02m*