### PR TITLE
[SECURITY] SQL Injection in db.py (execute replace format)

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -1064,24 +1064,27 @@ class DocsDB:
             # This avoids the N+1 query problem by batching multiple (url, version_id, chunk_index) tuples.
             # We use sorted(set()) to ensure uniqueness and improve cache locality.
             _unique_keys = sorted(set(_adj_keys))
-            _batch_size = (
-                32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
-            ) // 3
+            # ⚡ Bolt Optimization: Use json_each(?) to avoid dynamic SQL placeholder generation.
+            # Batch size set to 1000 to balance memory and query overhead.
+            _batch_size = 1000
 
             for i in range(0, len(_unique_keys), _batch_size):
                 _batch = _unique_keys[i : i + _batch_size]
-                _placeholders = ",".join(["(?,?,?)"] * len(_batch))
-                _params = [item for key_tuple in _batch for item in key_tuple]
 
-                # Security: Placeholders are constructed from static tokens (?,?,?)
-                # and strictly separated from the query structure.
-                sql = (
-                    "SELECT url, version_id, chunk_index, content "
-                    "FROM doc_chunks "
-                    "WHERE (url, version_id, chunk_index) IN (" + _placeholders + ")"
-                )
+                # ⚡ Bolt Optimization: Use json_each(?) to avoid dynamic SQL placeholder generation.
+                # Row-value IN with json_each requires extracting each tuple element.
+                sql = """
+                    SELECT url, version_id, chunk_index, content
+                    FROM doc_chunks
+                    WHERE (url, version_id, chunk_index) IN (
+                        SELECT json_extract(value, '$[0]'),
+                               json_extract(value, '$[1]'),
+                               json_extract(value, '$[2]')
+                        FROM json_each(?)
+                    )
+                """
                 # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                rows = self._conn.execute(sql, _params).fetchall()
+                rows = self._conn.execute(sql, (json.dumps(_batch),)).fetchall()
                 for r in rows:
                     _adj_map[(r["url"], r["version_id"], r["chunk_index"])] = r[
                         "content"
@@ -1220,9 +1223,16 @@ class DocsDB:
 
         def _get_existing(table: str, items: list) -> set:
             allowed_queries = {
-                "libraries": "SELECT id FROM libraries WHERE id IN ({})",
-                "versions": "SELECT id FROM versions WHERE id IN ({})",
-                "doc_chunks": "SELECT id FROM doc_chunks WHERE id IN ({})",
+                "libraries": (
+                    "SELECT id FROM libraries WHERE id IN (SELECT value FROM json_each(?))"
+                ),
+                "versions": (
+                    "SELECT id FROM versions WHERE id IN (SELECT value FROM json_each(?))"
+                ),
+                "doc_chunks": (
+                    "SELECT id FROM doc_chunks "
+                    "WHERE id IN (SELECT value FROM json_each(?))"
+                ),
             }
             if table not in allowed_queries:
                 raise ValueError(f"Invalid table name: {table}")
@@ -1230,15 +1240,15 @@ class DocsDB:
                 return set()
             ids = [obj["id"] for obj in items]
             existing = set()
-            batch_size = 32766 if sqlite3.sqlite_version_info >= (3, 32, 0) else 999
+            # ⚡ Bolt Optimization: Use json_each(?) to avoid dynamic SQL placeholder generation.
+            # Batch size set to 1000 to balance memory and query overhead.
+            batch_size = 1000
             for i in range(0, len(ids), batch_size):
                 batch = ids[i : i + batch_size]
-                placeholders = ",".join("?" * len(batch))
-                # Safe because table is strictly validated against allowlist
-                # and placeholders string contains only static "?" and ",".
-                query = allowed_queries[table].replace("{}", placeholders)
                 # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-                res = self._conn.execute(query, batch).fetchall()
+                res = self._conn.execute(
+                    allowed_queries[table], (json.dumps(batch),)
+                ).fetchall()
                 existing.update(r[0] for r in res)
             return existing
 


### PR DESCRIPTION
This PR addresses a potential SQL injection vulnerability in `src/wet_mcp/db.py` identified by security analysis.

### Changes:
- Refactored `_get_existing` in `import_jsonl` to use `json_each(?)` for batch ID lookups instead of dynamic string replacement for placeholders.
- Refactored the row-value `IN` clause in the `search` method (used for prefetching adjacent chunks) to use `json_each(?)` combined with `json_extract`.
- Standardized batch sizes to 1000 items to balance memory usage and query overhead.

### Security Impact:
The vulnerability involved using `.replace("{}", placeholders)` where `placeholders` was a dynamically generated string of `?,?` tokens. While the tokens themselves were static, the pattern is flagged as unsafe. By switching to `json_each(?)`, the query structure becomes completely static, and all data is passed through standard SQLite parameter binding, providing robust protection against SQL injection.

### Verification:
- Ran `uv run pytest tests/test_security_sql.py tests/test_db.py` (and other related db tests). All tests passed.
- Ran `uv run ruff check src/wet_mcp/db.py`. No linting issues found.
- Manually verified SQLite `json_each` support in the environment.

---
*PR created automatically by Jules for task [17658658062905637267](https://jules.google.com/task/17658658062905637267) started by @n24q02m*