### PR TITLE
[FIX] Excessively long line in server.py

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1278,14 +1278,14 @@ async def extract(  # noqa: PLR0913
         case "interact":
             if not url:
                 return (
-                    'Error: url is required for interact action. Example: '
+                    "Error: url is required for interact action. Example: "
                     'extract(action="interact", url="https://example.com/login", '
                     'actions=[{"type": "click", "selector": "#submit"}])'
                 )
             if not actions:
                 return (
-                    'Error: actions is required for interact action. Provide a '
-                    'list of {type, selector?, description?, value?} ops. '
+                    "Error: actions is required for interact action. Provide a "
+                    "list of {type, selector?, description?, value?} ops. "
                     'Example: actions=[{"type": "fill", "selector": "#email", '
                     '"value": "x@y.com"}, {"type": "submit", '
                     '"selector": "form"}]'

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1277,9 +1277,19 @@ async def extract(  # noqa: PLR0913
 
         case "interact":
             if not url:
-                return 'Error: url is required for interact action. Example: extract(action="interact", url="https://example.com/login", actions=[{"type": "click", "selector": "#submit"}])'
+                return (
+                    'Error: url is required for interact action. Example: '
+                    'extract(action="interact", url="https://example.com/login", '
+                    'actions=[{"type": "click", "selector": "#submit"}])'
+                )
             if not actions:
-                return 'Error: actions is required for interact action. Provide a list of {type, selector?, description?, value?} ops. Example: actions=[{"type": "fill", "selector": "#email", "value": "x@y.com"}, {"type": "submit", "selector": "form"}]'
+                return (
+                    'Error: actions is required for interact action. Provide a '
+                    'list of {type, selector?, description?, value?} ops. '
+                    'Example: actions=[{"type": "fill", "selector": "#email", '
+                    '"value": "x@y.com"}, {"type": "submit", '
+                    '"selector": "form"}]'
+                )
             from wet_mcp.sources.interact_orchestrator import run_interact
 
             result = await _with_timeout(

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR addresses the issue of excessively long lines in `src/wet_mcp/server.py` at lines 1280 and 1282. The long error message strings have been broken into multiple lines using Python's implicit string concatenation within parentheses. Additionally, single quotes are used as the outer wrapper for these strings to improve readability by avoiding the need to escape nested double quotes in the JSON-like examples.

---
*PR created automatically by Jules for task [15451403477715566502](https://jules.google.com/task/15451403477715566502) started by @n24q02m*