### PR TITLE
[TEST] Missing error path test in db.py - add_chunks serialization

### DIFF
--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -367,6 +367,27 @@ class TestAddChunksWithEmbeddings:
         assert count == 2
         d.close()
 
+    def test_add_chunks_serialization_error(self, tmp_path):
+        """Serialization error in one embedding is caught, others proceed (lines 817-818)."""
+        d = DocsDB(tmp_path / "ser.db", embedding_dims=2)
+        lib_id = d.upsert_library(name="serlib")
+        ver_id = d.upsert_version(lib_id)
+
+        d._vec_enabled = True
+        # Second embedding is invalid (string) -> serialization fails
+        embeddings = [[1.0, 2.0], "invalid"]
+        chunks = [
+            {"content": "good chunk"},
+            {"content": "bad chunk"},
+        ]
+        count = d.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
+        assert count == 2
+
+        # Only the first (valid) embedding should be in the vec table
+        vec_count = d._conn.execute("SELECT COUNT(*) FROM doc_chunks_vec").fetchone()[0]
+        assert vec_count == 1
+        d.close()
+
 
 # ---------------------------------------------------------------------------
 # FTS search error handling (lines 694-697)


### PR DESCRIPTION
Added `test_add_chunks_serialization_error` to `tests/test_db_coverage.py` to cover the error path in `add_chunks` serialization. This test verifies that if an individual embedding fails to serialize (e.g., due to invalid format), the operation continues for other chunks and embeddings, and the error is gracefully handled/logged.

---
*PR created automatically by Jules for task [13948900452245224292](https://jules.google.com/task/13948900452245224292) started by @n24q02m*