### PR TITLE
[FIX] Redundant DB table info fetch

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -189,8 +189,11 @@ def _chunk_quality_score(content: str) -> float:
 class DocsDB:
     """SQLite-backed docs storage with FTS5 hybrid search."""
 
+    _column_cache: dict[tuple[str, str], set[str]] = {}
+    _table_exists_cache: dict[tuple[str, str], bool] = {}
+
     def __init__(self, db_path: Path, embedding_dims: int = 0):
-        self._db_path = db_path
+        self._db_path = db_path.absolute()
         if (
             type(embedding_dims) is not int
             or embedding_dims < 0
@@ -230,6 +233,19 @@ class DocsDB:
 
         self._create_tables()
         logger.debug(f"DocsDB initialized at {db_path} (vec={self._vec_enabled})")
+
+    def _get_table_columns(self, table_name: str) -> set[str]:
+        """Get columns for a table, using cache if available."""
+        key = (str(self._db_path), table_name)
+        if key in self._column_cache:
+            return self._column_cache[key]
+
+        # PRAGMA table_info is safe here as table_name is internal
+        res = self._conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        cols = {r["name"] for r in res}
+        if cols:
+            self._column_cache[key] = cols
+        return cols
 
     def _create_tables(self) -> None:
         self._create_libraries_table()
@@ -492,10 +508,7 @@ class DocsDB:
 
         # Phase 2 columns may be absent on a pre-Alembic legacy DB. Detect
         # presence once per call so we don't crash on older schemas.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
             if package_managers is not None
@@ -615,10 +628,7 @@ class DocsDB:
         Silently no-ops on pre-Alembic legacy databases that lack the
         ``last_indexed_at`` / ``total_versions`` columns.
         """
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
-        }
+        existing_cols = self._get_table_columns("libraries")
         sets: list[str] = []
         params: list = []
         if "last_indexed_at" in existing_cols:
@@ -748,10 +758,7 @@ class DocsDB:
         chunk_ids = [uuid.uuid4().hex[:12] for _ in chunks]
 
         # Detect optional columns once so we can branch on a single INSERT.
-        existing_cols = {
-            r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
-        }
+        existing_cols = self._get_table_columns("doc_chunks")
         phase2_cols = [
             c
             for c in (
@@ -1344,11 +1351,18 @@ class DocsDB:
 
     def _ensure_project_context(self) -> bool:
         """Return True iff the project_context table exists."""
+        key = (str(self._db_path), "project_context")
+        if key in self._table_exists_cache:
+            return self._table_exists_cache[key]
+
         row = self._conn.execute(
             "SELECT name FROM sqlite_master "
             "WHERE type='table' AND name='project_context'"
         ).fetchone()
-        return row is not None
+        exists = row is not None
+        if exists:
+            self._table_exists_cache[key] = True
+        return exists
 
     def upsert_project_context(
         self, project_path: str, locked_libraries: list[dict]

--- a/uv.lock
+++ b/uv.lock
@@ -3573,7 +3573,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4"
+version = "3.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR addresses the issue of redundant database metadata queries in the `DocsDB` class. 

### Changes:
- Added `_column_cache` and `_table_exists_cache` class-level variables to `DocsDB`.
- Updated `DocsDB.__init__` to resolve the database path to an absolute path, ensuring cache key consistency.
- Introduced `_get_table_columns` helper method to encapsulate the caching and fetching of table columns.
- Refactored `upsert_library`, `mark_library_indexed`, and `add_chunks` to use the new `_get_table_columns` helper.
- Optimized `_ensure_project_context` to cache the existence of the `project_context` table.

### Impact:
Reduces CPU overhead and database contention by eliminating multiple `PRAGMA table_info` and `sqlite_master` queries during common operations.

### Verification:
- Ran `uv run pytest tests/test_db_coverage.py` - All tests passed.
- Manually verified caching logic with a temporary test script.

---
*PR created automatically by Jules for task [131837190166468791](https://jules.google.com/task/131837190166468791) started by @n24q02m*