### PR TITLE
[PERF] Sequential async API calls instead of gather

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -348,20 +348,25 @@ class CloudEmbeddingBackend:
             return await self._embed_batch_inner(texts, dimensions)
 
         # Split into batches
-        all_embeddings: list[list[float]] = []
         total_batches = (len(texts) + self.MAX_BATCH_SIZE - 1) // self.MAX_BATCH_SIZE
         logger.info(
             f"Splitting {len(texts)} texts into {total_batches} batches "
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
             batch_num = i // self.MAX_BATCH_SIZE + 1
             logger.debug(
-                f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
+                f"Queueing batch {batch_num}/{total_batches}: {len(batch)} texts"
             )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(self._embed_batch_inner(batch, dimensions))
+
+        results = await asyncio.gather(*tasks)
+
+        all_embeddings: list[list[float]] = []
+        for batch_result in results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -174,6 +174,34 @@ class TestCloudEmbeddingBackend:
             with pytest.raises(Exception, match="Invalid model"):
                 await backend.embed_texts(["test"])
 
+    async def test_embed_texts_multiple_batches(self):
+        """Correctly splits into batches and combines results."""
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
+        # Override batch size for easier testing
+        backend.MAX_BATCH_SIZE = 2
+
+        texts = ["t1", "t2", "t3", "t4", "t5"]
+        # Expected results for 3 batches
+        expected_results = [
+            [[0.1, 0.1], [0.2, 0.2]],
+            [[0.3, 0.3], [0.4, 0.4]],
+            [[0.5, 0.5]],
+        ]
+
+        with patch.object(
+            backend,
+            "_embed_batch_inner",
+            new_callable=AsyncMock,
+            side_effect=expected_results,
+        ) as mock_inner:
+            vecs = await backend.embed_texts(texts)
+
+        assert len(vecs) == 5
+        assert vecs[0] == [0.1, 0.1]
+        assert vecs[2] == [0.3, 0.3]
+        assert vecs[4] == [0.5, 0.5]
+        assert mock_inner.call_count == 3
+
     async def test_embed_single_success(self):
         """Single text embedding returns one vector."""
         backend = CloudEmbeddingBackend("text-embedding-3-small")


### PR DESCRIPTION
Optimizes the embedding process in `CloudEmbeddingBackend.embed_texts` by processing batches in parallel using `asyncio.gather` instead of sequentially. This change improves throughput for large embedding requests while maintaining result order and utilizing the existing retry logic in `_embed_batch_inner`.

---
*PR created automatically by Jules for task [6322271647701614110](https://jules.google.com/task/6322271647701614110) started by @n24q02m*