### PR TITLE
[SECURITY] SQL Injection in execute (ALTER TABLE versions)

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -283,22 +283,20 @@ class DocsDB:
         """)
 
         # Idempotent column adds for legacy DBs that pre-date Alembic.
-        # Each ALTER is wrapped in a try/except so re-running on a fresh
-        # head-shape table does not raise.
-        for col_ddl in (
-            "discovery_version INTEGER DEFAULT 0",
-            "canonical_name TEXT",
-            "homepage TEXT",
-            "github_url TEXT",
-            "package_managers TEXT",
-            "tier INTEGER NOT NULL DEFAULT 2",
-            "last_indexed_at REAL",
-            "total_versions INTEGER NOT NULL DEFAULT 0",
+        for stmt in (
+            "ALTER TABLE libraries ADD COLUMN discovery_version INTEGER DEFAULT 0",
+            "ALTER TABLE libraries ADD COLUMN canonical_name TEXT",
+            "ALTER TABLE libraries ADD COLUMN homepage TEXT",
+            "ALTER TABLE libraries ADD COLUMN github_url TEXT",
+            "ALTER TABLE libraries ADD COLUMN package_managers TEXT",
+            "ALTER TABLE libraries ADD COLUMN tier INTEGER NOT NULL DEFAULT 2",
+            "ALTER TABLE libraries ADD COLUMN last_indexed_at REAL",
+            "ALTER TABLE libraries ADD COLUMN total_versions INTEGER NOT NULL DEFAULT 0",
         ):
             try:
-                self._conn.execute(f"ALTER TABLE libraries ADD COLUMN {col_ddl}")
+                self._conn.execute(stmt)
                 self._conn.commit()
-                col_name = col_ddl.split()[0]
+                col_name = stmt.split("ADD COLUMN ")[1].split()[0]
                 logger.debug(f"Migrated libraries table: added {col_name}")
             except sqlite3.OperationalError:
                 pass  # Column already exists
@@ -322,9 +320,12 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in ("release_date REAL", "source_url TEXT"):
+        for stmt in (
+            "ALTER TABLE versions ADD COLUMN release_date REAL",
+            "ALTER TABLE versions ADD COLUMN source_url TEXT",
+        ):
             try:
-                self._conn.execute(f"ALTER TABLE versions ADD COLUMN {col_ddl}")
+                self._conn.execute(stmt)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass
@@ -351,14 +352,14 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in (
-            "section TEXT",
-            "topic TEXT",
-            "content_hash TEXT",
-            "token_count INTEGER",
+        for stmt in (
+            "ALTER TABLE doc_chunks ADD COLUMN section TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN topic TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN content_hash TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN token_count INTEGER",
         ):
             try:
-                self._conn.execute(f"ALTER TABLE doc_chunks ADD COLUMN {col_ddl}")
+                self._conn.execute(stmt)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass


### PR DESCRIPTION
This PR fixes a potential SQL injection vulnerability in `src/wet_mcp/db.py` by refactoring `ALTER TABLE` statements used for idempotent column additions.

Specifically:
- Replaced f-string based `ALTER TABLE` construction in `_create_libraries_table`, `_create_versions_table`, and `_create_doc_chunks_table` with hardcoded static SQL strings.
- Preserved the idempotent logic using `try/except sqlite3.OperationalError` to maintain backward compatibility for legacy databases.
- Updated the libraries migration logging to correctly extract column names from the new hardcoded strings.

This change adheres to security best practices by avoiding dynamic SQL construction for DDL statements, which SQLite does not support parameterization for.

All database tests passed, and manual verification of idempotent startup was successful.

---
*PR created automatically by Jules for task [2900200030778222312](https://jules.google.com/task/2900200030778222312) started by @n24q02m*