### PR TITLE
[SECURITY] SQL Injection in db.py (execute IN placeholders)

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -1234,7 +1234,9 @@ class DocsDB:
             batch_size = 1000
             # Security: Use json_each(?) to ensure the SQL string is 100% static
             # and properly parameterized, avoiding dynamic placeholder generation.
-            query = allowed_queries[table].replace("{}", "SELECT value FROM json_each(?)")
+            query = allowed_queries[table].replace(
+                "{}", "SELECT value FROM json_each(?)"
+            )
             for i in range(0, len(ids), batch_size):
                 batch = ids[i : i + batch_size]
                 res = self._conn.execute(query, (json.dumps(batch),)).fetchall()

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -1064,24 +1064,23 @@ class DocsDB:
             # This avoids the N+1 query problem by batching multiple (url, version_id, chunk_index) tuples.
             # We use sorted(set()) to ensure uniqueness and improve cache locality.
             _unique_keys = sorted(set(_adj_keys))
-            _batch_size = (
-                32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
-            ) // 3
+            # With json_each, we only use one parameter per batch, but we still
+            # batch to avoid extremely large JSON strings.
+            _batch_size = 1000
 
+            # Security: Use json_each(?) for row-value IN to ensure the SQL string
+            # is 100% static and properly parameterized, avoiding dynamic placeholder
+            # generation which can be flagged as unsafe.
+            sql = (
+                "SELECT url, version_id, chunk_index, content "
+                "FROM doc_chunks "
+                "WHERE (url, version_id, chunk_index) IN ("
+                "SELECT json_extract(value, '$[0]'), json_extract(value, '$[1]'), CAST(json_extract(value, '$[2]') AS INTEGER) "
+                "FROM json_each(?))"
+            )
             for i in range(0, len(_unique_keys), _batch_size):
                 _batch = _unique_keys[i : i + _batch_size]
-                _placeholders = ",".join(["(?,?,?)"] * len(_batch))
-                _params = [item for key_tuple in _batch for item in key_tuple]
-
-                # Security: Placeholders are constructed from static tokens (?,?,?)
-                # and strictly separated from the query structure.
-                sql = (
-                    "SELECT url, version_id, chunk_index, content "
-                    "FROM doc_chunks "
-                    "WHERE (url, version_id, chunk_index) IN (" + _placeholders + ")"
-                )
-                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                rows = self._conn.execute(sql, _params).fetchall()
+                rows = self._conn.execute(sql, (json.dumps(_batch),)).fetchall()
                 for r in rows:
                     _adj_map[(r["url"], r["version_id"], r["chunk_index"])] = r[
                         "content"
@@ -1230,15 +1229,15 @@ class DocsDB:
                 return set()
             ids = [obj["id"] for obj in items]
             existing = set()
-            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+            # With json_each, we only use one parameter per batch, but we still
+            # batch to avoid extremely large JSON strings.
+            batch_size = 1000
+            # Security: Use json_each(?) to ensure the SQL string is 100% static
+            # and properly parameterized, avoiding dynamic placeholder generation.
+            query = allowed_queries[table].replace("{}", "SELECT value FROM json_each(?)")
             for i in range(0, len(ids), batch_size):
                 batch = ids[i : i + batch_size]
-                placeholders = ",".join("?" * len(batch))
-                # Safe because table is strictly validated against allowlist
-                # and placeholders string contains only static "?" and ",".
-                query = allowed_queries[table].replace("{}", placeholders)
-                # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                res = self._conn.execute(query, batch).fetchall()
+                res = self._conn.execute(query, (json.dumps(batch),)).fetchall()
                 existing.update(r[0] for r in res)
             return existing
 

--- a/uv.lock
+++ b/uv.lock
@@ -3573,7 +3573,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4"
+version = "3.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Replaced dynamic SQL placeholder generation with static queries using SQLite's json_each function in the search method and _get_existing helper. This eliminates string concatenation in SQL construction, resolving a security vulnerability flagged by scanners. Used json_extract instead of ->> for better compatibility with older SQLite versions (>= 3.32.0). Standardized batch size to 1000 for JSON-based parameter passing. Verified with the full test suite.

---
*PR created automatically by Jules for task [13740096403969075602](https://jules.google.com/task/13740096403969075602) started by @n24q02m*