### PR TITLE
[SECURITY] SQL Injection in execute (ALTER TABLE libraries)

### DIFF
--- a/src/wet_mcp/alembic/versions/docs_002_libraries.py
+++ b/src/wet_mcp/alembic/versions/docs_002_libraries.py
@@ -62,6 +62,10 @@ def upgrade() -> None:
     """Add Phase 2 columns idempotently + backfill key fields."""
     # libraries
     lib_cols = _existing_columns("libraries")
+    if "discovery_version" not in lib_cols:
+        op.execute(
+            "ALTER TABLE libraries ADD COLUMN discovery_version INTEGER DEFAULT 0"
+        )
     if "canonical_name" not in lib_cols:
         op.execute("ALTER TABLE libraries ADD COLUMN canonical_name TEXT")
     if "homepage" not in lib_cols:

--- a/src/wet_mcp/alembic/versions/docs_002_libraries.py
+++ b/src/wet_mcp/alembic/versions/docs_002_libraries.py
@@ -43,36 +43,41 @@ logger = logging.getLogger("alembic.runtime.migration")
 
 
 def _existing_columns(table: str) -> set[str]:
+    if table not in ("libraries", "versions", "doc_chunks"):
+        raise ValueError(f"Invalid table name for column check: {table}")
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    rows = bind.exec_driver_sql(f"PRAGMA table_info('{table}')").fetchall()
     return {row[1] for row in rows}
 
 
 def _existing_indexes(table: str) -> set[str]:
+    if table not in ("libraries", "versions", "doc_chunks"):
+        raise ValueError(f"Invalid table name for index check: {table}")
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA index_list({table})").fetchall()
+    rows = bind.exec_driver_sql(f"PRAGMA index_list('{table}')").fetchall()
     return {row[1] for row in rows}
-
-
-def _add_column_if_missing(table: str, name: str, ddl: str) -> None:
-    if name not in _existing_columns(table):
-        op.execute(f"ALTER TABLE {table} ADD COLUMN {ddl}")
-    else:
-        logger.info(f"docs_002: {table}.{name} already present, skipping")
 
 
 def upgrade() -> None:
     """Add Phase 2 columns idempotently + backfill key fields."""
     # libraries
-    _add_column_if_missing("libraries", "canonical_name", "canonical_name TEXT")
-    _add_column_if_missing("libraries", "homepage", "homepage TEXT")
-    _add_column_if_missing("libraries", "github_url", "github_url TEXT")
-    _add_column_if_missing("libraries", "package_managers", "package_managers TEXT")
-    _add_column_if_missing("libraries", "tier", "tier INTEGER NOT NULL DEFAULT 2")
-    _add_column_if_missing("libraries", "last_indexed_at", "last_indexed_at REAL")
-    _add_column_if_missing(
-        "libraries", "total_versions", "total_versions INTEGER NOT NULL DEFAULT 0"
-    )
+    lib_cols = _existing_columns("libraries")
+    if "canonical_name" not in lib_cols:
+        op.execute("ALTER TABLE libraries ADD COLUMN canonical_name TEXT")
+    if "homepage" not in lib_cols:
+        op.execute("ALTER TABLE libraries ADD COLUMN homepage TEXT")
+    if "github_url" not in lib_cols:
+        op.execute("ALTER TABLE libraries ADD COLUMN github_url TEXT")
+    if "package_managers" not in lib_cols:
+        op.execute("ALTER TABLE libraries ADD COLUMN package_managers TEXT")
+    if "tier" not in lib_cols:
+        op.execute("ALTER TABLE libraries ADD COLUMN tier INTEGER NOT NULL DEFAULT 2")
+    if "last_indexed_at" not in lib_cols:
+        op.execute("ALTER TABLE libraries ADD COLUMN last_indexed_at REAL")
+    if "total_versions" not in lib_cols:
+        op.execute(
+            "ALTER TABLE libraries ADD COLUMN total_versions INTEGER NOT NULL DEFAULT 0"
+        )
 
     # Backfill canonical_name + last_indexed_at for pre-existing rows.
     op.execute(
@@ -84,14 +89,22 @@ def upgrade() -> None:
     )
 
     # versions
-    _add_column_if_missing("versions", "release_date", "release_date REAL")
-    _add_column_if_missing("versions", "source_url", "source_url TEXT")
+    ver_cols = _existing_columns("versions")
+    if "release_date" not in ver_cols:
+        op.execute("ALTER TABLE versions ADD COLUMN release_date REAL")
+    if "source_url" not in ver_cols:
+        op.execute("ALTER TABLE versions ADD COLUMN source_url TEXT")
 
     # doc_chunks
