### PR TITLE
feat: model-chain selection (wet)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "aiolimiter>=1.2.1",
     # Relay setup (zero-env-config) + LLM passthrough (litellm via [llm] extra).
     # Beta pin until 1.18.0 stable.
-    "n24q02m-mcp-core[llm]>=1.18.0b1,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.4",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from mcp_core.llm.providers import key_env_for_model
 from pydantic import SecretStr
 from pydantic_settings import BaseSettings
 
@@ -39,22 +40,6 @@ def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
     return onnx_name
 
 
-# Known providers that support reranking
-_RERANK_PROVIDERS: dict[str, str] = {
-    "JINA_AI_API_KEY": "jina_ai/jina-reranker-v3",
-    "COHERE_API_KEY": "cohere/rerank-v4.0-pro",
-}
-
-# Known providers that support embedding
-_EMBEDDING_PROVIDERS: dict[str, str] = {
-    "JINA_AI_API_KEY": "jina_ai/jina-embeddings-v5-text-small",
-    "GEMINI_API_KEY": "gemini/gemini-embedding-001",
-    "GOOGLE_API_KEY": "gemini/gemini-embedding-001",
-    "OPENAI_API_KEY": "text-embedding-3-large",
-    "COHERE_API_KEY": "embed-multilingual-v3.0",
-}
-
-
 class Settings(BaseSettings):
     """WET MCP Server configuration.
 
@@ -65,15 +50,18 @@ class Settings(BaseSettings):
         Or file path: "@path/to/keys"
         Example: "GOOGLE_API_KEY:AIza...,COHERE_API_KEY:..."
         Embedding providers: Jina, Google, OpenAI, Cohere
-        Reranking providers: Jina, Cohere (auto-detected)
-    - EMBEDDING_MODEL: Embedding model (auto-detected if not set)
+        Reranking providers: Jina, Cohere
+    - EMBEDDING_MODELS: Embedding model chain "provider/model,..." (order =
+        litellm fallback). Empty -> curated default filtered to configured
+        keys; no usable key -> local ONNX. Backend inferred from this chain.
+    - RERANK_MODELS: Rerank model chain (same semantics as EMBEDDING_MODELS).
     - EMBEDDING_DIMS: Embedding dimensions (0 = auto-detect, default 768)
-    - EMBEDDING_BACKEND: "cloud" | "local" (auto: API_KEYS -> cloud, else local)
-        Local: GGUF if GPU + llama-cpp-python, else ONNX
     - RERANK_ENABLED: Enable reranking (default: true)
-    - RERANK_BACKEND: "cloud" | "local" (auto: Cohere key -> cloud, else local)
-    - RERANK_MODEL: Rerank model (auto-detected from API_KEYS if Cohere)
     - RERANK_TOP_N: Return top N results after reranking (default: 10)
+    - EMBEDDING_MODEL / EMBEDDING_BACKEND / RERANK_MODEL / RERANK_BACKEND:
+        DEPRECATED (2026-06-11) -- singular model + backend env vars, folded
+        into the plural *_MODELS chain (honored one release with a warning).
+        Local: GGUF if GPU + llama-cpp-python, else ONNX.
     - SYNC_ENABLED: Enable Google Drive sync (default: true)
     - SYNC_FOLDER: Google Drive folder name (default: "wet-mcp")
     - SYNC_INTERVAL: Auto-sync interval in seconds (default: 300)
@@ -119,17 +107,25 @@ class Settings(BaseSettings):
     # Docs storage
     docs_db_path: str = ""  # Default: ~/.wet-mcp/docs.db
 
+    # Per-task model chains "provider/model,provider/model" (order = litellm
+    # fallback). Empty -> local ONNX. Replaces the priority-router auto-detect
+    # and the singular EMBEDDING_MODEL/EMBEDDING_BACKEND (deprecated shims).
+    embedding_models: str = ""
+    rerank_models: str = ""
+    # DEPRECATED (2026-06-11): folded into EMBEDDING_MODELS/RERANK_MODELS,
+    # honored one release with a warning. Backend now inferred.
+
     # Embedding
-    embedding_model: str = ""  # Model name, auto-detect if empty
+    embedding_model: str = ""  # DEPRECATED: folded into EMBEDDING_MODELS
     embedding_dims: int = 0  # 0 = use server default (768)
-    embedding_backend: str = ""  # "cloud" | "local" | "" (auto)
+    embedding_backend: str = ""  # DEPRECATED: inferred from EMBEDDING_MODELS
 
     # Reranking
     rerank_enabled: bool = (
         True  # Enable reranking (always available via local fallback)
     )
-    rerank_backend: str = ""  # "cloud" | "local" | "" (auto)
-    rerank_model: str = ""  # Rerank model (e.g., "rerank-v4.0-pro")
+    rerank_backend: str = ""  # DEPRECATED: inferred from RERANK_MODELS
+    rerank_model: str = ""  # DEPRECATED: folded into RERANK_MODELS
     rerank_top_n: int = 10  # Return top N after reranking
 
     # Docs sync (Google Drive API)
@@ -249,13 +245,70 @@ class Settings(BaseSettings):
 
         return keys_by_env
 
-    # --- Embedding resolution ---
+    # --- Per-task model chains ---
 
-    def resolve_embedding_model(self) -> str | None:
-        """Return explicit EMBEDDING_MODEL or None for auto-detect."""
-        if self.embedding_model:
-            return self.embedding_model
-        return None
+    # Explicit provider prefixes so key-availability filtering + litellm
+    # routing are unambiguous (cohere/openai bare names would mis-detect).
+    _DEFAULT_EMBEDDING_CHAIN = (
+        "jina_ai/jina-embeddings-v5-text-small",
+        "gemini/gemini-embedding-001",
+        "openai/text-embedding-3-large",
+        "cohere/embed-multilingual-v3.0",
+    )
+    _DEFAULT_RERANK_CHAIN = (
+        "jina_ai/jina-reranker-v3",
+        "cohere/rerank-v3.5",
+    )
+
+    def _key_available(self, env_var: str) -> bool:
+        """Whether a provider key is set (env or GOOGLE->GEMINI alias)."""
+        if os.getenv(env_var):
+            return True
+        # GOOGLE_API_KEY satisfies GEMINI_API_KEY (wet's _ENV_ALIASES)
+        aliases = getattr(self, "_ENV_ALIASES", {})
+        for alias, canonical in aliases.items():
+            if canonical == env_var and os.getenv(alias):
+                return True
+        return False
+
+    def _chain(self, primary: str, legacy: str, default: tuple[str, ...]) -> list[str]:
+        if primary:
+            return [m.strip() for m in primary.split(",") if m.strip()]
+        if legacy:
+            logger.warning(
+                "Deprecated singular model env honored; migrate to the plural "
+                "<TASK>_MODELS chain (removed next release): {!r}",
+                legacy,
+            )
+            return [legacy.strip()]
+        # Curated default, but ONLY models whose provider key is configured;
+        # none -> empty -> local ONNX (no priority-router, no keyless cloud).
+        return [m for m in default if self._key_available(key_env_for_model(m))]
+
+    def embedding_chain(self) -> list[str]:
+        return self._chain(
+            self.embedding_models, self.embedding_model, self._DEFAULT_EMBEDDING_CHAIN
+        )
+
+    def rerank_chain(self) -> list[str]:
+        if not self.rerank_enabled:
+            return []
+        return self._chain(
+            self.rerank_models, self.rerank_model, self._DEFAULT_RERANK_CHAIN
+        )
+
+    def embedding_primary(self) -> str | None:
+        c = self.embedding_chain()
+        return c[0] if c else None
+
+    def rerank_primary(self) -> str | None:
+        c = self.rerank_chain()
+        return c[0] if c else None
+
+    def llm_chain(self) -> list[str]:
+        return [m.strip() for m in self.llm_models.split(",") if m.strip()]
+
+    # --- Embedding resolution ---
 
     def resolve_embedding_dims(self) -> int:
         """Return explicit EMBEDDING_DIMS or 0 for auto-detect."""
@@ -271,19 +324,21 @@ class Settings(BaseSettings):
     def resolve_embedding_backend(self) -> str:
         """Resolve embedding backend: 'local' or 'cloud'.
 
