### PR TITLE
[SECURITY] SQL Injection in execute (ALTER TABLE versions)

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -285,20 +285,31 @@ class DocsDB:
         # Idempotent column adds for legacy DBs that pre-date Alembic.
         # Each ALTER is wrapped in a try/except so re-running on a fresh
         # head-shape table does not raise.
-        for col_ddl in (
-            "discovery_version INTEGER DEFAULT 0",
-            "canonical_name TEXT",
-            "homepage TEXT",
-            "github_url TEXT",
-            "package_managers TEXT",
-            "tier INTEGER NOT NULL DEFAULT 2",
-            "last_indexed_at REAL",
-            "total_versions INTEGER NOT NULL DEFAULT 0",
+        for col_name, sql in (
+            (
+                "discovery_version",
+                "ALTER TABLE libraries ADD COLUMN discovery_version INTEGER DEFAULT 0",
+            ),
+            ("canonical_name", "ALTER TABLE libraries ADD COLUMN canonical_name TEXT"),
+            ("homepage", "ALTER TABLE libraries ADD COLUMN homepage TEXT"),
+            ("github_url", "ALTER TABLE libraries ADD COLUMN github_url TEXT"),
+            (
+                "package_managers",
+                "ALTER TABLE libraries ADD COLUMN package_managers TEXT",
+            ),
+            (
+                "tier",
+                "ALTER TABLE libraries ADD COLUMN tier INTEGER NOT NULL DEFAULT 2",
+            ),
+            ("last_indexed_at", "ALTER TABLE libraries ADD COLUMN last_indexed_at REAL"),
+            (
+                "total_versions",
+                "ALTER TABLE libraries ADD COLUMN total_versions INTEGER NOT NULL DEFAULT 0",
+            ),
         ):
             try:
-                self._conn.execute(f"ALTER TABLE libraries ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
-                col_name = col_ddl.split()[0]
                 logger.debug(f"Migrated libraries table: added {col_name}")
             except sqlite3.OperationalError:
                 pass  # Column already exists
@@ -322,9 +333,12 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in ("release_date REAL", "source_url TEXT"):
+        for sql in (
+            "ALTER TABLE versions ADD COLUMN release_date REAL",
+            "ALTER TABLE versions ADD COLUMN source_url TEXT",
+        ):
             try:
-                self._conn.execute(f"ALTER TABLE versions ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass
@@ -351,14 +365,14 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in (
-            "section TEXT",
-            "topic TEXT",
-            "content_hash TEXT",
-            "token_count INTEGER",
+        for sql in (
+            "ALTER TABLE doc_chunks ADD COLUMN section TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN topic TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN content_hash TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN token_count INTEGER",
         ):
             try:
-                self._conn.execute(f"ALTER TABLE doc_chunks ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -301,7 +301,10 @@ class DocsDB:
                 "tier",
                 "ALTER TABLE libraries ADD COLUMN tier INTEGER NOT NULL DEFAULT 2",
             ),
-            ("last_indexed_at", "ALTER TABLE libraries ADD COLUMN last_indexed_at REAL"),
+            (
+                "last_indexed_at",
+                "ALTER TABLE libraries ADD COLUMN last_indexed_at REAL",
+            ),
             (
                 "total_versions",
                 "ALTER TABLE libraries ADD COLUMN total_versions INTEGER NOT NULL DEFAULT 0",


### PR DESCRIPTION
This PR fixes a potential SQL injection vulnerability in `src/wet_mcp/db.py` by replacing dynamic SQL construction (f-strings) in `ALTER TABLE` statements with explicit, hardcoded statements. This affects idempotent legacy schema upgrades in `_create_libraries_table`, `_create_versions_table`, and `_create_doc_chunks_table`. Existing functionality and idempotency for legacy databases are preserved. Verified with reproduction tests and the full test suite.

---
*PR created automatically by Jules for task [13263461060742442778](https://jules.google.com/task/13263461060742442778) started by @n24q02m*