-    _add_column_if_missing("doc_chunks", "section", "section TEXT")
-    _add_column_if_missing("doc_chunks", "topic", "topic TEXT")
-    _add_column_if_missing("doc_chunks", "content_hash", "content_hash TEXT")
-    _add_column_if_missing("doc_chunks", "token_count", "token_count INTEGER")
+    chunk_cols = _existing_columns("doc_chunks")
+    if "section" not in chunk_cols:
+        op.execute("ALTER TABLE doc_chunks ADD COLUMN section TEXT")
+    if "topic" not in chunk_cols:
+        op.execute("ALTER TABLE doc_chunks ADD COLUMN topic TEXT")
+    if "content_hash" not in chunk_cols:
+        op.execute("ALTER TABLE doc_chunks ADD COLUMN content_hash TEXT")
+    if "token_count" not in chunk_cols:
+        op.execute("ALTER TABLE doc_chunks ADD COLUMN token_count INTEGER")
 
     if "idx_doc_chunks_lib_ver_topic" not in _existing_indexes("doc_chunks"):
         op.execute(

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -300,6 +300,7 @@ class DocsDB:
                 UNIQUE(library_id, version)
             )
         """)
+
     def _create_doc_chunks_table(self) -> None:
         # Document chunks (Phase 2 schema with section/topic/content_hash/token_count).
         self._conn.execute("""

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -282,27 +282,6 @@ class DocsDB:
             ON libraries(name)
         """)
 
-        # Idempotent column adds for legacy DBs that pre-date Alembic.
-        # Each ALTER is wrapped in a try/except so re-running on a fresh
-        # head-shape table does not raise.
-        for col_ddl in (
-            "discovery_version INTEGER DEFAULT 0",
-            "canonical_name TEXT",
-            "homepage TEXT",
-            "github_url TEXT",
-            "package_managers TEXT",
-            "tier INTEGER NOT NULL DEFAULT 2",
-            "last_indexed_at REAL",
-            "total_versions INTEGER NOT NULL DEFAULT 0",
-        ):
-            try:
-                self._conn.execute(f"ALTER TABLE libraries ADD COLUMN {col_ddl}")
-                self._conn.commit()
-                col_name = col_ddl.split()[0]
-                logger.debug(f"Migrated libraries table: added {col_name}")
-            except sqlite3.OperationalError:
-                pass  # Column already exists
-
     def _create_versions_table(self) -> None:
         # Versions (Phase 2 schema with release_date + source_url).
         self._conn.execute("""
@@ -321,14 +300,6 @@ class DocsDB:
                 UNIQUE(library_id, version)
             )
         """)
-        # Idempotent column adds for legacy DBs.
-        for col_ddl in ("release_date REAL", "source_url TEXT"):
-            try:
-                self._conn.execute(f"ALTER TABLE versions ADD COLUMN {col_ddl}")
-                self._conn.commit()
-            except sqlite3.OperationalError:
-                pass
-
     def _create_doc_chunks_table(self) -> None:
         # Document chunks (Phase 2 schema with section/topic/content_hash/token_count).
         self._conn.execute("""
@@ -350,18 +321,6 @@ class DocsDB:
                 FOREIGN KEY (library_id) REFERENCES libraries(id) ON DELETE CASCADE
             )
         """)
-        # Idempotent column adds for legacy DBs.
-        for col_ddl in (
-            "section TEXT",
-            "topic TEXT",
-            "content_hash TEXT",
-            "token_count INTEGER",
-        ):
-            try:
-                self._conn.execute(f"ALTER TABLE doc_chunks ADD COLUMN {col_ddl}")
-                self._conn.commit()
-            except sqlite3.OperationalError:
-                pass
         self._conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_chunks_version
             ON doc_chunks(version_id)


### PR DESCRIPTION
This PR fixes a SQL injection vulnerability in `src/wet_mcp/db.py` and the associated Alembic migration `docs_002_libraries.py`. 

### Changes:
- **`src/wet_mcp/db.py`**: Removed the legacy "idempotent column add" loops in `_create_libraries_table`, `_create_versions_table`, and `_create_doc_chunks_table`. These loops used f-strings to dynamically build `ALTER TABLE` statements. They are no longer necessary because fresh databases are created with the full current schema, and existing databases are upgraded via Alembic.
- **`src/wet_mcp/alembic/versions/docs_002_libraries.py`**: 
    - Hardened `_existing_columns` and `_existing_indexes` by adding a strict table name allowlist and manually quoting the table name in the `PRAGMA` call.
    - Refactored `upgrade()` to use explicit, hardcoded `ALTER TABLE` statements instead of a generic helper function with f-strings.

These changes eliminate the risk of SQL injection while maintaining full compatibility with both fresh and legacy databases.

---
*PR created automatically by Jules for task [13614341905859664443](https://jules.google.com/task/13614341905859664443) started by @n24q02m*