-        Always returns a valid backend (never empty).
-
-        Auto-detect order:
-        1. Explicit EMBEDDING_BACKEND setting
-        2. 'cloud' if API keys are configured
-        3. 'local' (qwen3-embed built-in, always available)
+        Always returns a valid backend (never empty). Backend is inferred
+        from EMBEDDING_MODELS (non-empty chain -> cloud, empty -> local);
+        the deprecated EMBEDDING_BACKEND env var is honored for one release.
         """
         if self.embedding_backend:
-            return self.embedding_backend
-        mode = self.resolve_provider_mode()
-        if mode == "sdk":
-            return "cloud"
-        return "local"
+            logger.warning(
+                "Deprecated EMBEDDING_BACKEND honored; inferred from "
+                "EMBEDDING_MODELS now."
+            )
+            return (
+                "cloud"
+                if self.embedding_backend in ("cloud", "litellm")
+                else self.embedding_backend
+            )
+        return "cloud" if self.embedding_chain() else "local"
 
     # --- Reranking resolution ---
 
@@ -295,54 +350,24 @@ class Settings(BaseSettings):
         )
 
     def resolve_rerank_backend(self) -> str:
-        """Resolve reranking backend: 'local', 'cloud', or ''.
+        """Resolve reranking backend: 'cloud', 'local', or '' (disabled).
 
-        Returns '' only if reranking is explicitly disabled.
-        Always returns a valid backend otherwise.
-
-        Auto-detect order:
-        1. Explicit RERANK_BACKEND setting
-        2. 'cloud' if RERANK_MODEL is set
-        3. 'cloud' if API_KEYS contains a rerank-capable provider (Cohere)
-        4. 'local' (qwen3-embed built-in, always available)
+        Disabled when rerank_enabled is False. Otherwise inferred from
+        RERANK_MODELS (non-empty chain -> cloud, empty -> local); the
+        deprecated RERANK_BACKEND env var is honored for one release.
         """
         if not self.rerank_enabled:
             return ""
         if self.rerank_backend:
-            return self.rerank_backend
-        if self.rerank_model:
-            return "cloud"
-
-        # Check env vars first (populated by setup_api_keys)
-        for provider_key in _RERANK_PROVIDERS:
-            if os.environ.get(provider_key):
-                return "cloud"
-
-        if self.api_keys:
-            val = self.api_keys.get_secret_value()
-            if not val.startswith("@"):
-                for provider_key in _RERANK_PROVIDERS:
-                    if provider_key in val:
-                        return "cloud"
-        return "local"
-
-    def resolve_rerank_model(self) -> str | None:
-        """Resolve rerank model from config or auto-detect from API_KEYS."""
-        if self.rerank_model:
-            return self.rerank_model
-
-        # Check env vars first
-        for provider_key, model in _RERANK_PROVIDERS.items():
-            if os.environ.get(provider_key):
-                return model
-
-        if self.api_keys:
-            val = self.api_keys.get_secret_value()
-            if not val.startswith("@"):
-                for provider_key, model in _RERANK_PROVIDERS.items():
-                    if provider_key in val:
-                        return model
-        return None
+            logger.warning(
+                "Deprecated RERANK_BACKEND honored; inferred from RERANK_MODELS now."
+            )
+            return (
+                "cloud"
+                if self.rerank_backend in ("cloud", "litellm")
+                else self.rerank_backend
+            )
+        return "cloud" if self.rerank_chain() else "local"
 
     # --- Provider mode resolution ---
 
@@ -383,14 +408,5 @@ class Settings(BaseSettings):
 
         return mode
 
