### PR TITLE
[TEST] Missing test file for relay_schema.py

### DIFF
--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import typing
 from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ConfigData(BaseModel):
+    token: str = Field(..., description="The API token")
+
 
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "wet-mcp",

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,0 +1,61 @@
+"""Tests for relay schema definition."""
+
+import pytest
+from pydantic import ValidationError
+
+from wet_mcp.relay_schema import RELAY_SCHEMA, ConfigData
+
+
+class TestRelaySchema:
+    """Tests for relay schema definition."""
+
+    def test_schema_has_flat_fields(self):
+        """Schema uses flat fields structure (not modes)."""
+        assert "fields" in RELAY_SCHEMA
+        assert "modes" not in RELAY_SCHEMA
+
+    def test_schema_has_five_provider_fields(self):
+        fields = RELAY_SCHEMA["fields"]
+        assert len(fields) == 5
+
+    def test_schema_field_keys(self):
+        field_keys = [f["key"] for f in RELAY_SCHEMA["fields"]]
+        assert "JINA_AI_API_KEY" in field_keys
+        assert "GEMINI_API_KEY" in field_keys
+        assert "OPENAI_API_KEY" in field_keys
+        assert "COHERE_API_KEY" in field_keys
+        assert "GITHUB_TOKEN" in field_keys
+
+    def test_schema_server_name(self):
+        assert RELAY_SCHEMA["server"] == "wet-mcp"
+
+    def test_schema_display_name(self):
+        assert RELAY_SCHEMA["displayName"] == "Web Extended Toolkit"
+
+    def test_all_fields_optional(self):
+        for f in RELAY_SCHEMA["fields"]:
+            assert f.get("required") is False
+
+    def test_capability_info_present(self):
+        assert "capabilityInfo" in RELAY_SCHEMA
+        assert len(RELAY_SCHEMA["capabilityInfo"]) == 5
+        labels = [c["label"] for c in RELAY_SCHEMA["capabilityInfo"]]
+        assert "Search" in labels
+        assert "Extraction" in labels
+        assert "Embedding" in labels
+        assert "Reranking" in labels
+        assert "LLM" in labels
+
+
+class TestConfigData:
+    """Tests for ConfigData Pydantic model."""
+
+    def test_config_data_valid_token(self):
+        """Verify successful instantiation with a token string."""
+        config = ConfigData(token="test_token")
+        assert config.token == "test_token"
+
+    def test_config_data_invalid_token(self):
+        """Verify that a missing token triggers a Pydantic validation error."""
+        with pytest.raises(ValidationError):
+            ConfigData()  # type: ignore

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -16,47 +16,6 @@ from wet_mcp.relay_setup import (
 TEST_RELAY_URL = "https://relay.example.com"
 
 
-class TestRelaySchema:
-    """Tests for relay schema definition."""
-
-    def test_schema_has_flat_fields(self):
-        """Schema uses flat fields structure (not modes)."""
-        assert "fields" in RELAY_SCHEMA
-        assert "modes" not in RELAY_SCHEMA
-
-    def test_schema_has_five_provider_fields(self):
-        fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 5
-
-    def test_schema_field_keys(self):
-        field_keys = [f["key"] for f in RELAY_SCHEMA["fields"]]
-        assert "JINA_AI_API_KEY" in field_keys
-        assert "GEMINI_API_KEY" in field_keys
-        assert "OPENAI_API_KEY" in field_keys
-        assert "COHERE_API_KEY" in field_keys
-        assert "GITHUB_TOKEN" in field_keys
-
-    def test_schema_server_name(self):
-        assert RELAY_SCHEMA["server"] == "wet-mcp"
-
-    def test_schema_display_name(self):
-        assert RELAY_SCHEMA["displayName"] == "Web Extended Toolkit"
-
-    def test_all_fields_optional(self):
-        for f in RELAY_SCHEMA["fields"]:
-            assert f.get("required") is False
-
-    def test_capability_info_present(self):
-        assert "capabilityInfo" in RELAY_SCHEMA
-        assert len(RELAY_SCHEMA["capabilityInfo"]) == 5
-        labels = [c["label"] for c in RELAY_SCHEMA["capabilityInfo"]]
-        assert "Search" in labels
-        assert "Extraction" in labels
-        assert "Embedding" in labels
-        assert "Reranking" in labels
-        assert "LLM" in labels
-
-
 class TestLoadConfigFromFile:
     """Tests for load_config_from_file."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -3573,7 +3573,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4"
+version = "3.2.7b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This PR adds missing test coverage for `src/wet_mcp/relay_schema.py`.

Key changes:
- Implemented the `ConfigData` Pydantic model in `src/wet_mcp/relay_schema.py` as specified in the task.
- Created a new test file `tests/test_relay_schema.py` containing:
    - Tests for the `RELAY_SCHEMA` configuration dictionary (moved from `tests/test_relay_setup.py`).
    - New tests for the `ConfigData` model to verify valid token instantiation and validation errors for missing tokens.
- Refactored `tests/test_relay_setup.py` to remove the redundant `TestRelaySchema` class, improving test suite organization.
- Verified that `src/wet_mcp/relay_schema.py` now has 100% test coverage.

All existing and new tests passed successfully.

---
*PR created automatically by Jules for task [17774616843729014078](https://jules.google.com/task/17774616843729014078) started by @n24q02m*