### PR TITLE
[PERF] Sequential async API calls instead of gather

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -355,13 +355,17 @@ class CloudEmbeddingBackend:
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
             batch_num = i // self.MAX_BATCH_SIZE + 1
             logger.debug(
                 f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
             )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(self._embed_batch_inner(batch, dimensions))
+
+        results = await asyncio.gather(*tasks)
+        for batch_result in results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings

--- a/tests/test_embedder_perf.py
+++ b/tests/test_embedder_perf.py
@@ -1,0 +1,35 @@
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from wet_mcp.embedder import CloudEmbeddingBackend
+
+
+@pytest.mark.asyncio
+async def test_embed_texts_parallel():
+    backend = CloudEmbeddingBackend("text-embedding-3-small")
+    # Small batch size to trigger multiple batches easily
+    backend.MAX_BATCH_SIZE = 2
+
+    texts = ["t1", "t2", "t3", "t4"]  # 2 batches
+    delay = 0.5
+
+    async def mocked_embed_batch_inner(batch, dimensions=None):
+        await asyncio.sleep(delay)
+        return [[0.1] * 1536] * len(batch)
+
+    with patch.object(
+        backend, "_embed_batch_inner", side_effect=mocked_embed_batch_inner
+    ):
+        start_time = time.perf_counter()
+        results = await backend.embed_texts(texts)
+        end_time = time.perf_counter()
+
+    duration = end_time - start_time
+    assert len(results) == 4
+    # If sequential, duration >= 1.0. If parallel, duration approx 0.5.
+    assert duration < delay * 1.5, (
+        f"Duration {duration} was not fast enough, expected < {delay * 1.5}"
+    )


### PR DESCRIPTION
Optimized CloudEmbeddingBackend.embed_texts to use asyncio.gather for parallelizing batch embedding calls. This replaces sequential execution of _embed_batch_inner, significantly improving throughput when processing multiple text batches.

Key changes:
- Refactored CloudEmbeddingBackend.embed_texts to collect batch coroutines and execute them concurrently using asyncio.gather.
- Added tests/test_embedder_perf.py to verify that multiple batches are processed in parallel (total time reflects concurrent rather than sequential processing).
- Verified that existing functionality and tests remain intact.

---
*PR created automatically by Jules for task [12278583737471695718](https://jules.google.com/task/12278583737471695718) started by @n24q02m*