### PR TITLE
feat: migrate LLM/embedding/rerank to litellm passthrough via mcp-core[llm]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ mise run dev       # uv run wet-mcp
 ## Env vars
 
 - KHONG co prefix ung dung (day la open-source MCP server)
-- LLM: google-genai + openai (SDK) > disable if no key. Embed/Rerank: Jina > Gemini > OpenAI > Cohere (cloud) > local ONNX
+- LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]) > disable if no key. Embed/Rerank priority: Jina > Gemini > OpenAI > Cohere (cloud) > local ONNX. Custom endpoint: `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
 - Embedding: `EMBEDDING_BACKEND`, `EMBEDDING_MODEL`
 - Reranking: `RERANK_BACKEND`, `RERANK_MODEL`
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ mise run dev       # uv run wet-mcp
 ## Env vars
 
 - KHONG co prefix ung dung (day la open-source MCP server)
-- LLM: google-genai + openai (SDK) > disable if no key. Embed/Rerank: Jina > Gemini > OpenAI > Cohere (cloud) > local ONNX
+- LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]) > disable if no key. Embed/Rerank priority: Jina > Gemini > OpenAI > Cohere (cloud) > local ONNX. Custom endpoint: `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
 - Embedding: `EMBEDDING_BACKEND`, `EMBEDDING_MODEL`
 - Reranking: `RERANK_BACKEND`, `RERANK_MODEL`
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ wet-mcp/
 │       ├── server.py          # MCP server
 │       ├── searxng_runner.py   # Embedded SearXNG subprocess
 │       ├── setup.py           # Auto-setup (SearXNG + Playwright)
-│       ├── llm.py             # LLM utilities (LiteLLM)
+│       ├── llm.py             # LLM utilities (litellm passthrough via mcp-core[llm])
 │       ├── security.py        # URL security validation
 │       ├── docs/              # Tool documentation (Markdown)
 │       └── sources/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,12 +134,15 @@ wet-mcp does not pin a default LLM model. Provider selection at runtime
 walks env vars in priority order:
 
 ```text
-GEMINI_API_KEY / GOOGLE_API_KEY  -> google-genai SDK
-OPENAI_API_KEY                   -> openai SDK
-ANTHROPIC_API_KEY                -> anthropic SDK
-XAI_API_KEY                      -> openai SDK (with base_url override)
+GEMINI_API_KEY / GOOGLE_API_KEY  -> gemini/* (litellm passthrough)
+OPENAI_API_KEY                   -> openai/* (litellm passthrough)
+XAI_API_KEY                      -> xai/* (litellm passthrough)
 LLM_MODELS env                   -> explicit comma-separated fallback chain
+LLM_API_BASE env                 -> custom OpenAI-compatible endpoint
 ```
