### PR TITLE
[SECURITY] SQL Injection in exec_driver_sql (docs_002_libraries index)

### DIFF
--- a/src/wet_mcp/alembic/versions/docs_002_libraries.py
+++ b/src/wet_mcp/alembic/versions/docs_002_libraries.py
@@ -41,14 +41,20 @@ depends_on = None
 
 logger = logging.getLogger("alembic.runtime.migration")
 
+_ALLOWED_TABLES = {"libraries", "versions", "doc_chunks"}
+
 
 def _existing_columns(table: str) -> set[str]:
+    if table not in _ALLOWED_TABLES:
+        raise ValueError(f"Invalid table name: {table}")
     bind = op.get_bind()
     rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
     return {row[1] for row in rows}
 
 
 def _existing_indexes(table: str) -> set[str]:
+    if table not in _ALLOWED_TABLES:
+        raise ValueError(f"Invalid table name: {table}")
     bind = op.get_bind()
     rows = bind.exec_driver_sql(f"PRAGMA index_list({table})").fetchall()
     return {row[1] for row in rows}


### PR DESCRIPTION
Fixed a SQL injection vulnerability in the Alembic migration script docs_002_libraries.py by implementing an allowlist for table names used in PRAGMA table_info and PRAGMA index_list queries. SQLite identifiers like table names cannot be parameterized in these statements, so a strict allowlist is used to ensure only trusted table names are interpolated into the SQL string.

---
*PR created automatically by Jules for task [6579604247711056513](https://jules.google.com/task/6579604247711056513) started by @n24q02m*