### PR TITLE
[TEST] Missing edge case test for run_auto_setup when pip command fails

### DIFF
--- a/src/wet_mcp/setup.py
+++ b/src/wet_mcp/setup.py
@@ -121,9 +121,10 @@ def needs_setup() -> bool:
     return not SETUP_MARKER.exists()
 
 
-def _get_pip_command() -> list[str]:
+def _get_pip_command() -> list[str] | None:
     """Get cross-platform pip install command."""
     import shutil
+    import importlib.util
 
     uv_path = shutil.which("uv")
     if uv_path:
@@ -133,7 +134,10 @@ def _get_pip_command() -> list[str]:
     if pip_path:
         return [pip_path, "install"]
 
-    return [sys.executable, "-m", "pip", "install"]
+    if importlib.util.find_spec("pip"):
+        return [sys.executable, "-m", "pip", "install"]
+
+    return None
 
 
 def _install_searxng() -> bool:
@@ -153,6 +157,9 @@ def _install_searxng() -> bool:
     try:
         # Pre-install build dependencies
         pip_cmd = _get_pip_command()
+        if not pip_cmd:
+            return False
+
         deps_result = subprocess.run(
             [
                 *pip_cmd,
@@ -268,6 +275,11 @@ def run_auto_setup() -> bool:
         return True
 
     logger.info("First run detected, running auto-setup...")
+
+    pip_cmd = _get_pip_command()
+    if not pip_cmd:
+        logger.error("pip command not found, cannot proceed with auto-setup")
+        return False
 
     success = True
 

--- a/tests/test_setup_comprehensive.py
+++ b/tests/test_setup_comprehensive.py
@@ -227,8 +227,9 @@ def test_get_pip_command_pip(mock_which):
 @patch("shutil.which", return_value=None)
 @patch("sys.executable", "/usr/bin/python3")
 def test_get_pip_command_sys_executable(mock_which):
-    cmd = _get_pip_command()
-    assert cmd == ["/usr/bin/python3", "-m", "pip", "install"]
+    with patch("importlib.util.find_spec", return_value=MagicMock()):
+        cmd = _get_pip_command()
+        assert cmd == ["/usr/bin/python3", "-m", "pip", "install"]
 
 
 # Test _install_searxng
@@ -354,3 +355,20 @@ def test_run_auto_setup_crawl4ai_fail(
 ):
     assert run_auto_setup() is False
     mock_marker.touch.assert_not_called()
+
+
+def test_get_pip_command_none():
+    """Test that _get_pip_command returns None when no pip-related command is available."""
+    with (
+        patch("shutil.which", return_value=None),
+        patch("importlib.util.find_spec", return_value=None),
+    ):
+        cmd = _get_pip_command()
+        assert cmd is None
+
+
+@patch("wet_mcp.setup.needs_setup", return_value=True)
+@patch("wet_mcp.setup._get_pip_command", return_value=None)
+def test_run_auto_setup_no_pip(mock_get_pip, mock_needs_setup):
+    """Test that run_auto_setup returns False when pip command is not found."""
+    assert run_auto_setup() is False

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This change handles cases where no pip-compatible command (uv, pip, or python -m pip) is available during auto-setup.

Specifically:
- Updated `_get_pip_command` in `src/wet_mcp/setup.py` to return `None` instead of blindly returning `python -m pip` if nothing is found.
- Added explicit checks for `pip_cmd` in `run_auto_setup` and `_install_searxng` to return `False` gracefully.
- Added unit tests in `tests/test_setup_comprehensive.py` to cover these scenarios.
- Updated existing tests to account for more robust pip module detection.

---
*PR created automatically by Jules for task [7419427220407471569](https://jules.google.com/task/7419427220407471569) started by @n24q02m*