### PR TITLE
[SECURITY] SQL Injection in db.py (execute replace format)

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -1220,9 +1220,9 @@ class DocsDB:
 
         def _get_existing(table: str, items: list) -> set:
             allowed_queries = {
-                "libraries": "SELECT id FROM libraries WHERE id IN ({})",
-                "versions": "SELECT id FROM versions WHERE id IN ({})",
-                "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN ({})",
+                "libraries": "SELECT id FROM libraries WHERE id IN (SELECT value FROM json_each(?))",
+                "versions": "SELECT id FROM versions WHERE id IN (SELECT value FROM json_each(?))",
+                "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN (SELECT value FROM json_each(?))",
             }
             if table not in allowed_queries:
                 raise ValueError(f"Invalid table name: {table}")
@@ -1230,15 +1230,13 @@ class DocsDB:
                 return set()
             ids = [obj["id"] for obj in items]
             existing = set()
-            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+            # Use json_each to safely pass IDs as a JSON array parameter.
+            # Batching avoids excessive memory usage for very large imports.
+            batch_size = 5000
             for i in range(0, len(ids), batch_size):
                 batch = ids[i : i + batch_size]
-                placeholders = ",".join("?" * len(batch))
-                # Safe because table is strictly validated against allowlist
-                # and placeholders string contains only static "?" and ",".
-                query = allowed_queries[table].replace("{}", placeholders)
-                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                res = self._conn.execute(query, batch).fetchall()
+                query = allowed_queries[table]
+                res = self._conn.execute(query, (json.dumps(batch),)).fetchall()
                 existing.update(r[0] for r in res)
             return existing
 

--- a/tests/test_security_sql.py
+++ b/tests/test_security_sql.py
@@ -105,3 +105,55 @@ def test_get_existing_invalid_table(tmp_path):
     # Just ensure we can instantiate DocsDB
     db = DocsDB(db_path)
     assert db._db_path == db_path
+
+
+def test_get_existing_large_batch(tmp_path):
+    db_path = tmp_path / "test_large.db"
+    db = DocsDB(db_path)
+
+    # Create 6000 libraries (more than the 5000 batch size)
+    libs = []
+    for i in range(6000):
+        libs.append(
+            {
+                "_type": "library",
+                "id": f"lib_{i}",
+                "name": f"Library {i}",
+                "created_at": 1,
+                "updated_at": 1,
+            }
+        )
+
+    # First import to populate
+    data = "\n".join(json.dumps(lib_item) for lib_item in libs)
+    db.import_jsonl(data)
+
+    # Second import in merge mode to check existing
+    # All 6000 should be skipped
+    stats = db.import_jsonl(data, mode="merge")
+    assert stats["skipped"] == 6000
+    assert stats["libraries"] == 0
+
+
+def test_get_existing_malicious_id(tmp_path):
+    db_path = tmp_path / "test_malicious.db"
+    db = DocsDB(db_path)
+
+    # Test with an ID that looks like SQL injection
+    malicious_id = "'); DROP TABLE libraries; --"
+    lib = {
+        "_type": "library",
+        "id": malicious_id,
+        "name": "Malicious",
+        "created_at": 1,
+        "updated_at": 1,
+    }
+
+    db.import_jsonl(json.dumps(lib))
+
+    # Check if it exists (should not crash and should correctly identify)
+    stats = db.import_jsonl(json.dumps(lib), mode="merge")
+    assert stats["skipped"] == 1
+
+    # Verify table still exists
+    db.stats()

--- a/uv.lock
+++ b/uv.lock
@@ -3573,7 +3573,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4"
+version = "3.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR fixes a security vulnerability in `src/wet_mcp/db.py` where string `.replace()` was used to dynamically inject placeholders into an SQL `IN` clause within the `import_jsonl` function.

While the existing code used strict allowlists, the pattern was flagged as unsafe. The fix replaces this logic with SQLite's native `json_each` function, which allows passing the entire list of IDs as a single JSON-encoded parameter. This approach is more secure, eliminates dynamic query construction, and is more efficient for large batches.

Key changes:
- Refactored `_get_existing` in `import_jsonl` to use `json_each(?)`.
- Implemented batching (5000 items) to ensure memory efficiency.
- Added comprehensive tests in `tests/test_security_sql.py` covering large batches and malicious input strings.
- Verified all database tests pass.

---
*PR created automatically by Jules for task [17333609044725191530](https://jules.google.com/task/17333609044725191530) started by @n24q02m*