### PR TITLE
fix: correct docs drift (tool count, version framing, dead links)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,23 +76,18 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ### Types
 
+Only `feat` and `fix` are accepted. The pre-commit commit-message hook
+(`scripts/enforce-commit.sh`) rejects any other type (e.g. `docs`,
+`chore`, `refactor`, `ci`). Do not use the `!` breaking-change marker.
+
 - `feat`: New feature
 - `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
-- `ci`: CI/CD changes
-- `build`: Build system changes
 
 ### Examples
 
 ```text
 feat: add support for PDF extraction
 fix: handle SearXNG connection timeout
-docs: update configuration examples
 ```
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ mcp-name: io.github.n24q02m/wet-mcp
 |---|---|---|
 | Phase 1 | Shipped | web-core ScrapingAgent migration, smart chunks output, search polish, media slim |
 | Phase 2 | Shipped | Context7-level docs search: library index (Tier 1 + Tier 2), version-aware queries with token cap, project lock (Cabinets) |
-| Phase 3 | **Current (BREAKING v2.0.0)** | `extract.agent` multi-step research with cited synthesis, `extract.interact` click/fill/submit via patchright (optional session persistence), `docs_004_chunk_summaries` migration, **`media.analyze` removed** |
+| Phase 3 | **Shipped** | `extract.agent` multi-step research with cited synthesis, `extract.interact` click/fill/submit via patchright (optional session persistence), `docs_004_chunk_summaries` migration, **`media.analyze` removed (v2.0.0)** |
 
-> **BREAKING in v2.0.0** -- `media(action="analyze")` was removed entirely.
-> Use [`imagine-mcp`](https://github.com/n24q02m/imagine-mcp)'s
+> **Current release: v3.x.** `media(action="analyze")` was removed in the
+> v2.0.0 BREAKING release. Use
+> [`imagine-mcp`](https://github.com/n24q02m/imagine-mcp)'s
 > `understand` action for vision/audio/video analysis. See
 > [`docs/migration.md`](docs/migration.md) for the upgrade recipe.
 
@@ -129,7 +130,7 @@ and the paste-to-agent snippets at
 
 ## Documentation
 
-Full docs at **[mcp.n24q02m.com/servers/wet-mcp/](https://mcp.n24q02m.com/servers/wet-mcp/)**:
+Full docs at **[mcp.n24q02m.com/servers/wet-mcp/setup/](https://mcp.n24q02m.com/servers/wet-mcp/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/wet-mcp/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
 - [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
@@ -148,8 +149,8 @@ In-repo references (Spec F single source of truth: setup docs live in
 
 ## Tools
 
-5 MCP tools (3 domain + `config` + `help`). The legacy `setup` tool merged
-into `config` action dispatch.
+6 MCP tools (3 domain + `config` + `help` + `config__open_relay`). The legacy
+`setup` tool merged into `config` action dispatch.
 
 | Tool | Description |
 |:-----|:------------|
@@ -158,6 +159,7 @@ into `config` action dispatch.
 | `media` | `list` (discover URLs from gallery pages), `download` (SSRF-safe). `analyze` deprecated v&lt;auto&gt;+ -- forwards to `imagine-mcp.understand` |
 | `config` | `status`, `set`, `cache_clear`, `docs_reindex`, `warmup`, `setup_sync`, `setup_status`, `setup_skip`, `setup_reset`, `setup_complete` |
 | `help` | Per-tool documentation: `search`, `extract`, `media`, `config` |
+| `config__open_relay` | Re-trigger the zero-config relay setup flow (prints a fresh relay URL for the browser form). Registered via `mcp-core`'s `register_open_relay_tool` so an LLM can restart setup without a manual restart. |
 
 > **Media boundary**: For vision / audio understanding (image captioning,
 > OCR, audio transcription, video summarization), use
@@ -196,7 +198,7 @@ uv run wet-mcp
 
 ## Trust Model
 
-This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core trust model](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.x.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 3.x.x   | :white_check_mark: |
+| < 3.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -313,4 +313,4 @@ Reserved for the future LLM-enhanced summaries feature.
 - Web-core repo: `n24q02m/web-core` (`web_core.scraper.ScrapingAgent`,
   future `web_core.browsers.patchright.InteractOps`)
 - mcp-core repo: `n24q02m/mcp-core` (relay, JWT issuer, config storage primitives)
-- Trust model: <https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md>
+- Trust model: <https://mcp.n24q02m.com/servers/mcp-core/trust-model/>


### PR DESCRIPTION
Part of the multi-repo docs audit. All findings verified against actual code/release state before editing.

## Findings + status

1. **Tool-count drift 5 -> 6 (FIXED)** — source registers 5 `@mcp.tool` decorators (`search`, `extract`, `media`, `help`, `config`) plus `config__open_relay` via `register_open_relay_tool` (server.py:606) = 6. Updated README count line and added `config__open_relay` row to the Tools table. (Feature line "5-strategy web search" refers to extraction strategies, left as-is.)
2. **SECURITY.md supported versions stale (FIXED)** — listed `1.x`; current major is `3.x` (latest release v3.2.6). Updated to `3.x.x` / `< 3.0`.
3. **v2.0.0 stale-current framing (FIXED)** — README Phase 3 row said "Current (BREAKING v2.0.0)" and Status callout framed v2.0.0 as current; actual current is v3.x. Reframed to "Shipped" + "Current release: v3.x" while preserving the historical fact that `media.analyze` was removed in v2.0.0. No changelog fabricated.
4. **Missing `docker-compose.yml` base (NOT APPLICABLE)** — no doc, Makefile, or config references a base `docker-compose.yml`; repo ships only `docker-compose.http.yml`. Sibling repos (mnemo-mcp, imagine-mcp) follow the same `*.http.yml`-only pattern, so there is no canonical base file to add and no doc to correct. No change.
5. **Dead links (FIXED)** — `mcp-core/docs/TRUST-MODEL.md` returns 404 (mcp-core has only `docs/README.md`); replaced with canonical docs-site `https://mcp.n24q02m.com/servers/mcp-core/trust-model/` (200, matches imagine-mcp/better-notion-mcp) in README + docs/ARCHITECTURE.md. Bare docs-site server-root `https://mcp.n24q02m.com/servers/wet-mcp/` returns 404; replaced with the `/setup/` leaf (200, matches imagine-mcp's "Full docs at" pattern). All links curl-verified.
6. **CONTRIBUTING commit-type list (FIXED)** — listed docs/style/refactor/perf/test/chore/ci/build, contradicting `scripts/enforce-commit.sh` which accepts only `feat`/`fix` (+ PSR `chore(release):`). Trimmed to feat/fix-only with a note pointing at the hook.

## Files changed
- `README.md`
- `SECURITY.md`
- `CONTRIBUTING.md`
- `docs/ARCHITECTURE.md`

ruff check + ruff format --check pass; commit-msg hook passed (feat/fix prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)