### PR TITLE
Fix SQLite PRAGMA SQL injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,10 @@
 **Vulnerability:** The `token_store.py` module constructed file paths by directly concatenating user-controlled inputs (`provider`, `sub`) via `pathlib.Path` without validation. This allowed path traversal (e.g., using `../` or absolute paths) to read or write arbitrary files on the system with the application's permissions.
 **Learning:** Even when using higher-level path abstractions like `pathlib`, string concatenation or `/` division with unvalidated user input is unsafe because the underlying OS resolution still respects traversal sequences.
 **Prevention:** Always explicitly validate path components for dangerous characters (like `/`, `\`, and `..`) using an explicit string validation helper before passing them to file I/O operations or path constructors.
+
+## 2024-05-25 - SQL Injection in SQLite PRAGMA Statements
+**Vulnerability:** SQLite PRAGMA statements (like `PRAGMA table_info()` or `PRAGMA index_list()`) cannot accept bound parameters (`?`). Using f-strings to pass table names directly into `exec_driver_sql` or `execute` allows SQL injection if the table name is unvalidated. Even inside migration scripts, missing quoting leads to unintended behavior and potential injection.
+**Learning:** SQLite identifiers and PRAGMA arguments must be manually quoted. Furthermore, any dynamic inputs that define table names should be validated against a strict allowlist.
+**Prevention:**
+1. Always enclose dynamic table names in single quotes within `PRAGMA` statements: `PRAGMA table_info('{table_name}')`.
+2. When creating migration helpers that accept a table name dynamically, enforce an allowlist check before interpolating the string.

--- a/src/wet_mcp/alembic/versions/docs_002_libraries.py
+++ b/src/wet_mcp/alembic/versions/docs_002_libraries.py
@@ -43,14 +43,18 @@ logger = logging.getLogger("alembic.runtime.migration")
 
 
 def _existing_columns(table: str) -> set[str]:
+    if table not in ("libraries", "versions", "doc_chunks"):
+        raise ValueError(f"Invalid table: {table}")
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    rows = bind.exec_driver_sql(f"PRAGMA table_info('{table}')").fetchall()
     return {row[1] for row in rows}
 
 
 def _existing_indexes(table: str) -> set[str]:
+    if table not in ("libraries", "versions", "doc_chunks"):
+        raise ValueError(f"Invalid table: {table}")
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA index_list({table})").fetchall()
+    rows = bind.exec_driver_sql(f"PRAGMA index_list('{table}')").fetchall()
     return {row[1] for row in rows}
 
 

--- a/src/wet_mcp/alembic/versions/docs_004_chunk_summaries.py
+++ b/src/wet_mcp/alembic/versions/docs_004_chunk_summaries.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
     existing_cols = {
         row[1]
         for row in op.get_bind()
-        .exec_driver_sql("PRAGMA table_info(doc_chunks)")
+        .exec_driver_sql("PRAGMA table_info('doc_chunks')")
         .fetchall()
     }
     if "summary" not in existing_cols:

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -494,7 +494,7 @@ class DocsDB:
         # presence once per call so we don't crash on older schemas.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute("PRAGMA table_info('libraries')").fetchall()
         }
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
@@ -617,7 +617,7 @@ class DocsDB:
         """
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute("PRAGMA table_info('libraries')").fetchall()
         }
         sets: list[str] = []
         params: list = []
@@ -750,7 +750,7 @@ class DocsDB:
         # Detect optional columns once so we can branch on a single INSERT.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
+            for r in self._conn.execute("PRAGMA table_info('doc_chunks')").fetchall()
         }
         phase2_cols = [
             c

--- a/uv.lock
+++ b/uv.lock
@@ -3573,7 +3573,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4"
+version = "3.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR addresses an issue where SQLite `PRAGMA` statements (`PRAGMA table_info` and `PRAGMA index_list`) were being constructed using f-strings with unquoted table names and passed to `exec_driver_sql` and `execute`. Since `PRAGMA` statements do not accept parameter binding (i.e., `?`), unvalidated dynamic strings represent an SQL injection vulnerability (even if currently used safely in migration scripts).

We fixed this by:
1. Validating dynamically provided table names against an explicit allowlist in `src/wet_mcp/alembic/versions/docs_002_libraries.py`.
2. Enclosing table names inside single quotes (`'...'`) in `PRAGMA` statement formatting across `db.py`, `docs_002_libraries.py`, and `docs_004_chunk_summaries.py` to ensure syntactical safety and consistency.
3. Adding a new entry to the `.jules/sentinel.md` journal describing the vulnerability, learnings, and preventative measures.

---
*PR created automatically by Jules for task [4072724818608547407](https://jules.google.com/task/4072724818608547407) started by @n24q02m*