+
+All calls dispatch through `mcp_core.llm` (litellm passthrough via the
+`mcp-core[llm]` extra); any litellm `provider/model` string works.
 
 If none is set:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,17 +26,18 @@ dependencies = [
     # HTTP Client
     "httpx",
     # Config
-    # Pydantic upper bound lives here (not in web-core) because cohere>=6.1.0
-    # pins pydantic-core <2.44 and pydantic 2.13.x ships pydantic-core 2.46.
+    # Pydantic upper bound predates the litellm-passthrough migration: it was
+    # required by the now-removed direct cohere SDK dep (cohere>=6.1.0 pinned
+    # pydantic-core <2.44 while pydantic 2.13.x ships pydantic-core 2.46).
+    # Kept conservatively; relax in a dedicated bump.
     "pydantic>=2.13.4,<2.14",
     "pydantic-settings",
     # Logging
     "loguru",
-    # LLM + Embedding (native SDKs)
-    "cohere>=7.0.3",
+    # LLM + Embedding + Reranking dispatch through mcp_core.llm (litellm
+    # passthrough via the mcp-core[llm] extra below). No direct provider SDK
+    # deps; the openai SDK remains transitive via litellm.
     "httpx>=0.28.1",
-    "google-genai>=2.8.0",
-    "openai>=2.41.0",
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
@@ -50,8 +51,9 @@ dependencies = [
     "jsonschema>=4.26.0",
     # Per-domain rate limiting for batch operations
     "aiolimiter>=1.2.1",
-    # Relay setup (zero-env-config)
-    "n24q02m-mcp-core>=1.17.2,<2",
+    # Relay setup (zero-env-config) + LLM passthrough (litellm via [llm] extra).
+    # Beta pin until 1.18.0 stable.
+    "n24q02m-mcp-core[llm]>=1.18.0b1,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.4",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -377,7 +377,7 @@ class Settings(BaseSettings):
 
         if mode == "sdk":
             self.setup_api_keys()
-            logger.info("SDK direct mode (native provider SDKs)")
+            logger.info("SDK direct mode (litellm passthrough via mcp_core.llm)")
         else:
             logger.info("Local mode (no cloud providers)")
 

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -56,6 +56,7 @@ CLOUD_KEYS = [
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
     "COHERE_API_KEY",
+    "XAI_API_KEY",
 ]
 
 

--- a/src/wet_mcp/docs/config.md
+++ b/src/wet_mcp/docs/config.md
@@ -34,6 +34,24 @@ Valid keys:
 | `sync_folder` | String | Remote folder path |
 | `sync_interval` | Integer (seconds) | Sync interval |
 
+### models
+
+List cloud models (chat/embedding/rerank) from the litellm catalog,
+filtered to providers with configured API keys.
+
+```json
+{"action": "models"}
+```
+
+Full catalog (including unconfigured providers):
+
+```json
+{"action": "models", "key": "all"}
+```
+
+Returns: model list with provider/mode/vision flags. Any litellm
+`provider/model` string works via passthrough, even if not listed.
+
 ### cache_clear
 
 Clear web cache (search, extract, crawl, map results).

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -1,8 +1,9 @@
-"""Dual-backend embedding: Cloud (native SDKs) + qwen3-embed (local).
+"""Dual-backend embedding: Cloud (litellm passthrough) + qwen3-embed (local).
 
 Supports two backends:
-- **cloud**: Cloud providers via native SDKs (Google Gemini, OpenAI, Cohere).
-  Requires API keys. Auto-detects provider from API_KEYS config.
+- **cloud**: Cloud providers via mcp_core.llm (litellm passthrough — Jina,
+  Gemini, OpenAI, Cohere, or any litellm 'provider/model'). Requires API
+  keys. Auto-detects provider from API_KEYS config.
 - **local**: Local inference via qwen3-embed. GGUF if GPU + llama-cpp-python,
   ONNX otherwise. No API keys needed, ~0.5GB model download on first use.
 
@@ -144,12 +145,12 @@ def _strip_provider(model: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Cloud Backend (native SDKs)
+# Cloud Backend (litellm passthrough via mcp_core.llm)
 # ---------------------------------------------------------------------------
 
 
 class CloudEmbeddingBackend:
-    """Cloud embedding via native SDKs (Gemini, OpenAI, Cohere)."""
+    """Cloud embedding via mcp_core.llm (litellm passthrough)."""
 
     MAX_BATCH_SIZE = 96  # Common safe batch size across providers
 
@@ -163,7 +164,6 @@ class CloudEmbeddingBackend:
         self.api_base = api_base
         self.api_key = api_key
         self._provider = _detect_embedding_provider(model)
-        self._bare_model = _strip_provider(model)
 
     async def _embed_batch_inner(
         self,
@@ -216,124 +216,42 @@ class CloudEmbeddingBackend:
         assert last_exc is not None  # guaranteed by loop logic
         raise last_exc
 
+    def _litellm_model(self) -> str:
+        """Map wet's model naming to a litellm ``provider/model`` string."""
+        if "/" in self.model:
+            return self.model
+        if self._provider == "jina":
+            return f"jina_ai/{self.model}"
+        if self._provider == "gemini":
+            return f"gemini/{self.model}"
+        if self._provider == "cohere":
+            return f"cohere/{self.model}"
+        # OpenAI-style bare names (text-embedding-3-*) pass through as-is.
+        return self.model
+
     async def _call_provider(
         self, texts: list[str], dimensions: int | None = None
     ) -> list[list[float]]:
-        """Route to the correct provider SDK."""
-        if self._provider == "gemini":
-            return await self._embed_gemini(texts, dimensions)
-        elif self._provider == "cohere":
-            return await self._embed_cohere(texts, dimensions)
-        elif self._provider == "jina":
-            return await self._embed_jina(texts, dimensions)
-        else:
-            return await self._embed_openai(texts, dimensions)
+        """Single cloud path via mcp_core.llm (litellm passthrough)."""
+        # Lazy import: litellm costs ~1-2s on first import.
+        from mcp_core.llm import aembedding
 
-    async def _embed_gemini(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Embed via Gemini SDK (google-genai)."""
-        from google import genai
-        from google.genai import types
-
-        key = (
-            self.api_key
-            or os.getenv("GEMINI_API_KEY")
-            or os.getenv("GOOGLE_API_KEY")
-            or ""
-        )
-        client = genai.Client(api_key=key)
-
-        config_kwargs: dict = {}
-        if dimensions:
-            config_kwargs["output_dimensionality"] = dimensions
-
-        # google-genai Client.models.embed_content is synchronous, use to_thread
-        result = await asyncio.to_thread(
-            client.models.embed_content,
-            model=self._bare_model,
-            contents=texts,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]  # SDK accepts list[str]
-            config=types.EmbedContentConfig(**config_kwargs) if config_kwargs else None,
-        )
-
-        embeddings = result.embeddings or []
-        return [list(e.values or []) for e in embeddings]
-
-    async def _embed_openai(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Embed via OpenAI SDK."""
-        from openai import AsyncOpenAI
-
-        key = self.api_key or os.getenv("OPENAI_API_KEY") or ""
-        base = self.api_base or "https://api.openai.com/v1"
-        client = AsyncOpenAI(api_key=key, base_url=base)
-
-        kwargs: dict = {
-            "model": self._bare_model,
-            "input": texts,
-        }
+        kwargs: dict = {}
         if dimensions:
             kwargs["dimensions"] = dimensions
+        if self._provider == "cohere":
+            kwargs["input_type"] = "search_document"
 
-        response = await client.embeddings.create(**kwargs)
-        data = sorted(response.data, key=lambda x: x.index)
-        return [d.embedding for d in data]
-
-    async def _embed_cohere(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Embed via Cohere SDK (ClientV2)."""
-        import cohere
-
-        key = self.api_key or os.getenv("COHERE_API_KEY") or ""
-        # Cohere V2 SDK's ClientV2.embed is synchronous, use to_thread
-        client = cohere.ClientV2(api_key=key)
-
-        response = await asyncio.to_thread(
-            client.embed,
-            model=self._bare_model,
-            texts=texts,
-            input_type="search_document",
-            embedding_types=["float"],
-            truncate="END",
+        response = await aembedding(
+            model=self._litellm_model(),
+            input=texts,
+            api_base=self.api_base or os.getenv("EMBEDDING_API_BASE") or None,
+            api_key=self.api_key or None,
+            **kwargs,
         )
 
-        raw = response.embeddings.float_ or []
-        embeddings = [list(e) for e in raw]
-        # Truncate locally if dimensions requested (Cohere doesn't support it natively)
-        if dimensions and embeddings and len(embeddings[0]) > dimensions:
-            embeddings = [e[:dimensions] for e in embeddings]
-        return embeddings
-
-    async def _embed_jina(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Embed via Jina AI (httpx, REST API)."""
-        import httpx
-
-        key = self.api_key or os.getenv("JINA_AI_API_KEY") or ""
-        payload: dict = {
-            "model": self._bare_model,
-            "input": texts,
-        }
-        if dimensions:
-            payload["dimensions"] = dimensions
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                "https://api.jina.ai/v1/embeddings",
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {key}",
-                    "Content-Type": "application/json",
-                },
-                timeout=60,
-            )
-            response.raise_for_status()
-            data = response.json()["data"]
-            data_sorted = sorted(data, key=lambda x: x["index"])
-            return [d["embedding"] for d in data_sorted]
+        data = sorted(response.data, key=lambda item: item.get("index", 0))
+        return [item["embedding"] for item in data]
 
     async def embed_texts(
         self,

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -250,8 +250,20 @@ class CloudEmbeddingBackend:
             **kwargs,
         )
 
-        data = sorted(response.data, key=lambda item: item.get("index", 0))
-        return [item["embedding"] for item in data]
+        # litellm embedding items may be pydantic ``Embedding`` objects or
+        # plain dicts depending on provider/version — handle both shapes.
+        def _idx(item: Any) -> int:
+            return (
+                item.get("index", 0)
+                if isinstance(item, dict)
+                else getattr(item, "index", 0)
+            )
+
+        def _vec(item: Any) -> list[float]:
+            return item["embedding"] if isinstance(item, dict) else item.embedding
+
+        data = sorted(response.data or [], key=_idx)
+        return [_vec(item) for item in data]
 
     async def embed_texts(
         self,

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -1,4 +1,4 @@
-"""LLM utilities for WET MCP Server using native provider SDKs."""
+"""LLM utilities for WET MCP Server — litellm passthrough via mcp_core.llm."""
 
 import asyncio
 import base64
@@ -80,7 +80,7 @@ def _detect_provider(model: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Native async completion
+# Async completion (litellm passthrough via mcp_core.llm)
 # ---------------------------------------------------------------------------
 
 
@@ -96,218 +96,50 @@ async def acompletion(
     api_key: str | None = None,
     **kwargs,
 ) -> object:
-    """Unified async completion using native SDKs.
+    """Unified async completion via mcp_core.llm (litellm passthrough).
 
-    Routes to google-genai or openai based on model prefix.
-    Returns an OpenAI-compatible response object.
+    litellm infers the provider from the ``provider/model`` prefix and
+    returns OpenAI-shaped responses (``resp.choices[0].message.content``).
+    Fallback policy stays wet-owned: fallbacks are tried sequentially,
+    their exceptions are swallowed, and the primary exception is re-raised
+    when all fail.
     """
-    provider = _detect_provider(model)
-    bare_model = _strip_provider(model)
+    # Lazy import: litellm costs ~1-2s on first import.
+    from mcp_core.llm import acompletion as core_acompletion
+
+    call_kwargs: dict = dict(kwargs)
+    if temperature is not None:
+        call_kwargs["temperature"] = temperature
+    if max_tokens is not None:
+        call_kwargs["max_tokens"] = max_tokens
+    if response_format is not None:
+        call_kwargs["response_format"] = response_format
+
+    resolved_api_base = api_base or os.getenv("LLM_API_BASE") or None
 
     try:
-        if provider == "gemini":
-            return await _gemini_completion(
-                model=bare_model,
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                response_format=response_format,
-                api_key=api_key,
-            )
-        else:
-            # OpenAI-compatible (openai, xai/grok)
-            return await _openai_completion(
-                provider=provider,
-                model=bare_model,
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                response_format=response_format,
-                api_base=api_base,
-                api_key=api_key,
-            )
+        return await core_acompletion(
+            model=model,
+            messages=messages,
+            api_base=resolved_api_base,
+            api_key=api_key,
+            **call_kwargs,
+        )
     except Exception as e:
         # Try fallbacks
         if fallbacks:
             for fb_model in fallbacks:
                 try:
-                    return await acompletion(
+                    return await core_acompletion(
                         model=fb_model,
                         messages=messages,
-                        temperature=temperature,
-                        max_tokens=max_tokens,
-                        response_format=response_format,
-                        api_base=api_base,
+                        api_base=resolved_api_base,
                         api_key=api_key,
+                        **call_kwargs,
                     )
                 except Exception:
                     continue
         raise e
-
-
-class _Choice:
-    """Minimal OpenAI-compatible choice object."""
-
-    def __init__(self, content: str):
-        self.message = _Message(content)
-
-
-class _Message:
-    """Minimal OpenAI-compatible message object."""
-
-    def __init__(self, content: str):
-        self.content = content
-
-
-class _Response:
-    """Minimal OpenAI-compatible response object."""
-
-    def __init__(self, content: str):
-        self.choices = [_Choice(content)]
-
-
-async def _gemini_completion(
-    *,
-    model: str,
-    messages: list[dict],
-    temperature: float | None = None,
-    max_tokens: int | None = None,
-    response_format: dict | None = None,
-    api_key: str | None = None,
-) -> _Response:
-    """Call Gemini via google-genai SDK."""
-    from google import genai
-
-    key = api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY") or ""
-    client = genai.Client(api_key=key)
-
-    # Convert OpenAI-style messages to Gemini format
-    contents = _convert_messages_to_gemini(messages)
-
-    # Build config
-    config_kwargs: dict = {}
-    if temperature is not None:
-        config_kwargs["temperature"] = temperature
-    if max_tokens is not None:
-        config_kwargs["max_output_tokens"] = max_tokens
-
-    # Handle response_format
-    if response_format:
-        fmt_type = response_format.get("type", "")
-        if fmt_type == "json_object":
-            config_kwargs["response_mime_type"] = "application/json"
-        elif fmt_type == "json_schema":
-            config_kwargs["response_mime_type"] = "application/json"
-
-    config = (
-        genai.types.GenerateContentConfig(**config_kwargs) if config_kwargs else None
-    )
-
-    response = await asyncio.to_thread(
-        client.models.generate_content,
-        model=model,
-        contents=contents,
-        config=config,
-    )
-
-    text = response.text or ""
-    return _Response(text)
-
-
-def _convert_messages_to_gemini(messages: list[dict]) -> list:
-    """Convert OpenAI-style messages to Gemini contents format."""
-    from google.genai import types
-
-    contents = []
-    system_text = ""
-
-    for msg in messages:
-        role = msg.get("role", "user")
-        content = msg.get("content", "")
-
-        if role == "system":
-            system_text = content if isinstance(content, str) else str(content)
-            continue
-
-        gemini_role = "user" if role == "user" else "model"
-
-        if isinstance(content, str):
-            parts = [types.Part.from_text(text=content)]
-        elif isinstance(content, list):
-            parts = []
-            for item in content:
-                if isinstance(item, dict):
-                    if item.get("type") == "text":
-                        parts.append(types.Part.from_text(text=item.get("text", "")))
-                    elif item.get("type") == "image_url":
-                        url = item.get("image_url", {}).get("url", "")
-                        if url.startswith("data:"):
-                            # Parse data URL: data:mime;base64,data
-                            header, b64_data = url.split(",", 1)
-                            mime = header.split(":")[1].split(";")[0]
-                            import base64 as b64mod
-
-                            raw = b64mod.b64decode(b64_data)
-                            parts.append(
-                                types.Part.from_bytes(data=raw, mime_type=mime)
-                            )
-                        else:
-                            parts.append(
-                                types.Part.from_uri(
-                                    file_uri=url, mime_type="image/jpeg"
-                                )
-                            )
-                else:
-                    parts.append(types.Part.from_text(text=str(item)))
-        else:
-            parts = [types.Part.from_text(text=str(content))]
-
-        # Prepend system instruction to first user message
-        if system_text and gemini_role == "user":
-            parts.insert(0, types.Part.from_text(text=f"[System: {system_text}]\n\n"))
-            system_text = ""
-
-        contents.append(types.Content(role=gemini_role, parts=parts))
-
-    return contents
-
-
-async def _openai_completion(
-    *,
-    provider: str,
-    model: str,
-    messages: list[dict],
-    temperature: float | None = None,
-    max_tokens: int | None = None,
-    response_format: dict | None = None,
-    api_base: str | None = None,
-    api_key: str | None = None,
-) -> object:
-    """Call OpenAI-compatible API (OpenAI, xAI/Grok)."""
-    from openai import AsyncOpenAI
-
-    if provider == "xai":
-        key = api_key or os.getenv("XAI_API_KEY") or ""
-        base = api_base or "https://api.x.ai/v1"
-    else:
-        key = api_key or os.getenv("OPENAI_API_KEY") or ""
-        base = api_base or "https://api.openai.com/v1"
-
-    client = AsyncOpenAI(api_key=key, base_url=base)
-
-    kwargs: dict = {
-        "model": model,
-        "messages": messages,
-    }
-    if temperature is not None:
-        kwargs["temperature"] = temperature
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
-    if response_format:
-        # OpenAI supports response_format directly
-        kwargs["response_format"] = response_format
-
-    return await client.chat.completions.create(**kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -332,14 +164,23 @@ def get_llm_config() -> dict:
 
 
 def get_model_capabilities(model: str) -> dict:
-    """Check model's media capabilities using hardcoded maps.
+    """Check model's media capabilities.
+
+    Vision comes from the litellm registry (``mcp_core.llm.supports_vision``);
+    models unknown to the registry fall back to the hardcoded map. Audio
+    flags stay hardcoded-map-based (no registry coverage).
 
     Returns:
         Dict with 'vision', 'audio_input', 'audio_output' booleans.
     """
+    from mcp_core.llm import supports_vision
+
     bare = _strip_provider(model)
+    vision = supports_vision(model)
+    if vision is None:
+        vision = bare in _VISION_MODELS
     return {
-        "vision": bare in _VISION_MODELS,
+        "vision": vision,
         "audio_input": bare in _AUDIO_INPUT_MODELS,
         "audio_output": bare in _AUDIO_OUTPUT_MODELS,
     }

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -116,13 +116,16 @@ async def acompletion(
         call_kwargs["response_format"] = response_format
 
     resolved_api_base = api_base or os.getenv("LLM_API_BASE") or None
+    # Normalise empty string to None: mcp_core.llm forwards a non-None
+    # api_key to litellm, which suppresses provider env-var fallback (401).
+    resolved_api_key = api_key or None
 
     try:
         return await core_acompletion(
             model=model,
             messages=messages,
             api_base=resolved_api_base,
-            api_key=api_key,
+            api_key=resolved_api_key,
             **call_kwargs,
         )
     except Exception as e:
@@ -134,7 +137,7 @@ async def acompletion(
                         model=fb_model,
                         messages=messages,
                         api_base=resolved_api_base,
-                        api_key=api_key,
+                        api_key=resolved_api_key,
                         **call_kwargs,
                     )
                 except Exception:

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -46,6 +46,15 @@ RELAY_SCHEMA: dict[str, Any] = {
             "required": False,
         },
         {
+            "key": "XAI_API_KEY",
+            "label": "xAI API Key",
+            "type": "password",
+            "placeholder": "xai-...",
+            "helpUrl": "https://console.x.ai",
+            "helpText": "LLM (xAI/Grok).",
+            "required": False,
+        },
+        {
             "key": "GITHUB_TOKEN",
             "label": "GitHub Personal Access Token",
             "type": "password",
@@ -78,7 +87,7 @@ RELAY_SCHEMA: dict[str, Any] = {
         },
         {
             "label": "LLM",
-            "priority": "Gemini > OpenAI",
+            "priority": "Gemini > OpenAI > xAI",
             "description": "Used for structured extraction. Without a key, these features are limited.",
         },
     ],

--- a/src/wet_mcp/relay_setup.py
+++ b/src/wet_mcp/relay_setup.py
@@ -26,6 +26,7 @@ CLOUD_KEYS = [
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
     "COHERE_API_KEY",
+    "XAI_API_KEY",
 ]
 
 # 5 minutes: user needs time to copy URL, open browser, fill 4 keys

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -1,8 +1,9 @@
-"""Dual-backend reranking: Cohere SDK (cloud) + qwen3-embed (local ONNX).
+"""Dual-backend reranking: Cloud (litellm passthrough) + qwen3-embed (local ONNX).
 
 Supports two backends:
-- **cloud**: Cloud reranking via Cohere SDK (rerank-v4.0-pro).
-  Requires COHERE_API_KEY or CO_API_KEY env var.
+- **cloud**: Cloud reranking via mcp_core.llm (litellm passthrough — Jina,
+  Cohere, or any litellm rerank 'provider/model'). Requires the matching
+  provider API key env var (JINA_AI_API_KEY, COHERE_API_KEY / CO_API_KEY).
 - **local**: Local ONNX cross-encoder via qwen3-embed (Qwen3-Reranker-0.6B).
   No API keys needed, ~0.57GB model download on first use.
 
@@ -50,26 +51,45 @@ class RerankerBackend(Protocol):
 
 
 # ---------------------------------------------------------------------------
-# Cohere Backend (cloud)
+# Cloud Backend (litellm passthrough via mcp_core.llm)
 # ---------------------------------------------------------------------------
 
 
-class CohereReranker:
-    """Cloud reranking via Cohere SDK (ClientV2)."""
+class CloudReranker:
+    """Cloud reranking via mcp_core.llm (litellm passthrough)."""
 
     DEFAULT_MODEL = "rerank-v4.0-pro"
 
     def __init__(self, model: str | None = None, api_key: str | None = None):
         self.model = model or self.DEFAULT_MODEL
-        self.api_key = api_key or os.environ.get(
-            "COHERE_API_KEY", os.environ.get("CO_API_KEY", "")
+        # Explicit key only. When None, litellm falls back to the provider
+        # env var (JINA_AI_API_KEY, COHERE_API_KEY / CO_API_KEY) at call time.
+        self.api_key = api_key or None
+
+    def _litellm_model(self) -> str:
+        """Map wet's model naming to a litellm ``provider/model`` string."""
+        if "/" in self.model:
+            return self.model
+        if self.model.lower().startswith("jina"):
+            return f"jina_ai/{self.model}"
+        return f"cohere/{self.model}"
+
+    def _call_rerank(
+        self, query: str, documents: list[str], top_n: int
+    ) -> list[tuple[int, float]]:
+        """Single cloud path via mcp_core.llm (sync mirror — runs in to_thread)."""
+        # Lazy import: litellm costs ~1-2s on first import.
+        from mcp_core.llm import rerank as core_rerank
+
+        response = core_rerank(
+            model=self._litellm_model(),
+            query=query,
+            documents=documents,
+            top_n=top_n,
+            api_base=os.getenv("RERANK_API_BASE") or None,
+            api_key=self.api_key,
         )
-
-    def _get_client(self):
-        """Create a Cohere ClientV2 instance."""
-        import cohere
-
-        return cohere.ClientV2(api_key=self.api_key)
+        return [(r["index"], r["relevance_score"]) for r in response.results]
 
     def rerank(
         self,
@@ -77,55 +97,39 @@ class CohereReranker:
         documents: list[str],
         top_n: int = 10,
     ) -> list[tuple[int, float]]:
-        """Rerank using Cohere rerank API."""
+        """Rerank using the cloud rerank API."""
         if not documents:
             return []
 
         try:
-            client = self._get_client()
-            response = client.rerank(
-                model=self.model,
-                query=query,
-                documents=documents,
-                top_n=top_n,
-            )
-
-            results = []
-            for item in response.results:
-                results.append((item.index, item.relevance_score))
+            results = self._call_rerank(query, documents, top_n)
 
             # Sort by score descending
             results.sort(key=lambda x: x[1], reverse=True)
             return results[:top_n]
 
         except Exception as e:
-            logger.warning(f"Cohere reranking failed: {e}")
+            logger.warning(f"Cloud reranking failed: {e}")
             return []
 
     def check_available(self) -> bool:
-        """Check if Cohere reranking model is available.
+        """Check if the cloud reranking model is available.
 
         Distinguishes between invalid API keys (warning) and other
         failures (debug) so users know when their keys are wrong.
         """
         try:
-            client = self._get_client()
-            response = client.rerank(
-                model=self.model,
-                query="test",
-                documents=["test document"],
-                top_n=1,
-            )
-            return bool(response.results)
+            results = self._call_rerank("test", ["test document"], 1)
+            return bool(results)
         except Exception as e:
             msg = str(e).lower()
             if any(p in msg for p in _AUTH_ERROR_PATTERNS):
                 logger.warning(
                     f"API key invalid for reranker {self.model}: {e}. "
-                    "Check your COHERE_API_KEY or CO_API_KEY configuration."
+                    "Check your JINA_AI_API_KEY or COHERE_API_KEY configuration."
                 )
             else:
-                logger.debug(f"Cohere reranker {self.model} not available: {e}")
+                logger.debug(f"Cloud reranker {self.model} not available: {e}")
             return False
 
 
@@ -233,7 +237,7 @@ def init_reranker(
     global _backend
 
     if backend_type == "cloud":
-        _backend = CohereReranker(model=model, api_key=api_key)
+        _backend = CloudReranker(model=model, api_key=api_key)
     elif backend_type == "local":
         _backend = Qwen3Reranker(model)
     else:

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -14,7 +14,7 @@ for better precision. Pipeline: retrieve top-30 -> rerank -> return top-N.
 from __future__ import annotations
 
 import os
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -87,9 +87,22 @@ class CloudReranker:
             documents=documents,
             top_n=top_n,
             api_base=os.getenv("RERANK_API_BASE") or None,
-            api_key=self.api_key,
+            api_key=self.api_key or None,
         )
-        return [(r["index"], r["relevance_score"]) for r in response.results]
+
+        # litellm RerankResponse.results defaults to None and rerank items
+        # may be pydantic objects or plain dicts — guard + handle both shapes.
+        def _idx(r: Any) -> int:
+            return r["index"] if isinstance(r, dict) else getattr(r, "index", 0)
+
+        def _score(r: Any) -> float:
+            return (
+                r["relevance_score"]
+                if isinstance(r, dict)
+                else getattr(r, "relevance_score", 0.0)
+            )
+
+        return [(_idx(r), _score(r)) for r in (response.results or [])]
 
     def rerank(
         self,

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1686,10 +1686,30 @@ async def _handle_config_setup_complete() -> str:
     )
 
 
+async def _handle_config_models(key: str | None) -> str:
+    from mcp_core.llm import list_models
+
+    show_all = key == "all"
+    # to_thread: first list_models call imports litellm (~1-2s, blocking).
+    models = await asyncio.to_thread(
+        list_models,
+        modes=("chat", "embedding", "rerank"),
+        configured_only=not show_all,
+        limit=200,
+    )
+    return json.dumps(
+        {
+            "models": models,
+            "note": "Any litellm 'provider/model' works via passthrough, "
+            "even if not listed here.",
+        }
+    )
+
+
 @mcp.tool(
     description=(
         "Server config and management. Actions: "
-        "status|set|cache_clear|docs_reindex|warmup|setup_sync|"
+        "status|set|models|cache_clear|docs_reindex|warmup|setup_sync|"
         "setup_status|setup_skip|setup_reset|setup_complete. "
         "Use help tool with tool_name='config' for full docs."
     ),
@@ -1713,6 +1733,8 @@ async def config(
     Actions:
     - status: Show current config and status
     - set: Update runtime setting (key + value required)
+    - models: List cloud models (chat/embedding/rerank) for configured
+      providers; key='all' lists the full catalog
     - cache_clear: Clear web cache
     - docs_reindex: Force re-index a library (key = library name)
     - warmup: Pre-download models and run first-time setup
@@ -1728,6 +1750,9 @@ async def config(
 
         case "set":
             return _handle_config_set(key, value)
+
+        case "models":
+            return await _handle_config_models(key)
 
         case "cache_clear":
             return await _handle_config_cache_clear()
@@ -1759,6 +1784,7 @@ async def config(
             valid_actions = [
                 "cache_clear",
                 "docs_reindex",
+                "models",
                 "set",
                 "setup_complete",
                 "setup_reset",

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -428,116 +428,82 @@ class TestEnsureConfigForced:
 
 
 class TestLLMACompletion:
-    """Cover acompletion routing and fallback logic."""
+    """Cover acompletion passthrough and fallback logic."""
 
-    async def test_gemini_completion_routes(self):
-        """acompletion routes to _gemini_completion for gemini models."""
-        from wet_mcp.llm import _Response, acompletion
+    @staticmethod
+    def _response(content: str) -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content=content))]
+        return mock_response
 
-        with patch(
-            "wet_mcp.llm._gemini_completion", new_callable=AsyncMock
-        ) as mock_gemini:
-            mock_gemini.return_value = _Response("Hello from Gemini")
+    async def test_passthrough_returns_core_response(self):
+        """acompletion forwards model + messages to mcp_core.llm."""
+        from wet_mcp.llm import acompletion
+
+        with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+            mock_core.return_value = self._response("Hello from Gemini")
             result = await acompletion(
                 model="gemini/gemini-3-flash-preview",
                 messages=[{"role": "user", "content": "Hi"}],
             )
             assert result.choices[0].message.content == "Hello from Gemini"
-            mock_gemini.assert_called_once()
+            mock_core.assert_called_once()
+            call_kwargs = mock_core.call_args[1]
+            assert call_kwargs["model"] == "gemini/gemini-3-flash-preview"
+            assert call_kwargs["messages"] == [{"role": "user", "content": "Hi"}]
 
-    async def test_openai_completion_routes(self):
-        """acompletion routes to _openai_completion for openai models."""
+    async def test_xai_model_passthrough(self):
+        """xai/ prefixed models pass through unchanged (litellm native)."""
         from wet_mcp.llm import acompletion
 
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Hello from OpenAI"
-
-        with patch(
-            "wet_mcp.llm._openai_completion", new_callable=AsyncMock
-        ) as mock_openai:
-            mock_openai.return_value = mock_response
-            result = await acompletion(
-                model="openai/gpt-4",
-                messages=[{"role": "user", "content": "Hi"}],
-            )
-            assert result.choices[0].message.content == "Hello from OpenAI"
-            mock_openai.assert_called_once()
-
-    async def test_xai_completion_routes(self):
-        """acompletion routes to _openai_completion for xai models."""
-        from wet_mcp.llm import acompletion
-
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Hello from Grok"
-
-        with patch(
-            "wet_mcp.llm._openai_completion", new_callable=AsyncMock
-        ) as mock_openai:
-            mock_openai.return_value = mock_response
+        with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+            mock_core.return_value = self._response("Hello from Grok")
             result = await acompletion(
                 model="xai/grok-4-1-fast-reasoning",
                 messages=[{"role": "user", "content": "Hi"}],
             )
             assert result.choices[0].message.content == "Hello from Grok"
+            assert mock_core.call_args[1]["model"] == "xai/grok-4-1-fast-reasoning"
+
+    async def test_extra_kwargs_forwarded(self):
+        """Arbitrary litellm kwargs pass through the facade."""
+        from wet_mcp.llm import acompletion
+
+        with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+            mock_core.return_value = self._response("ok")
+            await acompletion(
+                model="gemini/gemini-3-flash-preview",
+                messages=[{"role": "user", "content": "Hi"}],
+                top_p=0.9,
+            )
+            assert mock_core.call_args[1]["top_p"] == 0.9
 
     async def test_fallback_on_primary_failure(self):
         """acompletion tries fallbacks when primary fails."""
-        from wet_mcp.llm import _Response, acompletion
+        from wet_mcp.llm import acompletion
 
-        call_count = 0
-
-        async def mock_completion(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            model = kwargs.get("model", "")
-            if "primary" in model:
-                raise Exception("primary failed")
-            return _Response("Fallback worked")
-
-        with patch("wet_mcp.llm.acompletion", side_effect=mock_completion):
-            # Direct test of fallback logic
-            pass
-
-        # Test via the actual function with mocked backends
-        with (
-            patch(
-                "wet_mcp.llm._gemini_completion",
-                new_callable=AsyncMock,
-                side_effect=Exception("gemini down"),
-            ),
-            patch(
-                "wet_mcp.llm._openai_completion",
-                new_callable=AsyncMock,
-                return_value=MagicMock(
-                    choices=[MagicMock(message=MagicMock(content="fallback ok"))]
-                ),
-            ),
-        ):
+        with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+            mock_core.side_effect = [
+                Exception("gemini down"),
+                self._response("fallback ok"),
+            ]
             result = await acompletion(
                 model="gemini/primary-model",
                 messages=[{"role": "user", "content": "Hi"}],
                 fallbacks=["openai/gpt-4"],
             )
             assert result.choices[0].message.content == "fallback ok"
+            assert mock_core.call_args[1]["model"] == "openai/gpt-4"
 
     async def test_fallback_all_fail_raises(self):
         """When all fallbacks fail, raises the original error."""
         from wet_mcp.llm import acompletion
 
-        with (
-            patch(
-                "wet_mcp.llm._gemini_completion",
-                new_callable=AsyncMock,
-                side_effect=Exception("gemini down"),
-            ),
-            patch(
-                "wet_mcp.llm._openai_completion",
-                new_callable=AsyncMock,
-                side_effect=Exception("openai down"),
-            ),
-        ):
+        with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+            mock_core.side_effect = [
+                Exception("gemini down"),
+                Exception("openai down"),
+            ]
             with pytest.raises(Exception, match="gemini down"):
                 await acompletion(
                     model="gemini/primary-model",
@@ -549,314 +515,13 @@ class TestLLMACompletion:
         """When no fallbacks and primary fails, raises."""
         from wet_mcp.llm import acompletion
 
-        with patch(
-            "wet_mcp.llm._gemini_completion",
-            new_callable=AsyncMock,
-            side_effect=Exception("gemini down"),
-        ):
+        with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+            mock_core.side_effect = Exception("gemini down")
             with pytest.raises(Exception, match="gemini down"):
                 await acompletion(
                     model="gemini/primary-model",
                     messages=[{"role": "user", "content": "Hi"}],
                 )
-
-
-class TestGeminiCompletion:
-    """Cover _gemini_completion internals."""
-
-    async def test_gemini_with_temperature_and_max_tokens(self):
-        """Config kwargs passed to Gemini."""
-        from wet_mcp.llm import _gemini_completion
-
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = "Gemini response"
-        mock_client.models.generate_content.return_value = mock_response
-
-        with (
-            patch("google.genai.Client", return_value=mock_client),
-            patch("wet_mcp.llm._convert_messages_to_gemini", return_value=[]),
-        ):
-            result = await _gemini_completion(
-                model="gemini-3-flash-preview",
-                messages=[{"role": "user", "content": "Hi"}],
-                temperature=0.7,
-                max_tokens=1000,
-                api_key="test-key",
-            )
-            assert result.choices[0].message.content == "Gemini response"
-
-    async def test_gemini_json_response_format(self):
-        """json_object response format sets mime type."""
-        from wet_mcp.llm import _gemini_completion
-
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = '{"key": "value"}'
-        mock_client.models.generate_content.return_value = mock_response
-
-        with (
-            patch("google.genai.Client", return_value=mock_client),
-            patch("wet_mcp.llm._convert_messages_to_gemini", return_value=[]),
-        ):
-            result = await _gemini_completion(
-                model="gemini-3-flash-preview",
-                messages=[{"role": "user", "content": "Hi"}],
-                response_format={"type": "json_object"},
-            )
-            assert result.choices[0].message.content == '{"key": "value"}'
-
-    async def test_gemini_json_schema_format(self):
-        """json_schema response format sets mime type."""
-        from wet_mcp.llm import _gemini_completion
-
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = '{"data": []}'
-        mock_client.models.generate_content.return_value = mock_response
-
-        with (
-            patch("google.genai.Client", return_value=mock_client),
-            patch("wet_mcp.llm._convert_messages_to_gemini", return_value=[]),
-        ):
-            result = await _gemini_completion(
-                model="gemini-3-flash-preview",
-                messages=[{"role": "user", "content": "Hi"}],
-                response_format={"type": "json_schema"},
-            )
-            assert result.choices[0].message.content == '{"data": []}'
-
-    async def test_gemini_empty_response(self):
-        """Empty Gemini response handled."""
-        from wet_mcp.llm import _gemini_completion
-
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = None
-        mock_client.models.generate_content.return_value = mock_response
-
-        with (
-            patch("google.genai.Client", return_value=mock_client),
-            patch("wet_mcp.llm._convert_messages_to_gemini", return_value=[]),
-        ):
-            result = await _gemini_completion(
-                model="gemini-3-flash-preview",
-                messages=[{"role": "user", "content": "Hi"}],
-            )
-            assert result.choices[0].message.content == ""
-
-
-class TestConvertMessagesToGemini:
-    """Cover _convert_messages_to_gemini edge cases."""
-
-    def test_system_message_prepended(self):
-        """System message prepended to first user message."""
-        from wet_mcp.llm import _convert_messages_to_gemini
-
-        with patch("google.genai.types") as mock_types:
-            mock_types.Part.from_text.return_value = MagicMock()
-            mock_types.Content.return_value = MagicMock()
-
-            messages = [
-                {"role": "system", "content": "You are helpful"},
-                {"role": "user", "content": "Hello"},
-            ]
-            _convert_messages_to_gemini(messages)
-            # System text prepended to first user message as Part
-            assert mock_types.Part.from_text.call_count >= 2
-
-    def test_assistant_role_mapped_to_model(self):
-        """Assistant role maps to 'model' in Gemini."""
-        from wet_mcp.llm import _convert_messages_to_gemini
-
-        with patch("google.genai.types") as mock_types:
-            mock_types.Part.from_text.return_value = MagicMock()
-            mock_types.Content.return_value = MagicMock()
-
-            messages = [
-                {"role": "assistant", "content": "Previous response"},
-                {"role": "user", "content": "Follow up"},
-            ]
-            _convert_messages_to_gemini(messages)
-            # Verify Content was called with role="model" for assistant
-            calls = mock_types.Content.call_args_list
-            assert any(
-                c[1].get("role") == "model" or (c[0] and len(c[0]) > 0) for c in calls
-            )
-
-    def test_multipart_content_with_image(self):
-        """Image content handled in multipart messages."""
-        from wet_mcp.llm import _convert_messages_to_gemini
-
-        with patch("google.genai.types") as mock_types:
-            mock_types.Part.from_text.return_value = MagicMock()
-            mock_types.Part.from_bytes.return_value = MagicMock()
-            mock_types.Part.from_uri.return_value = MagicMock()
-            mock_types.Content.return_value = MagicMock()
-
-            # data URL image
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": "Describe"},
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": "data:image/png;base64,aGVsbG8="},
-                        },
-                    ],
-                }
-            ]
-            _convert_messages_to_gemini(messages)
-            mock_types.Part.from_bytes.assert_called_once()
-
-    def test_multipart_content_with_url_image(self):
-        """HTTP URL image handled in multipart messages."""
-        from wet_mcp.llm import _convert_messages_to_gemini
-
-        with patch("google.genai.types") as mock_types:
-            mock_types.Part.from_text.return_value = MagicMock()
-            mock_types.Part.from_uri.return_value = MagicMock()
-            mock_types.Content.return_value = MagicMock()
-
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": "Describe"},
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": "https://example.com/img.jpg"},
-                        },
-                    ],
-                }
-            ]
-            _convert_messages_to_gemini(messages)
-            mock_types.Part.from_uri.assert_called_once()
-
-    def test_non_dict_list_items(self):
-        """Non-dict items in content list are converted to text."""
-        from wet_mcp.llm import _convert_messages_to_gemini
-
-        with patch("google.genai.types") as mock_types:
-            mock_types.Part.from_text.return_value = MagicMock()
-            mock_types.Content.return_value = MagicMock()
-
-            messages = [
-                {
-                    "role": "user",
-                    "content": ["plain string item"],
-                }
-            ]
-            _convert_messages_to_gemini(messages)
-            # Should call from_text with str(item)
-            mock_types.Part.from_text.assert_called()
-
-    def test_non_string_non_list_content(self):
-        """Non-string, non-list content converted to string."""
-        from wet_mcp.llm import _convert_messages_to_gemini
-
-        with patch("google.genai.types") as mock_types:
-            mock_types.Part.from_text.return_value = MagicMock()
-            mock_types.Content.return_value = MagicMock()
-
-            messages = [
-                {
-                    "role": "user",
-                    "content": 42,
-                }
-            ]
-            _convert_messages_to_gemini(messages)
-            mock_types.Part.from_text.assert_called()
-
-
-class TestOpenAICompletion:
-    """Cover _openai_completion for OpenAI and xAI providers."""
-
-    async def test_openai_provider(self):
-        """OpenAI provider uses correct base URL."""
-        from wet_mcp.llm import _openai_completion
-
-        mock_client = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-
-        with patch("openai.AsyncOpenAI", return_value=mock_client) as mock_cls:
-            result = await _openai_completion(
-                provider="openai",
-                model="gpt-4",
-                messages=[{"role": "user", "content": "Hi"}],
-                api_key="test-key",
-            )
-            assert result.choices[0].message.content == "ok"
-            mock_cls.assert_called_once_with(
-                api_key="test-key", base_url="https://api.openai.com/v1"
-            )
-
-    async def test_xai_provider(self):
-        """xAI provider uses correct base URL."""
-        from wet_mcp.llm import _openai_completion
-
-        mock_client = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content="grok"))]
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-
-        with patch("openai.AsyncOpenAI", return_value=mock_client) as mock_cls:
-            result = await _openai_completion(
-                provider="xai",
-                model="grok-4",
-                messages=[{"role": "user", "content": "Hi"}],
-                api_key="xai-key",
-            )
-            assert result.choices[0].message.content == "grok"
-            mock_cls.assert_called_once_with(
-                api_key="xai-key", base_url="https://api.x.ai/v1"
-            )
-
-    async def test_with_temperature_max_tokens_format(self):
-        """Optional params passed to OpenAI create call."""
-        from wet_mcp.llm import _openai_completion
-
-        mock_client = AsyncMock()
-        mock_response = MagicMock()
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-
-        with patch("openai.AsyncOpenAI", return_value=mock_client):
-            await _openai_completion(
-                provider="openai",
-                model="gpt-4",
-                messages=[{"role": "user", "content": "Hi"}],
-                temperature=0.5,
-                max_tokens=500,
-                response_format={"type": "json_object"},
-            )
-            call_kwargs = mock_client.chat.completions.create.call_args[1]
-            assert call_kwargs["temperature"] == 0.5
-            assert call_kwargs["max_tokens"] == 500
-            assert call_kwargs["response_format"] == {"type": "json_object"}
-
-    async def test_custom_api_base(self, monkeypatch):
-        """Custom api_base overrides default."""
-        from wet_mcp.llm import _openai_completion
-
-        # Clear env vars to ensure predictable api_key
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-        mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(return_value=MagicMock())
-
-        with patch("openai.AsyncOpenAI", return_value=mock_client) as mock_cls:
-            await _openai_completion(
-                provider="openai",
-                model="gpt-4",
-                messages=[{"role": "user", "content": "Hi"}],
-                api_base="https://custom.api.com/v1",
-            )
-            mock_cls.assert_called_once_with(
-                api_key="", base_url="https://custom.api.com/v1"
-            )
 
 
 class TestDetectProvider:
@@ -1072,19 +737,6 @@ class TestAnalyzeMediaExtended:
             assert "Error analyzing media" in result
 
         settings.download_dir = orig_dir
-
-
-class TestResponseObjects:
-    """Cover _Response, _Choice, _Message classes."""
-
-    def test_response_structure(self):
-        from wet_mcp.llm import _Choice, _Message, _Response
-
-        resp = _Response("test content")
-        assert len(resp.choices) == 1
-        assert isinstance(resp.choices[0], _Choice)
-        assert isinstance(resp.choices[0].message, _Message)
-        assert resp.choices[0].message.content == "test content"
 
 
 # =====================================================================

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -322,27 +322,21 @@ class TestCachePurgeAndClose:
 # ---------------------------------------------------------------------------
 
 
-class TestCohereRerankerResults:
-    """Cover CohereReranker rerank result parsing."""
+class TestCloudRerankerResults:
+    """Cover CloudReranker rerank result parsing."""
 
-    def test_rerank_with_object_results(self):
-        from wet_mcp.reranker import CohereReranker
+    def test_rerank_with_dict_results(self):
+        from wet_mcp.reranker import CloudReranker
 
-        reranker = CohereReranker(api_key="test-key")
+        reranker = CloudReranker(api_key="test-key")
 
         mock_response = MagicMock()
-        item0 = MagicMock()
-        item0.index = 0
-        item0.relevance_score = 0.8
-        item1 = MagicMock()
-        item1.index = 1
-        item1.relevance_score = 0.95
-        mock_response.results = [item0, item1]
+        mock_response.results = [
+            {"index": 0, "relevance_score": 0.8},
+            {"index": 1, "relevance_score": 0.95},
+        ]
 
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank", return_value=mock_response):
             results = reranker.rerank("query", ["doc1", "doc2"], top_n=2)
 
         assert results == [(1, 0.95), (0, 0.8)]

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -4,9 +4,9 @@ Targets uncovered lines in:
 - searxng_runner.py: process management, config, health checks, restart logic
 - searxng.py: unhealthy restart path, URL dedup merge logic
 - crawler.py: markitdown errors, _detect_document_content_type, _get_crawler retry
-- embedder.py: LiteLLM backend fallback, ONNX model loading errors
+- embedder.py: cloud backend fallback, ONNX model loading errors
 - llm.py: error handling paths
-- reranker.py: LiteLLM reranker fallback paths
+- reranker.py: cloud reranker fallback paths
 """
 
 import asyncio
@@ -1255,43 +1255,32 @@ class TestAnalyzeMediaErrorPaths:
 # -----------------------------------------------------------------------
 
 
-class TestCohereRerankerWithApiKey:
-    """Cover CohereReranker api_key pass-through."""
+class TestCloudRerankerWithApiKey:
+    """Cover CloudReranker api_key pass-through."""
 
     async def test_rerank_with_api_key(self):
-        from wet_mcp.reranker import CohereReranker
+        from wet_mcp.reranker import CloudReranker
 
-        reranker = CohereReranker(model="rerank-v4.0-pro", api_key="sk-test")
+        reranker = CloudReranker(model="rerank-v4.0-pro", api_key="sk-test")
 
         mock_response = MagicMock()
-        item = MagicMock()
-        item.index = 0
-        item.relevance_score = 0.9
-        mock_response.results = [item]
+        mock_response.results = [{"index": 0, "relevance_score": 0.9}]
 
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank", return_value=mock_response) as mock_rerank:
             results = reranker.rerank("query", ["doc1"])
             assert len(results) == 1
             assert reranker.api_key == "sk-test"
+            assert mock_rerank.call_args[1]["api_key"] == "sk-test"
 
     async def test_check_available_with_api_key(self):
-        from wet_mcp.reranker import CohereReranker
+        from wet_mcp.reranker import CloudReranker
 
-        reranker = CohereReranker(model="rerank-v4.0-pro", api_key="sk-test")
+        reranker = CloudReranker(model="rerank-v4.0-pro", api_key="sk-test")
 
         mock_response = MagicMock()
-        item = MagicMock()
-        item.index = 0
-        item.relevance_score = 0.5
-        mock_response.results = [item]
+        mock_response.results = [{"index": 0, "relevance_score": 0.5}]
 
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank", return_value=mock_response):
             result = reranker.check_available()
             assert result is True
             assert reranker.api_key == "sk-test"
@@ -1327,18 +1316,15 @@ class TestQwen3RerankerLoadModel:
                     reranker._get_model()
 
 
-class TestCohereRerankerCheckAvailableEmpty:
+class TestCloudRerankerCheckAvailableEmpty:
     """Cover edge case: check_available with empty results."""
 
     async def test_check_available_empty_results(self):
-        from wet_mcp.reranker import CohereReranker
+        from wet_mcp.reranker import CloudReranker
 
-        reranker = CohereReranker(api_key="test-key")
+        reranker = CloudReranker(api_key="test-key")
         mock_response = MagicMock()
         mock_response.results = []
 
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank", return_value=mock_response):
             assert reranker.check_available() is False

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -5,6 +5,7 @@ batch splitting, retry logic, Qwen3EmbedBackend (local ONNX), factory functions,
 and provider detection helpers.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -371,6 +372,45 @@ class TestCallProvider:
             result = await backend._call_provider(["a", "b"])
 
         assert result == [[0.1], [0.2]]
+
+    async def test_empty_api_key_normalised_to_none(self):
+        """Empty-string api_key is normalised to None (litellm env fallback)."""
+        backend = CloudEmbeddingBackend("text-embedding-3-small", api_key="")
+
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1]])
+            await backend._call_provider(["test"])
+            assert mock_embed.call_args[1]["api_key"] is None
+
+    async def test_pydantic_object_response_shape(self):
+        """litellm Embedding pydantic objects (.index/.embedding) are handled."""
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
+
+        # Plain objects (no dict subscript) mimicking litellm's Embedding type.
+        item0 = SimpleNamespace(index=1, embedding=[0.2])
+        item1 = SimpleNamespace(index=0, embedding=[0.1])
+        mock_response = MagicMock()
+        mock_response.data = [item0, item1]
+
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = mock_response
+            result = await backend._call_provider(["a", "b"])
+
+        # Re-sorted by .index even with object items.
+        assert result == [[0.1], [0.2]]
+
+    async def test_none_data_guarded(self):
+        """response.data=None yields [] instead of raising."""
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
+
+        mock_response = MagicMock()
+        mock_response.data = None
+
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = mock_response
+            result = await backend._call_provider(["a"])
+
+        assert result == []
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,6 +1,6 @@
 """Tests for src/wet_mcp/embedder.py -- Dual-backend embedding.
 
-Covers CloudEmbeddingBackend (native SDK providers: OpenAI, Cohere, Gemini, Jina),
+Covers CloudEmbeddingBackend (litellm passthrough via mcp_core.llm),
 batch splitting, retry logic, Qwen3EmbedBackend (local ONNX), factory functions,
 and provider detection helpers.
 """
@@ -218,201 +218,159 @@ class TestCloudEmbeddingBackend:
 
 
 # -----------------------------------------------------------------------
-# CloudEmbeddingBackend: Provider-specific SDK mocks
+# CloudEmbeddingBackend: litellm passthrough (_call_provider + _litellm_model)
 # -----------------------------------------------------------------------
 
 
-class TestProviderSDKs:
-    """Test that each provider SDK is called correctly."""
+def _embedding_response(embeddings: list[list[float]]) -> MagicMock:
+    """Build a litellm-shaped EmbeddingResponse mock (.data list of dicts)."""
+    mock_response = MagicMock()
+    mock_response.data = [
+        {"index": i, "embedding": emb, "object": "embedding"}
+        for i, emb in enumerate(embeddings)
+    ]
+    return mock_response
 
-    async def test_embed_openai(self):
-        """OpenAI SDK is called with correct params."""
+
+class TestLitellmModelMapping:
+    """_litellm_model maps wet's model naming to litellm provider prefixes."""
+
+    def test_prefixed_models_pass_through(self):
+        assert (
+            CloudEmbeddingBackend("gemini/gemini-embedding-001")._litellm_model()
+            == "gemini/gemini-embedding-001"
+        )
+        assert (
+            CloudEmbeddingBackend(
+                "jina_ai/jina-embeddings-v5-text-small"
+            )._litellm_model()
+            == "jina_ai/jina-embeddings-v5-text-small"
+        )
+        assert (
+            CloudEmbeddingBackend("cohere/embed-v4")._litellm_model()
+            == "cohere/embed-v4"
+        )
+
+    def test_bare_jina_gets_prefix(self):
+        backend = CloudEmbeddingBackend("jina-embeddings-v3")
+        assert backend._litellm_model() == "jina_ai/jina-embeddings-v3"
+
+    def test_bare_gemini_gets_prefix(self):
+        backend = CloudEmbeddingBackend("gemini-embedding-001")
+        assert backend._litellm_model() == "gemini/gemini-embedding-001"
+
+    def test_bare_cohere_gets_prefix(self):
+        backend = CloudEmbeddingBackend("embed-multilingual-v3.0")
+        assert backend._litellm_model() == "cohere/embed-multilingual-v3.0"
+
+    def test_bare_openai_stays_bare(self):
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
+        assert backend._litellm_model() == "text-embedding-3-small"
+
+
+class TestCallProvider:
+    """_call_provider dispatches through mcp_core.llm.aembedding."""
+
+    async def test_basic_call(self):
+        """Model, input, api_base and api_key are forwarded."""
         backend = CloudEmbeddingBackend("text-embedding-3-small", api_key="test-key")
 
-        mock_embedding = MagicMock()
-        mock_embedding.index = 0
-        mock_embedding.embedding = [0.1, 0.2, 0.3]
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1, 0.2, 0.3]])
+            result = await backend._call_provider(["test"])
 
-        mock_response = MagicMock()
-        mock_response.data = [mock_embedding]
-
-        mock_client = MagicMock()
-        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
-
-        mock_openai_cls = MagicMock(return_value=mock_client)
-        mock_openai_mod = MagicMock(AsyncOpenAI=mock_openai_cls)
-
-        with patch.dict("sys.modules", {"openai": mock_openai_mod}):
-            result = await backend._embed_openai(["test"])
-            mock_openai_cls.assert_called_once_with(
-                api_key="test-key", base_url="https://api.openai.com/v1"
-            )
-            mock_client.embeddings.create.assert_called_once_with(
-                model="text-embedding-3-small", input=["test"]
-            )
+            call_kwargs = mock_embed.call_args[1]
+            assert call_kwargs["model"] == "text-embedding-3-small"
+            assert call_kwargs["input"] == ["test"]
+            assert call_kwargs["api_key"] == "test-key"
+            assert call_kwargs["api_base"] is None
+            assert "dimensions" not in call_kwargs
 
         assert result == [[0.1, 0.2, 0.3]]
 
-    async def test_embed_openai_with_dimensions(self):
-        """OpenAI passes dimensions param."""
+    async def test_dimensions_forwarded(self):
+        """dimensions kwarg is only sent when set."""
         backend = CloudEmbeddingBackend("text-embedding-3-small", api_key="test-key")
 
-        mock_embedding = MagicMock()
-        mock_embedding.index = 0
-        mock_embedding.embedding = [0.1]
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1]])
+            await backend._call_provider(["test"], dimensions=256)
+            assert mock_embed.call_args[1]["dimensions"] == 256
 
