### PR TITLE
[FIX] Unused import: _MAX_RESTART_ATTEMPTS

### DIFF
--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -81,7 +81,6 @@ _wc_runner._find_available_port = _find_available_port  # type: ignore[assignmen
 from web_core.search.runner import (  # noqa: F401, E402
     _DISCOVERY_FILE,
     _HEALTH_CHECK_TIMEOUT,
-    _MAX_RESTART_ATTEMPTS,
     _RESTART_COOLDOWN,
     _STARTUP_HEALTH_TIMEOUT,
     _cleanup_process,


### PR DESCRIPTION
Removed _MAX_RESTART_ATTEMPTS from the re-export list in src/wet_mcp/searxng_runner.py because it was unused throughout the repository. This is a safe change with no functional impact and cleans up the code.

---
*PR created automatically by Jules for task [17987510136501859406](https://jules.google.com/task/17987510136501859406) started by @n24q02m*