### PR TITLE
fix: default local reranker to YesNo ONNX variant (#725-enabled)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
-    "qwen3-embed>=1.10.1",
+    "qwen3-embed>=1.11.2b3",
     "pillow>=12.2.0",
     "diskcache>=5.6.3",
     "cryptography>=48.0.0",

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -343,9 +343,14 @@ class Settings(BaseSettings):
     # --- Reranking resolution ---
 
     def resolve_local_rerank_model(self) -> str:
-        """Resolve local rerank model: GGUF if GPU + llama-cpp, else ONNX."""
+        """Resolve local rerank model: GGUF if GPU + llama-cpp, else ONNX.
+
+        The ONNX default is the YesNo variant (~598 MB at inference vs ~12 GB
+        for the full-vocab build); it is mathematically equivalent and, since
+        qwen3-embed 1.11.2b3, produces batch-invariant scores (issue #725).
+        """
         return _resolve_local_model(
-            "n24q02m/Qwen3-Reranker-0.6B-ONNX",
+            "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo",
             "n24q02m/Qwen3-Reranker-0.6B-GGUF",
         )
 

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -159,7 +159,9 @@ class Qwen3Reranker:
     Model is downloaded on first use (~0.57GB).
     """
 
-    DEFAULT_MODEL = "n24q02m/Qwen3-Reranker-0.6B-ONNX"
+    # YesNo variant: ~598 MB at inference vs ~12 GB for the full-vocab build,
+    # mathematically equivalent, batch-invariant since qwen3-embed 1.11.2b3 (#725).
+    DEFAULT_MODEL = "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
 
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or self.DEFAULT_MODEL

--- a/uv.lock
+++ b/uv.lock
@@ -2708,7 +2708,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.11.1"
+version = "1.11.2b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2719,9 +2719,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/0d/8877e7e9c19daae9c7b97cc5d18c706df02c22d73c2d11c880a72023daad/qwen3_embed-1.11.1.tar.gz", hash = "sha256:b86adf71b3fa158dbcd51b72db624352cb9a9b410de0c2e1b6d78144d7e8f256", size = 187826, upload-time = "2026-06-09T02:53:40.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/d7/b3a9d12b8f3b4853d944c0c2ccc6ca5da6d3685fd6226ca31e3ded363846/qwen3_embed-1.11.2b3.tar.gz", hash = "sha256:f6ba46d82a700802e21af9b0dd97487452380ad59244c30c7fc32146c83915f4", size = 186919, upload-time = "2026-06-11T13:13:37.795Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/4a/c46780c74524ac20be54c1ac68383e21453c5b229ce7b4bf38ed235061bb/qwen3_embed-1.11.1-py3-none-any.whl", hash = "sha256:9a459e62aef1d948ec5344aacdb19286c418454e91b3452822a4caf9ceb73dbd", size = 60923, upload-time = "2026-06-09T02:53:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/3de1a318fc166f6105717904fbe04b591ce10de4efb39017dcf6eaaeded1/qwen3_embed-1.11.2b3-py3-none-any.whl", hash = "sha256:dd849152ac99964b9b77b83007eef78ee52d677e78117fe1da86bce27e75f925", size = 60801, upload-time = "2026-06-11T13:13:38.721Z" },
 ]
 
 [[package]]
@@ -3492,7 +3492,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b3"
+version = "3.3.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3558,7 +3558,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },
-    { name = "qwen3-embed", specifier = ">=1.10.1" },
+    { name = "qwen3-embed", specifier = ">=1.11.2b3" },
     { name = "sqlite-vec" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "waitress", marker = "sys_platform == 'win32'", specifier = ">=3.0.2" },


### PR DESCRIPTION
Flips the default local ONNX reranker from the full-vocab build (~12GB RAM peak at inference) to the **YesNo** variant (~598MB). The two are mathematically equivalent (same weights; `sigmoid(no_logit - yes_logit)`).

Previously gated on a determinism bug: under batched inference the YesNo variant produced batch-dependent scores. Fixed upstream in **qwen3-embed 1.11.2b3** (per-row scoring, n24q02m/qwen3-embed#725). This PR bumps the pin floor to `>=1.11.2b3` so the fix is guaranteed present before flipping the default.

- `config.py::resolve_local_rerank_model()` — ONNX default -> `...-ONNX-YesNo` (GGUF path unchanged; no YesNo GGUF variant)
- `reranker.py::Qwen3Reranker.DEFAULT_MODEL` — kept in sync
- `pyproject.toml` — `qwen3-embed>=1.11.2b3`

Unit suite: 1830 passed, 32 skipped. ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)