-        mock_response = MagicMock()
-        mock_response.data = [mock_embedding]
-
-        mock_client = MagicMock()
-        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
-
-        mock_openai_cls = MagicMock(return_value=mock_client)
-        mock_openai_mod = MagicMock(AsyncOpenAI=mock_openai_cls)
-
-        with patch.dict("sys.modules", {"openai": mock_openai_mod}):
-            await backend._embed_openai(["test"], dimensions=256)
-            mock_client.embeddings.create.assert_called_once_with(
-                model="text-embedding-3-small", input=["test"], dimensions=256
-            )
-
-    async def test_embed_openai_with_api_base(self):
-        """OpenAI uses custom api_base."""
+    async def test_explicit_api_base_forwarded(self):
+        """Constructor api_base wins over EMBEDDING_API_BASE env."""
         backend = CloudEmbeddingBackend(
             "text-embedding-3-small",
             api_key="test-key",
             api_base="https://custom.api/v1",
         )
 
-        mock_embedding = MagicMock()
-        mock_embedding.index = 0
-        mock_embedding.embedding = [0.1]
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1]])
+            await backend._call_provider(["test"])
+            assert mock_embed.call_args[1]["api_base"] == "https://custom.api/v1"
 
-        mock_response = MagicMock()
-        mock_response.data = [mock_embedding]
+    async def test_env_api_base_fallback(self, monkeypatch):
+        """EMBEDDING_API_BASE env is used when no explicit api_base."""
+        monkeypatch.setenv("EMBEDDING_API_BASE", "https://env.api/v1")
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
 
