### PR TITLE
fix: cap n24q02m-web-core to <2.2 (private SSRF API drift breaks fresh install)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,13 @@ classifiers = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
-    # Shared web infrastructure (SSRF, SearXNG, URL utils, ScrapingAgent + Crawl4AI transitive)
-    "n24q02m-web-core>=2.1.1",
+    # Shared web infrastructure (SSRF, SearXNG, URL utils, ScrapingAgent + Crawl4AI transitive).
+    # Cap <2.2: wet's security.py + tests consume web-core private SSRF internals
+    # (_ssrf_event_hook, _original_getaddrinfo). web-core 2.2.x refactored these to a
+    # factory (_ssrf_event_hook_factory), so a fresh install resolving >=2.1.1 picks
+    # 2.2.x and ImportErrors at boot. Cap to the tested 2.1.x API until wet is
+    # decoupled to web-core's public surface (is_safe_url / safe_httpx_client).
+    "n24q02m-web-core>=2.1.1,<2.2",
     # MCP Server
     "mcp[cli]",
     # HTTP Client

--- a/uv.lock
+++ b/uv.lock
@@ -3587,7 +3587,7 @@ requires-dist = [
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
     { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b1,<2" },
-    { name = "n24q02m-web-core", specifier = ">=2.1.1" },
+    { name = "n24q02m-web-core", specifier = ">=2.1.1,<2.2" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },


### PR DESCRIPTION
## Problem (P1 — found by protocol Test B)

`uvx wet-mcp` / fresh PyPI install **fails to boot**:
```
ImportError: cannot import name '_ssrf_event_hook' from 'web_core.http.client'
```
`security.py` (+ `tests/test_security.py`, `tests/test_docs_coverage.py`) import web-core **private** SSRF internals (`_ssrf_event_hook`, `_original_getaddrinfo`, ...). web-core 2.2.x refactored these to a factory (`_ssrf_event_hook_factory`). wet pinned `>=2.1.1` (open upper) → fresh resolve picked 2.2.x → ImportError at import time.

CI never caught it: `uv.lock` pins web-core 2.1.1, so CI/precommit always ran the compatible version. Only a fresh resolution (uvx / new clone) hits 2.2.x. Surfaced by the litellm-wave protocol Test B (boots the published beta via `uvx`).

## Fix

Cap `n24q02m-web-core>=2.1.1,<2.2` — the API wet's code+tests are written against (matches the existing `fastmcp<4` cap pattern). Lock unchanged (already 2.1.1).

## Follow-up (not in this PR)

wet should be **decoupled from web-core private internals** — re-export only the public surface (`is_safe_url`, `safe_httpx_client`, `setup_browser_ssrf_protection`) and rewrite `test_security.py`/`test_docs_coverage.py` to test behavior via the public API. Then the cap can lift to adopt web-core 2.2.x SSRF hardening.

Discovered during the litellm passthrough wave; pre-existing, independent of litellm.