### PR TITLE
[FIX] Unused import: _MAX_RESTART_ATTEMPTS

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -81,7 +81,6 @@ _wc_runner._find_available_port = _find_available_port  # type: ignore[assignmen
 from web_core.search.runner import (  # noqa: F401, E402
     _DISCOVERY_FILE,
     _HEALTH_CHECK_TIMEOUT,
-    _MAX_RESTART_ATTEMPTS,
     _RESTART_COOLDOWN,
     _STARTUP_HEALTH_TIMEOUT,
     _cleanup_process,


### PR DESCRIPTION
Removed the unused re-export of `_MAX_RESTART_ATTEMPTS` from `src/wet_mcp/searxng_runner.py`. This constant was imported from `web_core.search.runner` but not utilized within the repository. Verified with ruff and the full test suite.

---
*PR created automatically by Jules for task [10329426033710034395](https://jules.google.com/task/10329426033710034395) started by @n24q02m*