### PR TITLE
fix: report wet-mcp package version in serverInfo.version

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -585,6 +585,17 @@ mcp = FastMCP(
     lifespan=_lifespan,
 )
 
+# Report wet-mcp's own package version in serverInfo.version. FastMCP (the SDK
+# class) does not accept a `version=` kwarg, so the underlying lowlevel Server
+# defaults `.version` to None and the SDK fills serverInfo with the `mcp`
+# package version instead. Setting it here propagates to
+# create_initialization_options().server_version. Read the version via
+# importlib.metadata (not `from wet_mcp import __version__`) to avoid a
+# circular import: wet_mcp/__init__.py imports `mcp` from this module.
+from importlib.metadata import version as _pkgver  # noqa: E402
+
+mcp._mcp_server.version = _pkgver("wet-mcp")
+
 # Register the standard `config__open_relay` MCP tool so an LLM can re-trigger
 # the relay form when the server is reachable over HTTP. Helper lives in
 # mcp-core >=1.13.0b4; signature: (mcp, server_name, public_url). Pass

--- a/tests/test_serverinfo_version.py
+++ b/tests/test_serverinfo_version.py
@@ -1,0 +1,30 @@
+"""Regression test: serverInfo.version reports wet-mcp's own version.
+
+FastMCP (the SDK class) does not accept a ``version=`` kwarg, so the underlying
+lowlevel Server defaults ``.version`` to ``None`` and the SDK fills
+``serverInfo`` with the ``mcp`` package version instead. ``server.py`` sets
+``mcp._mcp_server.version`` explicitly; this test asserts it propagates to
+``create_initialization_options().server_version`` and is wet-mcp's version,
+not the mcp SDK's.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+
+
+def test_serverinfo_reports_wet_mcp_version() -> None:
+    from wet_mcp import server
+
+    wet_version = version("wet-mcp")
+    server_version = (
+        server.mcp._mcp_server.create_initialization_options().server_version
+    )
+
+    assert server_version == wet_version
+
+    mcp_sdk_version = version("mcp")
+    assert server_version != mcp_sdk_version, (
+        "serverInfo.version must report wet-mcp's version, not the mcp SDK "
+        f"version ({mcp_sdk_version})."
+    )

--- a/tests/test_serverinfo_version.py
+++ b/tests/test_serverinfo_version.py
@@ -10,11 +10,18 @@ not the mcp SDK's.
 
 from __future__ import annotations
 
+import importlib
+import sys
 from importlib.metadata import version
 
 
 def test_serverinfo_reports_wet_mcp_version() -> None:
-    from wet_mcp import server
+    # ``test_server_timeout.py`` re-imports ``wet_mcp.server`` under heavy
+    # mocking (FastMCP -> MagicMock) and can leave a mocked module behind in
+    # ``sys.modules``. Force a clean re-import so we exercise the real FastMCP
+    # and the real lowlevel Server, not a MagicMock.
+    sys.modules.pop("wet_mcp.server", None)
+    server = importlib.import_module("wet_mcp.server")
 
     wet_version = version("wet-mcp")
     server_version = (


### PR DESCRIPTION
## Problem
The MCP server reported the mcp-SDK version (e.g. `1.27.2`) in `serverInfo.version` instead of wet-mcp's own package version. `mcp.server.fastmcp.FastMCP` does not accept a `version=` kwarg, so the underlying lowlevel Server left `.version = None`, and the SDK fell back to filling `serverInfo` with the `mcp` package version.

## Fix
Set `mcp._mcp_server.version` explicitly right after the `FastMCP(...)` constructor. This propagates to `create_initialization_options().server_version`. The version is read via `importlib.metadata.version("wet-mcp")` rather than `from wet_mcp import __version__` to avoid a circular import (`wet_mcp/__init__.py` imports `mcp` from `server.py`).

## Test
Added `tests/test_serverinfo_version.py` asserting `create_initialization_options().server_version == version("wet-mcp")` and `!= version("mcp")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)