-        mock_client = MagicMock()
-        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1]])
+            await backend._call_provider(["test"])
+            assert mock_embed.call_args[1]["api_base"] == "https://env.api/v1"
 
-        mock_openai_cls = MagicMock(return_value=mock_client)
-        mock_openai_mod = MagicMock(AsyncOpenAI=mock_openai_cls)
-
-        with patch.dict("sys.modules", {"openai": mock_openai_mod}):
-            await backend._embed_openai(["test"])
-            mock_openai_cls.assert_called_once_with(
-                api_key="test-key", base_url="https://custom.api/v1"
-            )
-
-    async def test_embed_cohere(self):
-        """Cohere SDK (ClientV2) is called with correct params."""
+    async def test_cohere_input_type_forwarded(self):
+        """Cohere models pass input_type=search_document through kwargs."""
         backend = CloudEmbeddingBackend("embed-multilingual-v3.0", api_key="test-key")
 
-        mock_embeddings = MagicMock()
-        mock_embeddings.float_ = [[0.1, 0.2, 0.3]]
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1, 0.2, 0.3]])
+            result = await backend._call_provider(["test"])
 
-        mock_response = MagicMock()
-        mock_response.embeddings = mock_embeddings
-
-        mock_client = MagicMock()
-        mock_client.embed.return_value = mock_response
-
-        mock_cohere_mod = MagicMock()
-        mock_cohere_mod.ClientV2.return_value = mock_client
-
-        with patch.dict("sys.modules", {"cohere": mock_cohere_mod}):
-            result = await backend._embed_cohere(["test"])
-            mock_cohere_mod.ClientV2.assert_called_once_with(api_key="test-key")
-            mock_client.embed.assert_called_once_with(
-                model="embed-multilingual-v3.0",
-                texts=["test"],
-                input_type="search_document",
-                embedding_types=["float"],
-                truncate="END",
-            )
+            call_kwargs = mock_embed.call_args[1]
+            assert call_kwargs["model"] == "cohere/embed-multilingual-v3.0"
+            assert call_kwargs["input_type"] == "search_document"
 
         assert result == [[0.1, 0.2, 0.3]]
 
