### PR TITLE
⚡ Bolt: optimize `_extract_passage` sliding window search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,6 @@
 ## 2024-05-18 - String uniform validation
 **Learning:** For uniform string validation (where `len(set(text)) == 1`), replacing an O(N) generator check like `all(c in ALLOWED for c in text)` with a simple O(1) index check `text[0] in ALLOWED` significantly improves iteration overhead.
 **Action:** Always prefer array indexing to generator comprehensions when validating a uniformly matching string, and ensure that the stripped result is cached to avoid redundant allocations.
+## 2024-10-30 - Sliding Window Optimizations
+**Learning:** In string processing tasks like passage extraction that use a sliding window approach with multiple query terms, repeatedly checking for terms that don't even exist in the document wastes significant CPU cycles.
+**Action:** When extracting passages, pre-filter query terms by first checking their existence in the overall text (`[term for term in query_terms if term in content]`). Additionally, record the `max_possible_score` so the algorithm can terminate early when the best possible window is found. This simple technique avoids redundant checking and provides an effective speedup.

--- a/src/wet_mcp/sources/search_strategies.py
+++ b/src/wet_mcp/sources/search_strategies.py
@@ -231,16 +231,26 @@ def _extract_passage(content: str, query_terms: list[str], max_chars: int = 500)
     """Extract most relevant passage from content around query terms."""
     content_lower = content.lower()
 
+    # Performance optimization: pre-filter terms that actually exist in the document.
+    # This prevents redundant membership checks in the sliding window loop for terms
+    # that are not present anywhere in the content, and allows early termination.
+    present_terms = [term for term in query_terms if term in content_lower]
+    max_possible_score = len(present_terms)
+
     # Find best position (most query terms nearby)
     best_pos = 0
     best_score = 0
 
-    for i in range(0, len(content_lower) - 100, 50):
-        window = content_lower[i : i + max_chars]
-        score = sum(1 for term in query_terms if term in window)
-        if score > best_score:
-            best_score = score
-            best_pos = i
+    if max_possible_score > 0:
+        for i in range(0, len(content_lower) - 100, 50):
+            window = content_lower[i : i + max_chars]
+            score = sum(1 for term in present_terms if term in window)
+            if score > best_score:
+                best_score = score
+                best_pos = i
+                # Early termination if we hit the maximum possible score
+                if best_score == max_possible_score:
+                    break
 
     if best_score == 0:
         # No query terms found, return beginning


### PR DESCRIPTION
💡 **What:** Optimized `_extract_passage` in `src/wet_mcp/sources/search_strategies.py` by pre-filtering `query_terms` against the document and adding early termination when the maximum possible score is reached.
🎯 **Why:** The original sliding window approach redundantly checked for query terms that did not exist anywhere in the document, doing so repeatedly on every 50-character shift.
📊 **Impact:** Reduces redundant string membership checks significantly, especially for queries where many terms are absent from the document or localized in one specific section. Speeds up passage extraction loops.
🔬 **Measurement:** Verify by running `uv run pytest tests/test_search_strategies.py`. Execution time will be lower for queries on large documents compared to before.

---
*PR created automatically by Jules for task [11738147562806296419](https://jules.google.com/task/11738147562806296419) started by @n24q02m*