### PR TITLE
[FIX] Excessively long line in server.py:1282

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1277,9 +1277,23 @@ async def extract(  # noqa: PLR0913
 
         case "interact":
             if not url:
-                return 'Error: url is required for interact action. Example: extract(action="interact", url="https://example.com/login", actions=[{"type": "click", "selector": "#submit"}])'
+                return (
+                    "Error: url is required for interact action. Example: "
+                    "extract(action=\"interact\", "
+                    "url=\"https://example.com/login\", "
+                    "actions=[{\"type\": \"click\", "
+                    "\"selector\": \"#submit\"}])"
+                )
             if not actions:
-                return 'Error: actions is required for interact action. Provide a list of {type, selector?, description?, value?} ops. Example: actions=[{"type": "fill", "selector": "#email", "value": "x@y.com"}, {"type": "submit", "selector": "form"}]'
+                return (
+                    "Error: actions is required for interact action. Provide a "
+                    "list of {type, selector?, description?, value?} ops. "
+                    "Example: actions=[{\"type\": \"fill\", "
+                    "\"selector\": \"#email\", "
+                    "\"value\": \"x@y.com\"}, "
+                    "{\"type\": \"submit\", "
+                    "\"selector\": \"form\"}]"
+                )
             from wet_mcp.sources.interact_orchestrator import run_interact
 
             result = await _with_timeout(

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1279,20 +1279,20 @@ async def extract(  # noqa: PLR0913
             if not url:
                 return (
                     "Error: url is required for interact action. Example: "
-                    "extract(action=\"interact\", "
-                    "url=\"https://example.com/login\", "
-                    "actions=[{\"type\": \"click\", "
-                    "\"selector\": \"#submit\"}])"
+                    'extract(action="interact", '
+                    'url="https://example.com/login", '
+                    'actions=[{"type": "click", '
+                    '"selector": "#submit"}])'
                 )
             if not actions:
                 return (
                     "Error: actions is required for interact action. Provide a "
                     "list of {type, selector?, description?, value?} ops. "
-                    "Example: actions=[{\"type\": \"fill\", "
-                    "\"selector\": \"#email\", "
-                    "\"value\": \"x@y.com\"}, "
-                    "{\"type\": \"submit\", "
-                    "\"selector\": \"form\"}]"
+                    'Example: actions=[{"type": "fill", '
+                    '"selector": "#email", '
+                    '"value": "x@y.com"}, '
+                    '{"type": "submit", '
+                    '"selector": "form"}]'
                 )
             from wet_mcp.sources.interact_orchestrator import run_interact
 

--- a/uv.lock
+++ b/uv.lock
@@ -3562,7 +3562,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4b1"
+version = "3.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR refactors excessively long error message lines in `src/wet_mcp/server.py` (specifically lines 1280 and 1282) that were exceeding the project's 88-character limit. The fix uses parentheses for implicit string concatenation, which is the preferred way to break long strings in Python without introducing extraneous escape characters or plus operators.

Changes:
- Refactored `url` validation error in `interact` action.
- Refactored `actions` validation error in `interact` action.
- Verified changes with `uv run ruff format` and `uv run pytest tests/test_server.py`.
- Confirmed that the specific lines are now well under the 88-character limit.

---
*PR created automatically by Jules for task [2634739230192146613](https://jules.google.com/task/2634739230192146613) started by @n24q02m*