-    async def test_embed_cohere_truncates_locally(self):
-        """Cohere truncates locally when dimensions requested."""
-        backend = CloudEmbeddingBackend("embed-multilingual-v3.0", api_key="test-key")
-
-        mock_embeddings = MagicMock()
-        mock_embeddings.float_ = [[0.1] * 1024]
-
-        mock_response = MagicMock()
-        mock_response.embeddings = mock_embeddings
-
-        mock_client = MagicMock()
-        mock_client.embed.return_value = mock_response
-
-        mock_cohere_mod = MagicMock()
-        mock_cohere_mod.ClientV2.return_value = mock_client
-
-        with patch.dict("sys.modules", {"cohere": mock_cohere_mod}):
-            result = await backend._embed_cohere(["test"], dimensions=768)
-
-        assert len(result[0]) == 768
-
-    async def test_embed_gemini(self):
-        """Gemini SDK is called with correct params."""
-        backend = CloudEmbeddingBackend(
-            "gemini/gemini-embedding-001", api_key="test-key"
-        )
-
-        mock_embedding = MagicMock()
-        mock_embedding.values = [0.1, 0.2, 0.3]
-
-        mock_result = MagicMock()
-        mock_result.embeddings = [mock_embedding]
-
-        mock_client = MagicMock()
-        mock_client.models.embed_content.return_value = mock_result
-
-        mock_genai = MagicMock()
-        mock_genai.Client.return_value = mock_client
-
-        mock_google = MagicMock()
-        mock_google.genai = mock_genai
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "google": mock_google,
-                "google.genai": mock_genai,
-                "google.genai.types": MagicMock(),
-            },
-        ):
-            result = await backend._embed_gemini(["test"])
-            mock_genai.Client.assert_called_once_with(api_key="test-key")
-
-        assert result == [[0.1, 0.2, 0.3]]
-
-    async def test_embed_jina(self):
-        """Jina AI REST API is called with correct params."""
+    async def test_non_cohere_has_no_input_type(self):
+        """Non-cohere providers do not send input_type."""
         backend = CloudEmbeddingBackend(
             "jina_ai/jina-embeddings-v3", api_key="test-key"
         )
 
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "data": [{"index": 0, "embedding": [0.1, 0.2, 0.3]}]
-        }
-        mock_response.raise_for_status = MagicMock()
-
-        # _embed_jina uses httpx.AsyncClient as an async context manager,
-        # then awaits client.post(). Build mocks to match that shape.
-        mock_async_client = MagicMock()
-        mock_async_client.post = AsyncMock(return_value=mock_response)
-        mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
-        mock_async_client.__aexit__ = AsyncMock(return_value=None)
-
-        mock_httpx = MagicMock()
-        mock_httpx.AsyncClient.return_value = mock_async_client
-
-        with patch.dict("sys.modules", {"httpx": mock_httpx}):
-            result = await backend._embed_jina(["test"])
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1, 0.2, 0.3]])
+            result = await backend._call_provider(["test"])
+            assert "input_type" not in mock_embed.call_args[1]
 
         assert result == [[0.1, 0.2, 0.3]]
+
+    async def test_no_api_key_passes_none(self):
+        """Without an explicit key, api_key=None lets litellm use env vars."""
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
+
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = _embedding_response([[0.1]])
+            await backend._call_provider(["test"])
+            assert mock_embed.call_args[1]["api_key"] is None
+
+    async def test_results_sorted_by_index(self):
+        """Out-of-order response data is re-sorted by index."""
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
+
+        mock_response = MagicMock()
+        mock_response.data = [
+            {"index": 1, "embedding": [0.2]},
+            {"index": 0, "embedding": [0.1]},
+        ]
+
+        with patch("mcp_core.llm.aembedding", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = mock_response
+            result = await backend._call_provider(["a", "b"])
+
+        assert result == [[0.1], [0.2]]
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_full_live.py
+++ b/tests/test_full_live.py
@@ -327,19 +327,19 @@ class TestFullSetup:
 
 
 # ---------------------------------------------------------------------------
-# LiteLLM mode (skipped if no LITELLM_PROXY_URL)
+# Custom LLM API base mode (skipped if no LLM_API_BASE)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(
-    not os.environ.get("LITELLM_PROXY_URL"),
-    reason="LITELLM_PROXY_URL not set",
+    not os.environ.get("LLM_API_BASE"),
+    reason="LLM_API_BASE not set",
 )
 @pytest.mark.timeout(120)