-
-# Embedding models to try during auto-detection (in priority order).
-# Validated against API keys -- first success wins.
-_EMBEDDING_CANDIDATES = [
-    "jina_ai/jina-embeddings-v5-text-small",
-    "gemini/gemini-embedding-001",
-    "text-embedding-3-large",
-    "embed-multilingual-v3.0",
-]
 
 settings = Settings()

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -1,59 +1,108 @@
-"""Config schema for relay page setup."""
+"""Config schema for relay page setup.
+
+Tasks are model chains (order = litellm fallback). Provider key fields are
+``derived`` -- the relay widget surfaces them automatically for the providers
+the chosen models reference. ``GITHUB_TOKEN`` is a plain (non-derived) key:
+it is NOT a model-provider key, just an optional GitHub API rate-limit bump
+for library docs discovery.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
+_EMBEDDING_SUGGESTED = [
+    "jina_ai/jina-embeddings-v5-text-small",
+    "gemini/gemini-embedding-001",
+    "openai/text-embedding-3-large",
+    "cohere/embed-multilingual-v3.0",
+]
+_RERANK_SUGGESTED = ["jina_ai/jina-reranker-v3", "cohere/rerank-v3.5"]
+_LLM_SUGGESTED = [
+    "gemini/gemini-3-flash-preview",
+    "openai/gpt-5.4-mini-2026-03-17",
+    "anthropic/claude-haiku-4-5",
+    "xai/grok-4-fast",
+]
+
+
+def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "type": "password",
+        "placeholder": ph,
+        "helpUrl": url,
+        "derived": True,
+        "required": False,
+    }
+
+
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "wet-mcp",
     "displayName": "Web Extended Toolkit",
-    "description": "Enter API keys for cloud capabilities. Leave all empty for pure local mode (ONNX models).",
+    "description": (
+        "Pick models per task (order = fallback). Leave a task empty for "
+        "local ONNX (embedding/rerank) — LLM features need at least one model. "
+        "Key fields appear automatically for the providers your models use. "
+        "Search + extraction are always local (no key needed)."
+    ),
     "fields": [
         {
-            "key": "JINA_AI_API_KEY",
-            "label": "Jina AI API Key",
-            "type": "password",
-            "placeholder": "jina_...",
-            "helpUrl": "https://jina.ai/api-key",
-            "helpText": "Embedding + Reranking (highest priority cloud provider).",
-            "required": False,
+            "key": "EMBEDDING_MODELS",
+            "label": "Embedding models",
+            "type": "model-chain",
+            "task": "embedding",
+            "suggestedModels": _EMBEDDING_SUGGESTED,
+            "hasLocal": True,
+            "placeholder": "add embedding model…",
         },
         {
-            "key": "GEMINI_API_KEY",
-            "label": "Gemini API Key",
-            "type": "password",
-            "placeholder": "AIza...",
-            "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": "LLM (structured extraction) + Embedding. Free tier available.",
-            "required": False,
+            "key": "RERANK_MODELS",
+            "label": "Rerank models",
+            "type": "model-chain",
+            "task": "rerank",
+            "suggestedModels": _RERANK_SUGGESTED,
+            "hasLocal": True,
+            "placeholder": "add rerank model…",
         },
         {
-            "key": "OPENAI_API_KEY",
-            "label": "OpenAI API Key",
-            "type": "password",
-            "placeholder": "sk-...",
-            "helpUrl": "https://platform.openai.com/api-keys",
-            "helpText": "LLM + Embedding (lower priority than Gemini).",
-            "required": False,
+            "key": "LLM_MODELS",
+            "label": "LLM models",
+            "type": "model-chain",
+            "task": "chat",
+            "suggestedModels": _LLM_SUGGESTED,
+            "hasLocal": False,
+            "placeholder": "add LLM model…",
         },
-        {
-            "key": "COHERE_API_KEY",
-            "label": "Cohere API Key",
-            "type": "password",
-            "placeholder": "co-...",
-            "helpUrl": "https://dashboard.cohere.com/api-keys",
-            "helpText": "Embedding + Reranking.",
-            "required": False,
-        },
-        {
-            "key": "XAI_API_KEY",
-            "label": "xAI API Key",
-            "type": "password",
-            "placeholder": "xai-...",
-            "helpUrl": "https://console.x.ai",
-            "helpText": "LLM (xAI/Grok).",
-            "required": False,
-        },
+        _key_field(
+            "JINA_AI_API_KEY", "Jina AI API Key", "jina_...", "https://jina.ai/api-key"
+        ),
+        _key_field(
+            "GEMINI_API_KEY",
+            "Gemini API Key",
+            "AIza...",
+            "https://aistudio.google.com/apikey",
+        ),
+        _key_field(
+            "OPENAI_API_KEY",
+            "OpenAI API Key",
+            "sk-...",
+            "https://platform.openai.com/api-keys",
+        ),
+        _key_field(
+            "COHERE_API_KEY",
+            "Cohere API Key",
+            "co-...",
+            "https://dashboard.cohere.com/api-keys",
+        ),
+        _key_field(
+            "ANTHROPIC_API_KEY",
+            "Anthropic API Key",
+            "sk-ant-...",
+            "https://console.anthropic.com/settings/keys",
+        ),
+        _key_field("XAI_API_KEY", "xAI API Key", "xai-...", "https://console.x.ai/"),
         {
             "key": "GITHUB_TOKEN",
             "label": "GitHub Personal Access Token",
@@ -77,18 +126,18 @@ RELAY_SCHEMA: dict[str, Any] = {
         },
         {
             "label": "Embedding",
-            "priority": "Jina > Gemini > OpenAI > Cohere > Local ONNX",
-            "description": "Vector embeddings for docs search. Local mode uses Qwen3-Embedding (0.6B ONNX).",
+            "priority": "configurable",
+            "description": "Vector embeddings for docs search. Empty = local Qwen3-Embedding ONNX.",
         },
         {
             "label": "Reranking",
-            "priority": "Jina > Cohere > Local ONNX",
-            "description": "Re-ranks search results for accuracy. Local mode uses Qwen3-Reranker (0.6B ONNX).",
+            "priority": "configurable",
+            "description": "Re-ranks search results for accuracy. Empty = local Qwen3-Reranker ONNX.",
         },
         {
             "label": "LLM",
-            "priority": "Gemini > OpenAI > xAI",
-            "description": "Used for structured extraction. Without a key, these features are limited.",
+            "priority": "configurable",
+            "description": "Structured extraction. Empty = these features are limited.",
         },
     ],
 }

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -23,7 +23,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from wet_mcp.cache import WebCache
-from wet_mcp.config import _EMBEDDING_CANDIDATES, settings
+from wet_mcp.config import settings
 from wet_mcp.db import DocsDB
 from wet_mcp.searxng_runner import ensure_searxng, stop_searxng
 from wet_mcp.security import wrap_external_content
@@ -413,37 +413,22 @@ async def _init_embedding_backend(mode: str) -> None:
             logger.error(f"Local embedding init failed: {e}")
         return
 
-    # CONFIGURED + cloud backend
-    model = settings.resolve_embedding_model()
-    if model:
+    # CONFIGURED + cloud backend -- no local fallback.
+    # Try each model in the chain (litellm fallback order) until one validates.
+    for candidate in settings.embedding_chain():
         try:
-            backend = await asyncio.to_thread(init_backend, "cloud", model)
+            backend = await asyncio.to_thread(init_backend, "cloud", candidate)
             native_dims = await backend.check_available()
             if native_dims > 0:
                 if _embedding_dims == 0:
                     _embedding_dims = _DEFAULT_EMBEDDING_DIMS
                 logger.info(
-                    f"Embedding: {model} "
+                    f"Embedding: {candidate} "
                     f"(native={native_dims}, stored={_embedding_dims})"
                 )
                 return
         except Exception as e:
-            logger.warning(f"Embedding model {model} not available: {e}")
-    elif mode == "sdk":
-        for candidate in _EMBEDDING_CANDIDATES:
-            try:
-                backend = await asyncio.to_thread(init_backend, "cloud", candidate)
-                native_dims = await backend.check_available()
-                if native_dims > 0:
-                    if _embedding_dims == 0:
-                        _embedding_dims = _DEFAULT_EMBEDDING_DIMS
-                    logger.info(
-                        f"Embedding: {candidate} "
-                        f"(native={native_dims}, stored={_embedding_dims})"
-                    )
-                    return
-            except Exception:
-                continue
+            logger.warning(f"Embedding model {candidate} not available: {e}")
 
     logger.error("Cloud embedding not available and local fallback is disabled")
 
@@ -484,9 +469,9 @@ async def _init_reranker_backend(mode: str) -> None:
             logger.error(f"Local reranker init failed: {e}")
         return
 
-    # CONFIGURED + cloud backend
-    model = settings.resolve_rerank_model()
-    if model:
+    # CONFIGURED + cloud backend -- no local fallback.
+    # Try each model in the chain (litellm fallback order) until one validates.
+    for model in settings.rerank_chain():
         try:
             reranker = await asyncio.to_thread(init_reranker, "cloud", model)
             available = await asyncio.to_thread(reranker.check_available)

--- a/src/wet_mcp/setup_tool.py
+++ b/src/wet_mcp/setup_tool.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from wet_mcp.config import _EMBEDDING_CANDIDATES, settings
+from wet_mcp.config import settings
 
 
 def clear_model_cache(model_name: str) -> str | None:
@@ -39,11 +39,8 @@ async def _validate_cloud_models(settings_obj) -> dict:
     from wet_mcp.embedder import init_backend
     from wet_mcp.reranker import init_reranker
 
-    model = settings_obj.resolve_embedding_model()
-    candidates = [model] if model else _EMBEDDING_CANDIDATES
-
     embedding_info = None
-    for candidate in candidates:
+    for candidate in settings_obj.embedding_chain():
         try:
             backend = init_backend("cloud", candidate)
             dims = await backend.check_available()
@@ -58,16 +55,17 @@ async def _validate_cloud_models(settings_obj) -> dict:
         return {"cloud_ready": False}
 
     reranker_info = None
-    rerank_model = settings_obj.resolve_rerank_model()
-    if rerank_model:
+    for rerank_model in settings_obj.rerank_chain():
         try:
             reranker = init_reranker("cloud", rerank_model)
             # reranker.check_available() is sync (unlike embedder.check_available());
             # adding async reranker backends will require awaiting here
             if reranker.check_available():
                 reranker_info = {"model": rerank_model}
+                break
         except Exception as exc:
             logger.debug(f"Cloud reranker {rerank_model} failed: {exc}")
+            continue
 
     return {
         "cloud_ready": True,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,31 +113,33 @@ def test_setup_api_keys_complex_whitespace():
 
 
 def test_resolve_embedding_backend_explicit():
-    """Explicit EMBEDDING_BACKEND is returned as-is."""
+    """Deprecated EMBEDDING_BACKEND is still honored (one release)."""
     settings = Settings(embedding_backend="cloud")
     assert settings.resolve_embedding_backend() == "cloud"
 
 
 def test_resolve_embedding_backend_local_auto():
-    """Auto-detect returns 'local' when qwen3-embed is importable."""
-    settings = Settings(embedding_backend="")
-    with mock.patch.dict("sys.modules", {"qwen3_embed": mock.MagicMock()}):
+    """Inferred 'local' when chain is empty (no keys)."""
+    settings = Settings(embedding_backend="", embedding_models="")
+    with mock.patch.dict(os.environ, {}, clear=True):
         assert settings.resolve_embedding_backend() == "local"
 
 
 def test_resolve_embedding_backend_cloud_auto():
-    """Auto-detect returns 'cloud' when API keys are set."""
-    settings = Settings(embedding_backend="", api_keys=SecretStr("GOOGLE_API_KEY:abc"))
-    result = settings.resolve_embedding_backend()
-    assert result == "cloud"
+    """Inferred 'cloud' when an explicit chain is set."""
+    settings = Settings(
+        embedding_backend="",
+        embedding_models="gemini/gemini-embedding-001",
+    )
+    assert settings.resolve_embedding_backend() == "cloud"
 
 
 def test_resolve_embedding_backend_none():
-    """Returns 'local' when no backend is available and no keys."""
+    """Returns 'local' when chain is empty and no keys."""
     settings = Settings(embedding_backend="", api_keys=None)
     with mock.patch.dict(os.environ, {}, clear=True):
         result = settings.resolve_embedding_backend()
-        assert isinstance(result, str)
+        assert result == "local"
 
 
 # -----------------------------------------------------------------------
@@ -152,37 +154,27 @@ def test_resolve_rerank_backend_disabled():
 
 
 def test_resolve_rerank_backend_explicit():
-    """Explicit RERANK_BACKEND is returned as-is."""
+    """Deprecated RERANK_BACKEND is still honored (one release)."""
     settings = Settings(rerank_backend="cloud", rerank_enabled=True)
     assert settings.resolve_rerank_backend() == "cloud"
 
 
-def test_resolve_rerank_backend_follows_embedding():
-    """Rerank backend follows embedding backend when not explicit."""
+def test_resolve_rerank_backend_local_when_empty():
+    """Inferred 'local' when rerank chain is empty (no keys)."""
     settings = Settings(
-        embedding_backend="local",
         rerank_backend="",
+        rerank_models="",
         rerank_enabled=True,
     )
-    with mock.patch.dict("sys.modules", {"qwen3_embed": mock.MagicMock()}):
+    for v in ("JINA_AI_API_KEY", "COHERE_API_KEY"):
+        os.environ.pop(v, None)
+    with mock.patch.dict(os.environ, {}, clear=True):
         assert settings.resolve_rerank_backend() == "local"
 
 
 # -----------------------------------------------------------------------
 # Embedding model resolution
 # -----------------------------------------------------------------------
-
-
-def test_resolve_embedding_model_explicit():
-    """Explicit EMBEDDING_MODEL is returned."""
-    settings = Settings(embedding_model="gemini/gemini-embedding-2-preview")
-    assert settings.resolve_embedding_model() == "gemini/gemini-embedding-2-preview"
-
-
-def test_resolve_embedding_model_auto():
-    """Returns None for auto-detection when no explicit model."""
-    settings = Settings(embedding_model="")
-    assert settings.resolve_embedding_model() is None
 
 
 def test_resolve_embedding_dims():
@@ -274,12 +266,12 @@ def test_setup_api_keys_file_read_error(tmp_path):
 
 
 # -----------------------------------------------------------------------
-# resolve_rerank_backend: rerank_model, env var, api_keys detection
+# resolve_rerank_backend: chain-inferred + disabled
 # -----------------------------------------------------------------------
 
 
 def test_resolve_rerank_backend_rerank_model_set():
-    """Returns 'cloud' when rerank_model is explicitly set."""
+    """Deprecated rerank_model folds into the chain -> 'cloud'."""
     settings = Settings(
         rerank_enabled=True,
         rerank_backend="",
@@ -288,75 +280,27 @@ def test_resolve_rerank_backend_rerank_model_set():
     assert settings.resolve_rerank_backend() == "cloud"
 
 
-def test_resolve_rerank_backend_env_var_detection():
-    """Returns 'cloud' when COHERE_API_KEY is in env."""
+def test_resolve_rerank_backend_explicit_chain_cloud():
+    """Explicit RERANK_MODELS chain -> 'cloud'."""
     settings = Settings(
         rerank_enabled=True,
         rerank_backend="",
-        api_keys=None,
+        rerank_models="cohere/rerank-v3.5",
     )
-    with mock.patch.dict(os.environ, {"COHERE_API_KEY": "test-key"}, clear=False):
-        assert settings.resolve_rerank_backend() == "cloud"
-
-
-def test_resolve_rerank_backend_api_keys_cohere():
-    """Returns 'cloud' when API_KEYS contains COHERE_API_KEY."""
-    settings = Settings(
-        rerank_enabled=True,
-        rerank_backend="",
-        api_keys=SecretStr("COHERE_API_KEY:test"),
-    )
-    with mock.patch.dict(os.environ, {}, clear=True):
-        assert settings.resolve_rerank_backend() == "cloud"
+    assert settings.resolve_rerank_backend() == "cloud"
 
 
 def test_resolve_rerank_backend_local_fallback():
-    """Returns 'local' when no rerank provider is detected."""
+    """Returns 'local' when no rerank provider key / chain configured."""
     settings = Settings(
         rerank_enabled=True,
         rerank_backend="",
+        rerank_models="",
         api_keys=None,
     )
     with mock.patch.dict(os.environ, {}, clear=True):
-        # Remove COHERE_API_KEY if present
         os.environ.pop("COHERE_API_KEY", None)
         assert settings.resolve_rerank_backend() == "local"
-
-
-# -----------------------------------------------------------------------
-# resolve_rerank_model: auto-detection
-# -----------------------------------------------------------------------
-
-
-def test_resolve_rerank_model_explicit():
-    """Returns explicit rerank_model when set."""
-    settings = Settings(rerank_model="cohere/custom-model")
-    assert settings.resolve_rerank_model() == "cohere/custom-model"
-
-
-def test_resolve_rerank_model_env_var_auto():
-    """Auto-detects model from COHERE_API_KEY env var."""
-    settings = Settings(rerank_model="")
-    with mock.patch.dict(os.environ, {"COHERE_API_KEY": "test-key"}, clear=False):
-        assert settings.resolve_rerank_model() == "cohere/rerank-v4.0-pro"
-
-
-def test_resolve_rerank_model_api_keys_auto():
-    """Auto-detects model from API_KEYS containing COHERE_API_KEY."""
-    settings = Settings(
-        rerank_model="",
-        api_keys=SecretStr("COHERE_API_KEY:test-key"),
-    )
-    with mock.patch.dict(os.environ, {}, clear=True):
-        assert settings.resolve_rerank_model() == "cohere/rerank-v4.0-pro"
-
-
-def test_resolve_rerank_model_none():
-    """Returns None when no rerank provider detected."""
-    settings = Settings(rerank_model="", api_keys=None)
-    with mock.patch.dict(os.environ, {}, clear=True):
-        os.environ.pop("COHERE_API_KEY", None)
-        assert settings.resolve_rerank_model() is None
 
 
 # -----------------------------------------------------------------------
@@ -505,3 +449,93 @@ def test_resolve_local_rerank_model():
         result = settings.resolve_local_rerank_model()
         assert result == "test-rerank"
         m.assert_called_once()
+
+
+# -----------------------------------------------------------------------
+# Per-task model chains (model-chain migration, 2026-06-11)
+# -----------------------------------------------------------------------
+
+
+def test_wet_embedding_chain_explicit(monkeypatch):
+    monkeypatch.setenv(
+        "EMBEDDING_MODELS",
+        "jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
+    )
+    s = Settings()
+    assert s.embedding_chain()[0] == "jina_ai/jina-embeddings-v5-text-small"
+    assert s.resolve_embedding_backend() == "cloud"
+
+
+def test_wet_embedding_empty_local(monkeypatch):
+    for v in (
+        "EMBEDDING_MODELS",
+        "EMBEDDING_MODEL",
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_KEY",
+        "COHERE_API_KEY",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    assert Settings().embedding_chain() == []
+    assert Settings().resolve_embedding_backend() == "local"
+
+
+def test_wet_rerank_openai_only_is_local(monkeypatch):
+    for v in ("RERANK_MODELS", "RERANK_MODEL", "JINA_AI_API_KEY", "COHERE_API_KEY"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+    assert Settings().rerank_chain() == []  # no jina/cohere key -> empty -> local
+    assert Settings().resolve_rerank_backend() == "local"
+
+
+def test_wet_llm_chain_default(monkeypatch):
+    monkeypatch.delenv("LLM_MODELS", raising=False)
+    assert Settings().llm_chain()[0] == "gemini/gemini-3-flash-preview"
+
+
+def test_wet_embedding_primary(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_MODELS", "cohere/embed-multilingual-v3.0")
+    assert Settings().embedding_primary() == "cohere/embed-multilingual-v3.0"
+
+
+def test_wet_rerank_primary(monkeypatch):
+    monkeypatch.setenv("RERANK_MODELS", "jina_ai/jina-reranker-v3,cohere/rerank-v3.5")
+    assert Settings().rerank_primary() == "jina_ai/jina-reranker-v3"
+
+
+def test_wet_rerank_chain_disabled():
+    s = Settings(rerank_enabled=False, rerank_models="cohere/rerank-v3.5")
+    assert s.rerank_chain() == []
+    assert s.resolve_rerank_backend() == ""
+
+
+def test_wet_default_chain_filters_to_configured_keys(monkeypatch):
+    for v in (
+        "EMBEDDING_MODELS",
+        "EMBEDDING_MODEL",
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_KEY",
+        "COHERE_API_KEY",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "x")
+    # Default chain filtered to providers with a configured key.
+    assert Settings().embedding_chain() == ["gemini/gemini-embedding-001"]
+
+
+def test_wet_google_alias_satisfies_gemini(monkeypatch):
+    for v in (
+        "EMBEDDING_MODELS",
+        "EMBEDDING_MODEL",
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "COHERE_API_KEY",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "x")
+    # GOOGLE_API_KEY alias satisfies GEMINI_API_KEY for the gemini default.
+    assert "gemini/gemini-embedding-001" in Settings().embedding_chain()

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -209,7 +209,6 @@ class TestSetupToolCoverageGaps:
         mock_clear.assert_called_once_with("org/embed")
         assert result["status"] == "warning"
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/embed"])
     @patch("wet_mcp.reranker.init_reranker")
     @patch("wet_mcp.embedder.init_backend")
     async def test_cloud_reranker_init_exception(self, mock_init, mock_rr_init):
@@ -217,8 +216,8 @@ class TestSetupToolCoverageGaps:
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
-        mock_settings.resolve_rerank_model.return_value = "cohere/rerank"
+        mock_settings.embedding_chain.return_value = ["gemini/embed"]
+        mock_settings.rerank_chain.return_value = ["cohere/rerank"]
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=768)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -236,15 +236,14 @@ class TestDownloadLocalReranker:
 class TestValidateCloudModels:
     """_validate_cloud_models checks cloud embedding and reranking."""
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/embed-1"])
     @patch("wet_mcp.reranker.init_reranker")
     @patch("wet_mcp.embedder.init_backend")
     async def test_cloud_embedding_and_reranker_success(self, mock_init, mock_rr_init):
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
-        mock_settings.resolve_rerank_model.return_value = "cohere/rerank"
+        mock_settings.embedding_chain.return_value = ["gemini/embed-1"]
+        mock_settings.rerank_chain.return_value = ["cohere/rerank"]
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=768)
@@ -260,13 +259,12 @@ class TestValidateCloudModels:
         assert result["embedding"]["model"] == "gemini/embed-1"
         assert result["reranker"]["model"] == "cohere/rerank"
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["model-a"])
     @patch("wet_mcp.embedder.init_backend")
     async def test_cloud_embedding_fails(self, mock_init):
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["model-a"]
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=0)
@@ -275,15 +273,14 @@ class TestValidateCloudModels:
         result = await _validate_cloud_models(mock_settings)
         assert result["cloud_ready"] is False
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/embed"])
     @patch("wet_mcp.reranker.init_reranker")
     @patch("wet_mcp.embedder.init_backend")
     async def test_cloud_reranker_fails(self, mock_init, mock_rr_init):
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
-        mock_settings.resolve_rerank_model.return_value = "cohere/rerank"
+        mock_settings.embedding_chain.return_value = ["gemini/embed"]
+        mock_settings.rerank_chain.return_value = ["cohere/rerank"]
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=768)
@@ -297,15 +294,14 @@ class TestValidateCloudModels:
         assert result["cloud_ready"] is True
         assert result["reranker"] is None
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/embed"])
     @patch("wet_mcp.reranker.init_reranker")
     @patch("wet_mcp.embedder.init_backend")
     async def test_cloud_reranker_init_exception(self, mock_init, mock_rr_init):
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
-        mock_settings.resolve_rerank_model.return_value = "cohere/rerank"
+        mock_settings.embedding_chain.return_value = ["gemini/embed"]
+        mock_settings.rerank_chain.return_value = ["cohere/rerank"]
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=768)
@@ -317,14 +313,13 @@ class TestValidateCloudModels:
         assert result["cloud_ready"] is True
         assert result["reranker"] is None
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/embed"])
     @patch("wet_mcp.embedder.init_backend")
     async def test_explicit_model_tried_first(self, mock_init):
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = "explicit/model"
-        mock_settings.resolve_rerank_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["explicit/model"]
+        mock_settings.rerank_chain.return_value = []
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=512)
@@ -335,14 +330,13 @@ class TestValidateCloudModels:
         mock_init.assert_called_once_with("cloud", "explicit/model")
         assert result["cloud_ready"] is True
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/embed"])
     @patch("wet_mcp.embedder.init_backend")
     async def test_no_rerank_model_skips_check(self, mock_init):
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
-        mock_settings.resolve_rerank_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["gemini/embed"]
+        mock_settings.rerank_chain.return_value = []
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=768)
@@ -352,13 +346,12 @@ class TestValidateCloudModels:
         assert result["cloud_ready"] is True
         assert result["reranker"] is None
 
-    @patch("wet_mcp.setup_tool._EMBEDDING_CANDIDATES", ["model-a"])
     @patch("wet_mcp.embedder.init_backend")
     async def test_cloud_exception_returns_not_ready(self, mock_init):
         from wet_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["model-a"]
 
         mock_init.side_effect = Exception("init failed")
 

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,0 +1,35 @@
+from wet_mcp.relay_schema import RELAY_SCHEMA
+
+
+def test_has_model_chain_tasks():
+    tasks = {
+        f.get("task") for f in RELAY_SCHEMA["fields"] if f.get("type") == "model-chain"
+    }
+    assert tasks == {"embedding", "rerank", "chat"}
+
+
+def test_key_fields_are_derived():
+    derived = {f["key"] for f in RELAY_SCHEMA["fields"] if f.get("derived")}
+    assert "GEMINI_API_KEY" in derived and "JINA_AI_API_KEY" in derived
+
+
+def test_github_token_not_derived_not_chain():
+    # GITHUB_TOKEN is a plain rate-limit key, not a model-provider key.
+    gh = next(f for f in RELAY_SCHEMA["fields"] if f["key"] == "GITHUB_TOKEN")
+    assert gh["type"] == "password"
+    assert not gh.get("derived")
+    assert gh.get("task") is None
+
+
+def test_no_hardcoded_priority_strings():
+    for cap in RELAY_SCHEMA.get("capabilityInfo", []):
+        assert ">" not in cap.get("priority", "")
+
+
+def test_suggested_models_carry_provider_prefix():
+    # Every suggested model must carry a "<provider>/" prefix so the widget
+    # derive-keys maps it to the correct key field.
+    for f in RELAY_SCHEMA["fields"]:
+        if f.get("type") == "model-chain":
+            for m in f["suggestedModels"]:
+                assert "/" in m, f"suggested model {m!r} lacks a provider prefix"

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -24,9 +24,13 @@ class TestRelaySchema:
         assert "fields" in RELAY_SCHEMA
         assert "modes" not in RELAY_SCHEMA
 
-    def test_schema_has_six_provider_fields(self):
+    def test_schema_has_provider_and_chain_fields(self):
         fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 6
+        # 3 model-chain tasks + 6 derived provider keys + ANTHROPIC + GITHUB_TOKEN
+        chains = [f for f in fields if f.get("type") == "model-chain"]
+        keys = [f for f in fields if f.get("type") == "password"]
+        assert len(chains) == 3
+        assert len(keys) == 7
 
     def test_schema_field_keys(self):
         field_keys = [f["key"] for f in RELAY_SCHEMA["fields"]]
@@ -34,6 +38,7 @@ class TestRelaySchema:
         assert "GEMINI_API_KEY" in field_keys
         assert "OPENAI_API_KEY" in field_keys
         assert "COHERE_API_KEY" in field_keys
+        assert "ANTHROPIC_API_KEY" in field_keys
         assert "XAI_API_KEY" in field_keys
         assert "GITHUB_TOKEN" in field_keys
 
@@ -44,8 +49,10 @@ class TestRelaySchema:
         assert RELAY_SCHEMA["displayName"] == "Web Extended Toolkit"
 
     def test_all_fields_optional(self):
+        # Password key fields are explicitly optional; model-chain fields have
+        # no "required" flag (the widget treats them as optional by default).
         for f in RELAY_SCHEMA["fields"]:
-            assert f.get("required") is False
+            assert f.get("required", False) is False
 
     def test_capability_info_present(self):
         assert "capabilityInfo" in RELAY_SCHEMA

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -1004,7 +1004,7 @@ async def test_init_embedding_backend_litellm_explicit_model():
         patch("wet_mcp.embedder.init_backend") as mock_init,
     ):
         ms.resolve_embedding_backend.return_value = "cloud"
-        ms.resolve_embedding_model.return_value = "text-embedding-3-large"
+        ms.embedding_chain.return_value = ["text-embedding-3-large"]
         ms.resolve_embedding_dims.return_value = 768
         ms.resolve_local_embedding_model.return_value = "local-model"
 
@@ -1024,7 +1024,7 @@ async def test_init_embedding_backend_litellm_explicit_model_fail():
         patch("wet_mcp.embedder.init_backend") as mock_init,
     ):
         ms.resolve_embedding_backend.return_value = "cloud"
-        ms.resolve_embedding_model.return_value = "bad-model"
+        ms.embedding_chain.return_value = ["bad-model"]
         ms.resolve_embedding_dims.return_value = 768
         ms.resolve_local_embedding_model.return_value = "local-model"
 
@@ -1049,7 +1049,12 @@ async def test_init_embedding_backend_autodetect_candidates():
         patch("wet_mcp.embedder.init_backend") as mock_init,
     ):
         ms.resolve_embedding_backend.return_value = "cloud"
-        ms.resolve_embedding_model.return_value = None
+        ms.embedding_chain.return_value = [
+            "jina_ai/jina-embeddings-v5-text-small",
+            "gemini/gemini-embedding-001",
+            "openai/text-embedding-3-large",
+            "cohere/embed-multilingual-v3.0",
+        ]
         ms.resolve_embedding_dims.return_value = 768
         ms.resolve_local_embedding_model.return_value = "local-model"
 
@@ -1078,7 +1083,12 @@ async def test_init_embedding_backend_all_candidates_fail():
         patch("wet_mcp.embedder.init_backend") as mock_init,
     ):
         ms.resolve_embedding_backend.return_value = "cloud"
-        ms.resolve_embedding_model.return_value = None
+        ms.embedding_chain.return_value = [
+            "jina_ai/jina-embeddings-v5-text-small",
+            "gemini/gemini-embedding-001",
+            "openai/text-embedding-3-large",
+            "cohere/embed-multilingual-v3.0",
+        ]
         ms.resolve_embedding_dims.return_value = 768
         ms.resolve_local_embedding_model.return_value = "local-model"
 
@@ -1154,7 +1164,7 @@ async def test_init_reranker_backend_cloud_fail_no_local_fallback():
         patch("wet_mcp.reranker.init_reranker") as mock_init,
     ):
         ms.resolve_rerank_backend.return_value = "cloud"
-        ms.resolve_rerank_model.return_value = "rerank-model"
+        ms.rerank_chain.return_value = ["rerank-model"]
 
         ms.resolve_local_rerank_model.return_value = "local-rerank"
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -33,8 +33,8 @@ def _mock_settings():
         mock.resolve_embedding_dims.return_value = 768
         mock.resolve_embedding_backend.return_value = "cloud"
         mock.resolve_rerank_backend.return_value = "cloud"
-        mock.resolve_embedding_model.return_value = "gemini"
-        mock.resolve_rerank_model.return_value = "gemini-rerank"
+        mock.embedding_chain.return_value = ["gemini/gemini-embedding-001"]
+        mock.rerank_chain.return_value = ["cohere/rerank-v3.5"]
         mock.resolve_local_embedding_model.return_value = "local-model"
         mock.resolve_local_rerank_model.return_value = "local-rerank"
         mock.wet_auto_searxng = False
@@ -266,8 +266,11 @@ async def test_init_embedding_litellm_explicit_model_failure_no_local_fallback()
 
 
 async def test_init_embedding_litellm_autodetect(_mock_settings):
-    """Lines 225-242: auto-detect candidate models when no explicit model."""
-    _mock_settings.resolve_embedding_model.return_value = None
+    """Lines 225-242: iterate the embedding chain (litellm fallback order)."""
+    _mock_settings.embedding_chain.return_value = [
+        "gemini/gemini-embedding-001",
+        "text-embedding-3-large",
+    ]
     _mock_settings.resolve_embedding_backend.return_value = "cloud"
 
     attempts = []

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -36,11 +36,9 @@ class TestRunWarmup:
             patch("wet_mcp.reranker.init_reranker") as mock_init_reranker,
         ):
             mock_settings.setup_providers.return_value = "sdk"
-            mock_settings.resolve_embedding_model.return_value = (
-                "text-embedding-3-large"
-            )
+            mock_settings.embedding_chain.return_value = ["text-embedding-3-large"]
             mock_settings.rerank_enabled = True
-            mock_settings.resolve_rerank_model.return_value = "rerank-v3"
+            mock_settings.rerank_chain.return_value = ["rerank-v3"]
 
             mock_backend = MagicMock()
             mock_backend.check_available = AsyncMock(return_value=768)
@@ -68,7 +66,8 @@ class TestRunWarmup:
             patch("qwen3_embed.TextEmbedding") as mock_embed,
         ):
             mock_settings.setup_providers.return_value = "sdk"
-            mock_settings.resolve_embedding_model.return_value = None
+            mock_settings.embedding_chain.return_value = ["gemini/embed"]
+            mock_settings.rerank_chain.return_value = []
             mock_settings.rerank_enabled = False
             mock_settings.resolve_local_embedding_model.return_value = "Qwen/test-model"
             mock_settings.resolve_local_rerank_model.return_value = "Qwen/test-reranker"

--- a/tests/test_setup_tool_logging.py
+++ b/tests/test_setup_tool_logging.py
@@ -17,8 +17,8 @@ async def test_validate_cloud_models_logging(caplog):
     logger.add(loguru_caplog_bridge, level="DEBUG")
 
     mock_settings = MagicMock()
-    mock_settings.resolve_embedding_model.return_value = "test-embed"
-    mock_settings.resolve_rerank_model.return_value = "test-rerank"
+    mock_settings.embedding_chain.return_value = ["test-embed"]
+    mock_settings.rerank_chain.return_value = ["test-rerank"]
 
     with (
         patch(
@@ -54,8 +54,8 @@ async def test_validate_cloud_models_reranker_logging(caplog):
     logger.add(loguru_caplog_bridge, level="DEBUG")
 
     mock_settings = MagicMock()
-    mock_settings.resolve_embedding_model.return_value = "test-embed"
-    mock_settings.resolve_rerank_model.return_value = "test-rerank"
+    mock_settings.embedding_chain.return_value = ["test-embed"]
+    mock_settings.rerank_chain.return_value = ["test-rerank"]
 
     mock_backend = MagicMock()
     mock_backend.check_available = AsyncMock(return_value=768)

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "sys_platform != 'win32'",
 ]
 
+[options]
+prerelease-mode = "allow"
+
 [[package]]
 name = "aiofile"
 version = "3.11.1"
@@ -1823,7 +1826,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b1"
+version = "1.18.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1838,9 +1841,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/aa/e8eb296141165057abb74f2e62f392c341b14e3259cb1677547b3a6760f1/n24q02m_mcp_core-1.18.0b1.tar.gz", hash = "sha256:832b29c70cae6a610a83c3a5c06bcb7220e6eaf43ea5dfa91ef47adc75ac332e", size = 252457, upload-time = "2026-06-10T13:31:50.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ed/59f51b85af63f4986918e6d76ccd7e8bb177706aeb397629d7cc76da5bcd/n24q02m_mcp_core-1.18.0b2.tar.gz", hash = "sha256:30baf5173e460ef20f1b24ac91e6310b8d7737696be033138a4b05785cb4b5a9", size = 256688, upload-time = "2026-06-11T05:07:18.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/22/ce4c37b7c120eb6e0aee229665841bfcb2482bc650d49168c74a22253a77/n24q02m_mcp_core-1.18.0b1-py3-none-any.whl", hash = "sha256:6d4f84e4369aab5aa5d1213a1c7b34d5c61672eaa3834ee92bc9b4414626eb79", size = 135751, upload-time = "2026-06-10T13:31:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/47/1182dda7b70180245e57d5e6316940e219faf46d6692be2d8edf8d2c603d/n24q02m_mcp_core-1.18.0b2-py3-none-any.whl", hash = "sha256:905efd3e25ceb8ab6d14132a8f6e660bde6ba324bf0363342b1a5d87f09dd242", size = 139516, upload-time = "2026-06-11T05:07:19.407Z" },
 ]
 
 [package.optional-dependencies]
@@ -3525,7 +3528,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.2.7b1"
+version = "3.3.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3586,7 +3589,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b1,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b2,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.1.1,<2.2" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
Phase 2 selection redesign. Per-task `EMBEDDING_MODELS`/`RERANK_MODELS`/`LLM_MODELS` chains (key-gated default, explicit prefixes, no-usable-key→local), relay model-chain widget + derived keys (GITHUB_TOKEN stays plain), drop priority-router. Pin mcp-core[llm]>=1.18.0b2. 1831 tests, cov 93.1%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)