### PR TITLE
[TEST] Missing edge case test in setup.py - missing searxng package dir

### DIFF
--- a/tests/test_setup_edge_cases.py
+++ b/tests/test_setup_edge_cases.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
+
 from wet_mcp.setup import patch_searxng_version, patch_searxng_windows
+
 
 @patch("wet_mcp.setup._find_searx_package_dir")
 @patch("wet_mcp.setup.Path")
@@ -20,6 +22,7 @@ def test_patch_searxng_version_no_dir_noop(mock_path, mock_find_dir):
     # but here we specifically want to see that searx_dir was not used.
     # If it returned early, it shouldn't have reached 'vf = searx_dir / "version_frozen.py"'
     mock_path.assert_not_called()
+
 
 @patch("platform.system", return_value="Windows")
 @patch("wet_mcp.setup._find_searx_package_dir")

--- a/tests/test_setup_edge_cases.py
+++ b/tests/test_setup_edge_cases.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+from wet_mcp.setup import patch_searxng_version, patch_searxng_windows
+
+@patch("wet_mcp.setup._find_searx_package_dir")
+@patch("wet_mcp.setup.Path")
+def test_patch_searxng_version_no_dir_noop(mock_path, mock_find_dir):
+    """
+    Test that patch_searxng_version returns immediately when no searx directory is found,
+    without performing any Path operations.
+    """
+    mock_find_dir.return_value = None
+
+    patch_searxng_version()
+
+    # Assert that find_dir was called
+    mock_find_dir.assert_called_once()
+
+    # Assert that no Path object was created or manipulated
+    # Note: Path() might be called for other things if we are not careful,
+    # but here we specifically want to see that searx_dir was not used.
+    # If it returned early, it shouldn't have reached 'vf = searx_dir / "version_frozen.py"'
+    mock_path.assert_not_called()
+
+@patch("platform.system", return_value="Windows")
+@patch("wet_mcp.setup._find_searx_package_dir")
+@patch("wet_mcp.setup.Path")
+def test_patch_searxng_windows_no_dir_noop(mock_path, mock_find_dir, mock_system):
+    """
+    Test that patch_searxng_windows returns immediately when no searx directory is found,
+    without performing any Path operations.
+    """
+    mock_find_dir.return_value = None
+
+    patch_searxng_windows()
+
+    # Assert that find_dir was called
+    mock_find_dir.assert_called_once()
+
+    # Assert that no Path object was created or manipulated
+    mock_path.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -3573,7 +3573,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4"
+version = "3.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR adds explicit test coverage for edge cases in src/wet_mcp/setup.py where _find_searx_package_dir() returns None. It verifies that patch_searxng_version and patch_searxng_windows exit immediately without performing any file operations in this scenario. New tests are located in tests/test_setup_edge_cases.py.

---
*PR created automatically by Jules for task [8405253979781579302](https://jules.google.com/task/8405253979781579302) started by @n24q02m*