-class TestFullLiteLLMMode:
+class TestFullLLMApiBaseMode:
     @pytest.fixture
-    async def litellm_session(self, tmp_path):
-        """MCP session using LiteLLM proxy mode."""
+    async def api_base_session(self, tmp_path):
+        """MCP session using a custom LLM API base (litellm passthrough)."""
         server_params = StdioServerParameters(
             command="uv",
             args=["run", "wet-mcp"],
@@ -366,17 +366,17 @@ class TestFullLiteLLMMode:
             else:
                 raise
 
-    async def test_search_docs_litellm(self, litellm_session: ClientSession):
-        """search.docs with LiteLLM embedding."""
-        r = await litellm_session.call_tool(
+    async def test_search_docs_api_base(self, api_base_session: ClientSession):
+        """search.docs with custom-api-base embedding."""
+        r = await api_base_session.call_tool(
             "search", {"action": "docs", "library": "requests", "query": "get"}
         )
         text = parse(r)
         assert len(text) > 50, f"Docs result too short: {len(text)} chars"
 
-    async def test_config_status_litellm(self, litellm_session: ClientSession):
-        """config.status should show litellm mode."""
-        r = await litellm_session.call_tool("config", {"action": "status"})
+    async def test_config_status_api_base(self, api_base_session: ClientSession):
+        """config.status should show cloud embedding available."""
+        r = await api_base_session.call_tool("config", {"action": "status"})
         text = parse(r)
         data = json.loads(text)
         embedding = data.get("embedding", {})

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -540,6 +540,33 @@ async def test_acompletion_no_api_base_when_unset(monkeypatch):
         assert mock_core.call_args[1]["api_base"] is None
 
 
+@pytest.mark.asyncio
+async def test_acompletion_normalises_empty_api_key(monkeypatch):
+    """Empty-string api_key is normalised to None (litellm env fallback)."""
+
+    monkeypatch.delenv("LLM_API_BASE", raising=False)
+    mock_response = MagicMock()
+
+    with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+        mock_core.return_value = mock_response
+
+        await acompletion(
+            model="gemini/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="",
+        )
+        assert mock_core.call_args[1]["api_key"] is None
+
+        # An explicit non-empty key is forwarded verbatim.
+        mock_core.reset_mock()
+        await acompletion(
+            model="gemini/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="real-key",
+        )
+        assert mock_core.call_args[1]["api_key"] == "real-key"
+
+
 def test_get_model_capabilities_catalog_hit():
     """Registry-known models take vision from mcp_core.llm.supports_vision."""
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
@@ -416,19 +416,16 @@ def test_has_llm_provider():
 async def test_acompletion_fallback_skips_error():
     """Test that acompletion skips failed fallbacks and continues to the next one."""
 
-    # We mock _gemini_completion to fail (triggering fallback)
-    # We mock _openai_completion to fail on first call and succeed on second call
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "Fallback success"
 
-    with (
-        patch(
-            "wet_mcp.llm._gemini_completion", side_effect=Exception("Primary failed")
-        ),
-        patch("wet_mcp.llm._openai_completion") as mock_openai,
-    ):
-        # Mocking the side effect to fail then succeed
-        mock_response = MagicMock()
-        mock_response.choices[0].message.content = "Fallback success"
-        mock_openai.side_effect = [Exception("First fallback failed"), mock_response]
+    # Primary fails, first fallback fails, second fallback succeeds.
+    with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+        mock_core.side_effect = [
+            Exception("Primary failed"),
+            Exception("First fallback failed"),
+            mock_response,
+        ]
 
         result = await acompletion(
             model="gemini/primary",
@@ -437,7 +434,8 @@ async def test_acompletion_fallback_skips_error():
         )
 
         assert result.choices[0].message.content == "Fallback success"
-        assert mock_openai.call_count == 2
+        assert mock_core.call_count == 3
+        assert mock_core.call_args_list[2][1]["model"] == "openai/success"
 
 
 @pytest.mark.asyncio
@@ -446,12 +444,13 @@ async def test_acompletion_all_fallbacks_fail():
 
     primary_error = Exception("Primary failed")
 
-    with (
-        patch("wet_mcp.llm._gemini_completion", side_effect=primary_error),
-        patch(
-            "wet_mcp.llm._openai_completion", side_effect=Exception("Fallback failed")
-        ),
-    ):
+    with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+        mock_core.side_effect = [
+            primary_error,
+            Exception("Fallback failed"),
+            Exception("Fallback failed"),
+        ]
+
         with pytest.raises(Exception) as excinfo:
             await acompletion(
                 model="gemini/primary",
@@ -460,3 +459,108 @@ async def test_acompletion_all_fallbacks_fail():
             )
 
         assert excinfo.value is primary_error
+        assert mock_core.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_acompletion_passes_optional_params():
+    """Optional params are forwarded only when set; None values are omitted."""
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "ok"
+
+    with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+        mock_core.return_value = mock_response
+
+        await acompletion(
+            model="gemini/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.5,
+            max_tokens=100,
+            response_format={"type": "json_object"},
+        )
+
+        call_kwargs = mock_core.call_args[1]
+        assert call_kwargs["model"] == "gemini/test-model"
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["max_tokens"] == 100
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+
+        mock_core.reset_mock()
+        await acompletion(
+            model="gemini/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        call_kwargs = mock_core.call_args[1]
+        assert "temperature" not in call_kwargs
+        assert "max_tokens" not in call_kwargs
+        assert "response_format" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_acompletion_resolves_llm_api_base_env(monkeypatch):
+    """LLM_API_BASE env var is used when no explicit api_base is given."""
+
+    monkeypatch.setenv("LLM_API_BASE", "https://proxy.example.com/v1")
+    mock_response = MagicMock()
+
+    with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+        mock_core.return_value = mock_response
+
+        await acompletion(
+            model="gemini/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert mock_core.call_args[1]["api_base"] == "https://proxy.example.com/v1"
+
+        # Explicit api_base wins over the env var.
+        mock_core.reset_mock()
+        await acompletion(
+            model="gemini/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            api_base="https://explicit.example.com/v1",
+        )
+        assert mock_core.call_args[1]["api_base"] == "https://explicit.example.com/v1"
+
+
+@pytest.mark.asyncio
+async def test_acompletion_no_api_base_when_unset(monkeypatch):
+    """api_base resolves to None when neither arg nor env var is set."""
+
+    monkeypatch.delenv("LLM_API_BASE", raising=False)
+    mock_response = MagicMock()
+
+    with patch("mcp_core.llm.acompletion", new_callable=AsyncMock) as mock_core:
+        mock_core.return_value = mock_response
+
+        await acompletion(
+            model="gemini/test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert mock_core.call_args[1]["api_base"] is None
+
+
+def test_get_model_capabilities_catalog_hit():
+    """Registry-known models take vision from mcp_core.llm.supports_vision."""
+
+    with patch("mcp_core.llm.supports_vision", return_value=True):
+        caps = get_model_capabilities("some/registry-vision-model")
+        assert caps["vision"] is True
+
+    with patch("mcp_core.llm.supports_vision", return_value=False):
+        # Registry verdict overrides the hardcoded map.
+        caps = get_model_capabilities("gemini/gemini-2.5-flash")
+        assert caps["vision"] is False
+        # Audio flags still come from the hardcoded maps.
+        assert caps["audio_input"] is True
+
+
+def test_get_model_capabilities_fallback_map():
+    """Registry-unknown models (None) fall back to the hardcoded map."""
+
+    with patch("mcp_core.llm.supports_vision", return_value=None):
+        caps = get_model_capabilities("gemini/gemini-2.5-flash")
+        assert caps["vision"] is True
+
+        caps = get_model_capabilities("some/unknown-model")
+        assert caps["vision"] is False

--- a/tests/test_real_comprehensive.py
+++ b/tests/test_real_comprehensive.py
@@ -1,8 +1,8 @@
 """Comprehensive real-world testing for wet-mcp.
 
 Tests all configuration combinations:
-1. Embedding: local ONNX vs LiteLLM proxy
-2. Reranking: local ONNX vs LiteLLM proxy
+1. Embedding: local ONNX vs custom LLM API base (litellm passthrough)
+2. Reranking: local ONNX vs custom LLM API base (litellm passthrough)
 3. SearXNG: embedded vs external (oci-vm-infra)
 4. All 4 tools: search, extract, media, config
 5. Docs search: fixed cases (vinejs, inertia, dry-rb)
@@ -21,8 +21,10 @@ import pytest
 # Fixtures for different config modes
 # ---------------------------------------------------------------------------
 
-LITELLM_PROXY_URL = "https://litellm.n24q02m.com"
-LITELLM_PROXY_KEY = os.environ.get("LITELLM_PROXY_KEY", "")
+# Self-hosted OpenAI-compatible proxy for the custom-api-base tests below.
+# Env-supplied only — there is no centralized n24q02m proxy deployment.
+LLM_API_BASE = os.environ.get("LLM_API_BASE", "")
+LLM_API_KEY = os.environ.get("LLM_API_KEY", "")
 _SEARXNG_AUTH_PASS = os.environ.get("SEARXNG_AUTH_PASS")
 SEARXNG_EXTERNAL_URL = "https://klprism:{}@searxng.n24q02m.com".format(
     _SEARXNG_AUTH_PASS or ""
@@ -216,18 +218,19 @@ class TestExtractTool:
 
 
 # ---------------------------------------------------------------------------
-# 5. LiteLLM proxy mode — embedding + reranking
+# 5. Custom LLM API base mode — embedding + reranking
 # ---------------------------------------------------------------------------
 
 
-class TestLiteLLMProxy:
-    """Test with LiteLLM proxy (oci-vm-infra)."""
+@pytest.mark.skipif(not LLM_API_BASE, reason="LLM_API_BASE not set")
+class TestCustomApiBaseProxy:
+    """Test against a self-hosted OpenAI-compatible proxy (env-supplied)."""
 
     async def test_proxy_reachable(self):
         import httpx
 
         async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(f"{LITELLM_PROXY_URL}/health/liveliness")
+            resp = await client.get(f"{LLM_API_BASE}/health/liveliness")
             assert resp.status_code == 200
 
     async def test_proxy_chat(self):
@@ -236,9 +239,9 @@ class TestLiteLLMProxy:
 
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(
-                f"{LITELLM_PROXY_URL}/chat/completions",
+                f"{LLM_API_BASE}/chat/completions",
                 headers={
-                    "Authorization": f"Bearer {LITELLM_PROXY_KEY}",
+                    "Authorization": f"Bearer {LLM_API_KEY}",
                     "Content-Type": "application/json",
                 },
                 json={
@@ -257,9 +260,9 @@ class TestLiteLLMProxy:
 
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(
-                f"{LITELLM_PROXY_URL}/rerank",
+                f"{LLM_API_BASE}/rerank",
                 headers={
-                    "Authorization": f"Bearer {LITELLM_PROXY_KEY}",
+                    "Authorization": f"Bearer {LLM_API_KEY}",
                     "Content-Type": "application/json",
                 },
                 json={
@@ -276,49 +279,30 @@ class TestLiteLLMProxy:
             data = resp.json()
             assert len(data["results"]) > 0
 
-    async def test_proxy_rerank_via_litellm_sdk(self):
-        """Test reranking via proxy using LiteLLM SDK with proxy mode flag."""
-        import os
+    async def test_proxy_rerank_via_cloud_reranker(self, monkeypatch):
+        """Test reranking through wet's CloudReranker with RERANK_API_BASE."""
+        monkeypatch.setenv("RERANK_API_BASE", LLM_API_BASE)
 
-        import litellm
+        from wet_mcp.reranker import CloudReranker
 
-        # Enable proxy mode (same as config.setup_litellm in proxy mode)
-        old_base = os.environ.get("LITELLM_PROXY_API_BASE")
-        old_key = os.environ.get("LITELLM_PROXY_API_KEY")
-        old_proxy = litellm.use_litellm_proxy
-        try:
-            os.environ["LITELLM_PROXY_API_BASE"] = LITELLM_PROXY_URL
-            os.environ["LITELLM_PROXY_API_KEY"] = LITELLM_PROXY_KEY
-            litellm.use_litellm_proxy = True
-
-            from wet_mcp.reranker import LiteLLMReranker
-
-            reranker = LiteLLMReranker(model="mcp/rerank-multilingual-v3")
-            results = reranker.rerank(
-                query="What is Python?",
-                documents=[
-                    "Python is a programming language",
-                    "Java is a programming language",
-                    "The weather is nice today",
-                ],
-                top_n=2,
-            )
-            assert len(results) == 2, f"Expected 2 results, got {len(results)}"
-            # Python doc should score highest
-            assert results[0][0] == 0, (
-                f"Expected Python doc first, got index {results[0][0]}"
-            )
-            assert results[0][1] > 0.5, f"Expected high score, got {results[0][1]}"
-        finally:
-            litellm.use_litellm_proxy = old_proxy
-            if old_base is None:
-                os.environ.pop("LITELLM_PROXY_API_BASE", None)
-            else:
-                os.environ["LITELLM_PROXY_API_BASE"] = old_base
-            if old_key is None:
-                os.environ.pop("LITELLM_PROXY_API_KEY", None)
-            else:
-                os.environ["LITELLM_PROXY_API_KEY"] = old_key
+        reranker = CloudReranker(
+            model="cohere/rerank-multilingual-v3", api_key=LLM_API_KEY
+        )
+        results = reranker.rerank(
+            query="What is Python?",
+            documents=[
+                "Python is a programming language",
+                "Java is a programming language",
+                "The weather is nice today",
+            ],
+            top_n=2,
+        )
+        assert len(results) == 2, f"Expected 2 results, got {len(results)}"
+        # Python doc should score highest
+        assert results[0][0] == 0, (
+            f"Expected Python doc first, got index {results[0][0]}"
+        )
+        assert results[0][1] > 0.5, f"Expected high score, got {results[0][1]}"
 
 
 # ---------------------------------------------------------------------------
@@ -560,13 +544,13 @@ class TestConfigTool:
         from wet_mcp.config import settings
 
         backend = settings.resolve_embedding_backend()
-        assert backend in ("litellm", "local")
+        assert backend in ("cloud", "local")
 
     async def test_config_rerank_backend_resolution(self):
         from wet_mcp.config import settings
 
         backend = settings.resolve_rerank_backend()
-        assert backend in ("litellm", "local")
+        assert backend in ("cloud", "local")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -24,9 +24,9 @@ class TestRelaySchema:
         assert "fields" in RELAY_SCHEMA
         assert "modes" not in RELAY_SCHEMA
 
-    def test_schema_has_five_provider_fields(self):
+    def test_schema_has_six_provider_fields(self):
         fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 5
+        assert len(fields) == 6
 
     def test_schema_field_keys(self):
         field_keys = [f["key"] for f in RELAY_SCHEMA["fields"]]
@@ -34,6 +34,7 @@ class TestRelaySchema:
         assert "GEMINI_API_KEY" in field_keys
         assert "OPENAI_API_KEY" in field_keys
         assert "COHERE_API_KEY" in field_keys
+        assert "XAI_API_KEY" in field_keys
         assert "GITHUB_TOKEN" in field_keys
 
     def test_schema_server_name(self):

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -4,6 +4,7 @@ Covers CloudReranker (litellm passthrough via mcp_core.llm), Qwen3Reranker,
 factory functions, and graceful fallback behavior.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -121,6 +122,42 @@ class TestCloudReranker:
             mock_rerank.return_value = _rerank_response([(0, 0.5)])
             reranker.rerank("query", ["doc"])
             assert mock_rerank.call_args[1]["api_key"] is None
+
+    def test_empty_api_key_normalised_to_none(self):
+        """Empty-string api_key is normalised to None (litellm env fallback)."""
+        reranker = CloudReranker(api_key="")
+        assert reranker.api_key is None
+
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.5)])
+            reranker.rerank("query", ["doc"])
+            assert mock_rerank.call_args[1]["api_key"] is None
+
+    def test_none_results_guarded(self):
+        """RerankResponse.results=None yields [] instead of raising."""
+        reranker = CloudReranker(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.results = None
+
+        with patch("mcp_core.llm.rerank", return_value=mock_response):
+            assert reranker.rerank("query", ["doc1", "doc2"]) == []
+
+    def test_pydantic_object_results_shape(self):
+        """litellm rerank pydantic items (.index/.relevance_score) are handled."""
+        reranker = CloudReranker(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.results = [
+            SimpleNamespace(index=0, relevance_score=0.3),
+            SimpleNamespace(index=1, relevance_score=0.9),
+        ]
+
+        with patch("mcp_core.llm.rerank", return_value=mock_response):
+            results = reranker.rerank("query", ["doc a", "doc b"], top_n=2)
+
+        # Sorted by score descending, object items parsed via attr-access.
+        assert results == [(1, 0.9), (0, 0.3)]
 
 
 class TestCloudRerankerModelMapping:

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,7 +1,7 @@
 """Tests for src/wet_mcp/reranker.py — Dual-backend reranking.
 
-Covers CohereReranker, Qwen3Reranker, factory functions, and
-graceful fallback behavior.
+Covers CloudReranker (litellm passthrough via mcp_core.llm), Qwen3Reranker,
+factory functions, and graceful fallback behavior.
 """
 
 from unittest.mock import MagicMock, patch
@@ -9,38 +9,34 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from wet_mcp.reranker import (
-    CohereReranker,
+    CloudReranker,
     Qwen3Reranker,
     get_reranker,
     init_reranker,
 )
 
+
+def _rerank_response(items: list[tuple[int, float]]) -> MagicMock:
+    """Build a litellm-shaped RerankResponse mock (.results list of dicts)."""
+    mock_response = MagicMock()
+    mock_response.results = [
+        {"index": idx, "relevance_score": score} for idx, score in items
+    ]
+    return mock_response
+
+
 # -----------------------------------------------------------------------
-# CohereReranker
+# CloudReranker
 # -----------------------------------------------------------------------
 
 
-class TestCohereReranker:
+class TestCloudReranker:
     def test_rerank_success(self):
         """Reranking returns sorted (index, score) tuples."""
-        reranker = CohereReranker(model="rerank-v4.0-pro", api_key="test-key")
+        reranker = CloudReranker(model="rerank-v4.0-pro", api_key="test-key")
 
-        mock_response = MagicMock()
-        item0 = MagicMock()
-        item0.index = 0
-        item0.relevance_score = 0.3
-        item1 = MagicMock()
-        item1.index = 1
-        item1.relevance_score = 0.9
-        item2 = MagicMock()
-        item2.index = 2
-        item2.relevance_score = 0.6
-        mock_response.results = [item0, item1, item2]
-
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.3), (1, 0.9), (2, 0.6)])
             results = reranker.rerank(
                 "test query",
                 ["doc a", "doc b", "doc c"],
@@ -56,75 +52,100 @@ class TestCohereReranker:
 
     def test_rerank_empty_documents(self):
         """Empty documents return empty results."""
-        reranker = CohereReranker(api_key="test-key")
+        reranker = CloudReranker(api_key="test-key")
         results = reranker.rerank("query", [], top_n=5)
         assert results == []
 
     def test_rerank_api_error_returns_empty(self):
         """API errors return empty results (graceful fallback)."""
-        reranker = CohereReranker(api_key="test-key")
+        reranker = CloudReranker(api_key="test-key")
 
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("API error")
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank", side_effect=Exception("API error")):
             results = reranker.rerank("query", ["doc1", "doc2"])
 
         assert results == []
 
+    def test_rerank_forwards_params(self):
+        """Model mapping, query, documents, top_n and api_key are forwarded."""
+        reranker = CloudReranker(model="rerank-v4.0-pro", api_key="test-key")
+
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.9)])
+            reranker.rerank("test query", ["doc a"], top_n=3)
+
+            call_kwargs = mock_rerank.call_args[1]
+            assert call_kwargs["model"] == "cohere/rerank-v4.0-pro"
+            assert call_kwargs["query"] == "test query"
+            assert call_kwargs["documents"] == ["doc a"]
+            assert call_kwargs["top_n"] == 3
+            assert call_kwargs["api_key"] == "test-key"
+            assert call_kwargs["api_base"] is None
+
+    def test_rerank_api_base_env(self, monkeypatch):
+        """RERANK_API_BASE env var is forwarded as api_base."""
+        monkeypatch.setenv("RERANK_API_BASE", "https://proxy.example.com")
+        reranker = CloudReranker(api_key="test-key")
+
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.9)])
+            reranker.rerank("query", ["doc"])
+            assert mock_rerank.call_args[1]["api_base"] == "https://proxy.example.com"
+
     def test_check_available_success(self):
         """Returns True when model is available."""
-        reranker = CohereReranker(api_key="test-key")
+        reranker = CloudReranker(api_key="test-key")
 
-        mock_response = MagicMock()
-        item = MagicMock()
-        item.index = 0
-        item.relevance_score = 0.5
-        mock_response.results = [item]
-
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.5)])
             assert reranker.check_available() is True
 
     def test_check_available_failure(self):
         """Returns False when model is not available."""
-        reranker = CohereReranker(api_key="test-key")
+        reranker = CloudReranker(api_key="test-key")
 
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("Not found")
-
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        with patch("mcp_core.llm.rerank", side_effect=Exception("Not found")):
             assert reranker.check_available() is False
 
     def test_default_model(self):
-        """Default model is rerank-v4.0-pro."""
-        reranker = CohereReranker(api_key="test-key")
+        """Default model is rerank-v4.0-pro (mapped to cohere/ at call time)."""
+        reranker = CloudReranker(api_key="test-key")
         assert reranker.model == "rerank-v4.0-pro"
+        assert reranker._litellm_model() == "cohere/rerank-v4.0-pro"
 
-    def test_api_key_from_env(self):
-        """API key falls back to COHERE_API_KEY env var."""
-        with patch.dict("os.environ", {"COHERE_API_KEY": "env-key"}, clear=False):
-            reranker = CohereReranker()
-            assert reranker.api_key == "env-key"
+    def test_no_api_key_stays_none(self):
+        """Without an explicit key, api_key=None lets litellm use env vars."""
+        reranker = CloudReranker()
+        assert reranker.api_key is None
 
-    def test_api_key_from_co_env(self):
-        """API key falls back to CO_API_KEY env var."""
-        with patch.dict(
-            "os.environ",
-            {"CO_API_KEY": "co-key"},
-            clear=False,
-        ):
-            # Remove COHERE_API_KEY if present
-            import os
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.5)])
+            reranker.rerank("query", ["doc"])
+            assert mock_rerank.call_args[1]["api_key"] is None
 
-            env = os.environ.copy()
-            env.pop("COHERE_API_KEY", None)
-            env["CO_API_KEY"] = "co-key"
-            with patch.dict("os.environ", env, clear=True):
-                reranker = CohereReranker()
-                assert reranker.api_key == "co-key"
+
+class TestCloudRerankerModelMapping:
+    """_litellm_model maps wet's model naming to litellm provider prefixes."""
+
+    def test_prefixed_models_pass_through(self):
+        assert (
+            CloudReranker(model="cohere/rerank-v4.0-pro")._litellm_model()
+            == "cohere/rerank-v4.0-pro"
+        )
+        assert (
+            CloudReranker(model="jina_ai/jina-reranker-v3")._litellm_model()
+            == "jina_ai/jina-reranker-v3"
+        )
+
+    def test_bare_jina_gets_prefix(self):
+        assert (
+            CloudReranker(model="jina-reranker-v3")._litellm_model()
+            == "jina_ai/jina-reranker-v3"
+        )
+
+    def test_bare_cohere_gets_prefix(self):
+        assert (
+            CloudReranker(model="rerank-v3.5")._litellm_model() == "cohere/rerank-v3.5"
+        )
 
 
 # -----------------------------------------------------------------------
@@ -207,49 +228,38 @@ class TestQwen3Reranker:
 # -----------------------------------------------------------------------
 
 
-class TestCohereRerankerApiKeyValidation:
+class TestCloudRerankerApiKeyValidation:
     """check_available() distinguishes API key errors from other failures."""
 
     def test_api_key_401_returns_false(self):
         """401 errors return False."""
-        reranker = CohereReranker(api_key="bad-key")
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("401 Unauthorized")
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        reranker = CloudReranker(api_key="bad-key")
+        with patch("mcp_core.llm.rerank", side_effect=Exception("401 Unauthorized")):
             assert reranker.check_available() is False
 
     def test_api_key_403_returns_false(self):
         """403 errors return False."""
-        reranker = CohereReranker(api_key="bad-key")
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("403 Forbidden")
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        reranker = CloudReranker(api_key="bad-key")
+        with patch("mcp_core.llm.rerank", side_effect=Exception("403 Forbidden")):
             assert reranker.check_available() is False
 
     def test_invalid_key_detected(self):
         """'invalid' keyword triggers warning path."""
-        reranker = CohereReranker(api_key="bad-key")
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("Invalid API key")
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        reranker = CloudReranker(api_key="bad-key")
+        with patch("mcp_core.llm.rerank", side_effect=Exception("Invalid API key")):
             assert reranker.check_available() is False
 
     def test_non_auth_error_returns_false(self):
         """Non-auth errors also return False."""
-        reranker = CohereReranker(api_key="test-key")
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("Model not found")
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        reranker = CloudReranker(api_key="test-key")
+        with patch("mcp_core.llm.rerank", side_effect=Exception("Model not found")):
             assert reranker.check_available() is False
 
     def test_success_returns_true(self):
         """Successful check returns True."""
-        reranker = CohereReranker(api_key="test-key")
-        mock_response = MagicMock()
-        mock_response.results = [MagicMock(index=0, relevance_score=0.9)]
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-        with patch.object(reranker, "_get_client", return_value=mock_client):
+        reranker = CloudReranker(api_key="test-key")
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.9)])
             assert reranker.check_available() is True
 
 
@@ -273,9 +283,9 @@ class TestQwen3RerankerGetModelWarning:
 
 class TestRerankerFactory:
     def test_init_cloud_reranker(self):
-        """init_reranker('cloud') creates CohereReranker."""
+        """init_reranker('cloud') creates CloudReranker."""
         reranker = init_reranker("cloud", api_key="test-key")
-        assert isinstance(reranker, CohereReranker)
+        assert isinstance(reranker, CloudReranker)
         assert get_reranker() is reranker
 
     def test_init_local_reranker(self):
@@ -299,11 +309,11 @@ class TestRerankerFactory:
     def test_init_cloud_default_model(self):
         """Cloud reranker uses default model when none specified."""
         reranker = init_reranker("cloud", api_key="test-key")
-        assert isinstance(reranker, CohereReranker)
+        assert isinstance(reranker, CloudReranker)
         assert reranker.model == "rerank-v4.0-pro"
 
     def test_init_cloud_custom_model(self):
         """Cloud reranker accepts custom model."""
         reranker = init_reranker("cloud", model="rerank-v3.5", api_key="test-key")
-        assert isinstance(reranker, CohereReranker)
+        assert isinstance(reranker, CloudReranker)
         assert reranker.model == "rerank-v3.5"

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -719,6 +719,41 @@ async def test_config_unknown_action():
     assert "error" in data
     assert "Unknown action" in data["error"]
     assert "valid_actions" in data
+    assert "models" in data["valid_actions"]
+
+
+@pytest.mark.asyncio
+async def test_config_models_configured_only():
+    """models action lists configured-provider models with passthrough note."""
+    fake_models = [
+        {
+            "model": "gemini/gemini-3-flash-preview",
+            "provider": "gemini",
+            "mode": "chat",
+            "supports_vision": True,
+        }
+    ]
+    with patch("mcp_core.llm.list_models", return_value=fake_models) as mock_list:
+        res = await server.config("models")
+        data = json.loads(res)
+
+    assert data["models"] == fake_models
+    assert "passthrough" in data["note"]
+    call_kwargs = mock_list.call_args[1]
+    assert call_kwargs["modes"] == ("chat", "embedding", "rerank")
+    assert call_kwargs["configured_only"] is True
+    assert call_kwargs["limit"] == 200
+
+
+@pytest.mark.asyncio
+async def test_config_models_all():
+    """models action with key='all' lists the full catalog."""
+    with patch("mcp_core.llm.list_models", return_value=[]) as mock_list:
+        res = await server.config("models", key="all")
+        data = json.loads(res)
+
+    assert data["models"] == []
+    assert mock_list.call_args[1]["configured_only"] is False
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -430,25 +430,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cohere"
-version = "7.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastavro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/c0/3c9b38c7332dfb1523a079fa3c5ea701a5ea82997d12d057c4002b6a0c75/cohere-7.0.3.tar.gz", hash = "sha256:f74c6be98ee5d0d1310c3892171def2f184d5a9b7ab81d906407ffc7a5e62adc", size = 208811, upload-time = "2026-06-01T21:52:38.093Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/0d/f543e349da10761c498e3a773e728c2d6b1aeb47195f2f09c6145452d51c/cohere-7.0.3-py3-none-any.whl", hash = "sha256:c880a45c4cd670d5e7c9297de122005f21e2d9624fda9314cb3e4e0406bc9ec5", size = 351965, upload-time = "2026-06-01T21:52:36.429Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -744,26 +725,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastavro"
-version = "1.12.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/5b/ccb338db71f347e3bc031d268bf6dc41e5ead63b6997b8e72af92f05e18e/fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab", size = 1030127, upload-time = "2026-04-24T14:36:01.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/39/f489a441d41cc9c0a8449fb1325d7a9c9eb57a5634e6ab19dfb0a1105324/fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704", size = 958566, upload-time = "2026-04-24T14:36:45.49Z" },
-    { url = "https://files.pythonhosted.org/packages/31/69/776cc025aee2d02acacb734cf690d2fbc295eaadde1b5d47caf8c77a6a2b/fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0", size = 3276390, upload-time = "2026-04-24T14:36:47.875Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bc/b7e15fa788f42cbe65827af2ec06c9ad91bb9f72c213110dbef61b53a5b0/fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e", size = 3372779, upload-time = "2026-04-24T14:36:50.122Z" },
-    { url = "https://files.pythonhosted.org/packages/79/c2/98993ca810231fc1397212f48c3d46626983722a24bbaaa5c27ee0963751/fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea", size = 3187591, upload-time = "2026-04-24T14:36:52.451Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/bb/c180f340eba6478f1b20deccdd17e2b4a4d5074dafd812e3c4254fd035f7/fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e", size = 3320589, upload-time = "2026-04-24T14:36:54.647Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/e9/aca0456216b5b8992e7b0a8542711b66799c05bfe24c8e32ef6f56e7eb93/fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39", size = 440883, upload-time = "2026-04-24T14:36:56.585Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7e/984896e716af504927be71b80a1e9661aa96c6f9e1e777d52823aacb99f2/fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36", size = 377536, upload-time = "2026-04-24T14:36:58.274Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/42/09a1e1f8d9998d73848a6ff0aad6713ae6abf0dbf99918776f8ef33344a7/fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31", size = 1049506, upload-time = "2026-04-24T14:36:59.797Z" },
-    { url = "https://files.pythonhosted.org/packages/52/ef/80cc16f43919d532f25a707f34b275cccc09dca87a05b000fbbfc8e8f255/fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef", size = 3495899, upload-time = "2026-04-24T14:37:02.306Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/54/a0817d1d0236e9e0233f5c996f450cc795b056b8e06edb531f24b9df82ed/fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397", size = 3399232, upload-time = "2026-04-24T14:37:04.837Z" },
-    { url = "https://files.pythonhosted.org/packages/38/0a/650f256c15f5875b6081544b9ba7ed8254329213e7e49e3db0aec68b5bee/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff", size = 3320222, upload-time = "2026-04-24T14:37:07.281Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/54/8351d388f94fbb0870e8cffaae41d3cc607acc8d6a8a6a217e2794829593/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423", size = 3337096, upload-time = "2026-04-24T14:37:09.452Z" },
-]
-
-[[package]]
 name = "fastmcp"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -847,11 +808,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
 ]
 
 [[package]]
@@ -972,11 +933,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
 ]
 
-[package.optional-dependencies]
-requests = [
-    { name = "requests" },
-]
-
 [[package]]
 name = "google-auth-httplib2"
 version = "0.4.0"
@@ -988,27 +944,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
-]
-
-[[package]]
-name = "google-genai"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "google-auth", extra = ["requests"] },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "sniffio" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
 ]
 
 [[package]]
@@ -1230,14 +1165,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
 ]
 
 [[package]]
@@ -1568,6 +1503,29 @@ wheels = [
 ]
 
 [[package]]
+name = "litellm"
+version = "1.88.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ea/f99ececb7f22703fe120f1d8be9ffb749ec9453fbbbbbebc0d6a6b4d7864/litellm-1.88.1.tar.gz", hash = "sha256:89c6b74cc7912d6365793006ff951c0450fe847625008dfe49de8a7dc4529aa5", size = 13885969, upload-time = "2026-06-09T01:06:25.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/9a/8f8909201b4bebaf96498c09226f6baa8540086a4c4188ad57d7dfbd97c1/litellm-1.88.1-py3-none-any.whl", hash = "sha256:369b84e57d9426582ddc35e731956ddb6618cda97cc44e4e4d2dfa75982a6e3a", size = 15276206, upload-time = "2026-06-09T01:06:16.72Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1865,13 +1823,14 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.17.2"
+version = "1.18.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
     { name = "fastmcp" },
     { name = "filelock" },
+    { name = "httpcore" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "platformdirs" },
@@ -1879,9 +1838,14 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/d2/eb201a338a11207744fe1982f45bd35423e8b9609cc9662a0b6f7cdb0f4b/n24q02m_mcp_core-1.17.2.tar.gz", hash = "sha256:ffaa61a670a81b8c87474ab9e3b346defaf17167d8faa264b730485b17685a45", size = 201062, upload-time = "2026-06-01T06:44:10.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/aa/e8eb296141165057abb74f2e62f392c341b14e3259cb1677547b3a6760f1/n24q02m_mcp_core-1.18.0b1.tar.gz", hash = "sha256:832b29c70cae6a610a83c3a5c06bcb7220e6eaf43ea5dfa91ef47adc75ac332e", size = 252457, upload-time = "2026-06-10T13:31:50.457Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/44/93287e5005da6424e72c7676df401b171298a4dc93aabb9026bbb123d7e9/n24q02m_mcp_core-1.17.2-py3-none-any.whl", hash = "sha256:0ae421eb53198f71ff4837464baf41e114599b2527c4fcabbdde3698ef773826", size = 128228, upload-time = "2026-06-01T06:44:08.865Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/ce4c37b7c120eb6e0aee229665841bfcb2482bc650d49168c74a22253a77/n24q02m_mcp_core-1.18.0b1-py3-none-any.whl", hash = "sha256:6d4f84e4369aab5aa5d1213a1c7b34d5c61672eaa3834ee92bc9b4414626eb79", size = 135751, upload-time = "2026-06-10T13:31:49.33Z" },
+]
+
+[package.optional-dependencies]
+llm = [
+    { name = "litellm" },
 ]
 
 [[package]]
@@ -3341,18 +3305,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.33.0.20260518"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3573,19 +3525,17 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.4"
+version = "3.2.7b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
     { name = "alembic" },
     { name = "boto3" },
-    { name = "cohere" },
     { name = "cryptography" },
     { name = "diskcache" },
     { name = "fastmcp" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
-    { name = "google-genai" },
     { name = "greenlet" },
     { name = "httpx" },
     { name = "jsonschema" },
@@ -3593,9 +3543,8 @@ dependencies = [
     { name = "loguru" },
     { name = "markitdown", extra = ["docx", "pdf", "pptx", "xlsx"] },
     { name = "mcp", extra = ["cli"] },
-    { name = "n24q02m-mcp-core" },
+    { name = "n24q02m-mcp-core", extra = ["llm"] },
     { name = "n24q02m-web-core" },
-    { name = "openai" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -3624,13 +3573,11 @@ requires-dist = [
     { name = "aiolimiter", specifier = ">=1.2.1" },
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.43.24" },
-    { name = "cohere", specifier = ">=7.0.3" },
     { name = "cryptography", specifier = ">=48.0.0" },
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "fastmcp", specifier = ">=3.4.2,<4" },
     { name = "google-api-python-client", specifier = ">=2.197.0" },
     { name = "google-auth", specifier = ">=2.53.0" },
-    { name = "google-genai", specifier = ">=2.8.0" },
     { name = "greenlet", specifier = "<3.5.2" },
     { name = "httpx" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -3639,9 +3586,8 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.17.2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b1,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.1.1" },
-    { name = "openai", specifier = ">=2.41.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },


### PR DESCRIPTION
## Summary

Migrates wet-mcp's LLM/embedding/rerank dispatch from hand-rolled native-SDK code to the new `mcp_core.llm` litellm-passthrough primitive (mcp-core[llm] 1.18.0b1). Zero behavior change to defaults; opens passthrough to any litellm provider/model.

- **llm.py**: `acompletion` signature preserved (4 call sites unchanged); delegates to `mcp_core.llm.acompletion` (lazy import); wet-owned fallback loop kept; `LLM_API_BASE` env. Removed ~250 lines of provider-specific code (`_gemini_completion`/`_openai_completion`/`_convert_messages_to_gemini`/OpenAI shim classes).
- **embedder.py / reranker.py**: per-provider cloud methods → single litellm path (`aembedding` / sync `rerank`); model-prefix mapping; `EMBEDDING_API_BASE`/`RERANK_API_BASE`; preserved retry/backoff, dimensions-retry, batch-split, 768-dim truncation, `[]`-on-failure, local ONNX backends. Hardened response-shape parsing (None-guard, dict/pydantic dual-access).
- **Parity fix**: added `XAI_API_KEY` to relay form + credential state (was supported in code but never collectable).
- **config(action="models")**: lists litellm catalog models filtered by capability + configured providers, with passthrough note.
- Removed direct deps: google-genai, cohere, openai (openai stays transitive via litellm). Kept qwen3-embed.

## Test plan

- Full suite: 1824 passed / 32 skipped / 0 failed (baseline was 1815).
- E2E gate (real keys, skret): Jina embedding + Jina rerank end-to-end PASS; xAI chat acompletion (system-message role + json_schema enforce) PASS; protocol `config(models/status)` + tools/list PASS over stdio ClientSession; provider routing verified via litellm logs. Gemini live path deferred (account billing-gated; identical code path covered by units + Jina).

🤖 Generated with [Claude Code](https://claude.com/claude-code)