### PR TITLE
fix: sweep priority-router language from docs and plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,31 +3,49 @@
   "description": "Web search, content extraction, and media download",
   "version": "3.3.0-beta.5",
   "userConfig": {
+    "EMBEDDING_MODELS": {
+      "type": "string",
+      "title": "Embedding model chain (optional)",
+      "description": "CSV 'provider/model,provider/model' (order = litellm fallback); provider inferred from prefix. Empty = local ONNX (qwen3-embed). Example: jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
+      "required": false
+    },
+    "RERANK_MODELS": {
+      "type": "string",
+      "title": "Rerank model chain (optional)",
+      "description": "CSV 'provider/model,...'; provider inferred from prefix. Empty = local ONNX cross-encoder. Example: jina_ai/jina-reranker-v3",
+      "required": false
+    },
+    "LLM_MODELS": {
+      "type": "string",
+      "title": "LLM model chain (optional)",
+      "description": "CSV 'provider/model,...'; provider inferred from prefix. Empty = LLM features off. Example: gemini/gemini-3-flash-preview,openai/gpt-5.4-mini",
+      "required": false
+    },
     "JINA_AI_API_KEY": {
       "type": "string",
       "title": "Jina AI API key (optional)",
-      "description": "Optional cloud reranker key. Without it, server uses local ONNX rerank. https://jina.ai/api-dashboard/",
+      "description": "Enables jina_ai/ models referenced in a model chain. Without any cloud key the server uses local ONNX. https://jina.ai/api-dashboard/",
       "sensitive": true,
       "required": false
     },
     "GEMINI_API_KEY": {
       "type": "string",
       "title": "Gemini API key (optional)",
-      "description": "Optional cloud embedding fallback. https://ai.google.dev/",
+      "description": "Enables gemini/ models referenced in a model chain. https://ai.google.dev/",
       "sensitive": true,
       "required": false
     },
     "OPENAI_API_KEY": {
       "type": "string",
       "title": "OpenAI API key (optional)",
-      "description": "Optional cloud LLM + embedding fallback (lower priority than Gemini). https://platform.openai.com/api-keys",
+      "description": "Enables openai/ models referenced in a model chain. https://platform.openai.com/api-keys",
       "sensitive": true,
       "required": false
     },
     "COHERE_API_KEY": {
       "type": "string",
       "title": "Cohere API key (optional)",
-      "description": "Optional cloud embedding + reranking fallback. https://dashboard.cohere.com/api-keys",
+      "description": "Enables cohere/ models referenced in a model chain. https://dashboard.cohere.com/api-keys",
       "sensitive": true,
       "required": false
     },
@@ -63,6 +81,9 @@
       ],
       "env": {
         "MCP_TRANSPORT": "stdio",
+        "EMBEDDING_MODELS": "${user_config.EMBEDDING_MODELS}",
+        "RERANK_MODELS": "${user_config.RERANK_MODELS}",
+        "LLM_MODELS": "${user_config.LLM_MODELS}",
         "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}",
         "GEMINI_API_KEY": "${user_config.GEMINI_API_KEY}",
         "OPENAI_API_KEY": "${user_config.OPENAI_API_KEY}",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,19 +128,22 @@ Docs-search schema additions (libraries, versions, project_context)
 land via Alembic revisions `docs_002_libraries`,
 `docs_003_project_context`.
 
-## LLM provider dispatch (no hardcoded default)
+## LLM provider dispatch (per-task model chains)
 
-wet-mcp does not pin a default LLM model. Provider selection at runtime
-walks env vars in priority order:
+wet-mcp selects models via per-task model chains, not a pinned model or a
+key-priority router. Each chain is a CSV of `provider/model` entries
+(order = litellm fallback); the provider is inferred from the model prefix:
 
 ```text
-GEMINI_API_KEY / GOOGLE_API_KEY  -> gemini/* (litellm passthrough)
-OPENAI_API_KEY                   -> openai/* (litellm passthrough)
-XAI_API_KEY                      -> xai/* (litellm passthrough)
-LLM_MODELS env                   -> explicit comma-separated fallback chain
-LLM_API_BASE env                 -> custom OpenAI-compatible endpoint
+LLM_MODELS        -> LLM chain (e.g. extract agent). Empty -> LLM features off.
+EMBEDDING_MODELS  -> embedding chain. Empty -> local ONNX (qwen3-embed).
+RERANK_MODELS     -> rerank chain. Empty -> local ONNX cross-encoder.
+LLM_API_BASE      -> custom OpenAI-compatible endpoint (SSRF-guarded)
 ```
 
+The default chains list curated models but are filtered to providers whose
+`<PROVIDER>_API_KEY` is configured; if none has a key, the chain resolves
+empty and wet falls back to local (no keyless cloud call, no priority router).
 All calls dispatch through `mcp_core.llm` (litellm passthrough via the
 `mcp-core[llm]` extra); any litellm `provider/model` string works.
 
@@ -231,9 +234,9 @@ LRU eviction tracking.
 ```text
 extract(action="agent", query=...)
   |
-  +-- detect_llm_provider() (GEMINI_API_KEY > OPENAI_API_KEY > XAI_API_KEY)
+  +-- resolve LLM_MODELS chain (provider inferred from prefix; key-gated)
   |     |
-  |     +-- not configured -> return "Error: no LLM provider detected"
+  |     +-- no provider key configured -> return "Error: no LLM provider detected"
   |     |                     (does not crash the SDK)
   |     +-- configured     -> proceed
   |


### PR DESCRIPTION
## Vấn đề (di sản priority-router sau migration model-chain 2026-06-11)
- `docs/ARCHITECTURE.md`: section "LLM provider dispatch" mô tả "walks env vars in priority order" (GEMINI > OPENAI > XAI) + diagram gọi `detect_llm_provider()` — hàm KHÔNG tồn tại (verified: code dùng `LLM_MODELS` chain qua `llm.py` + `_has_llm_provider()`).
- `.claude-plugin/plugin.json`: userConfig ghi "lower priority than Gemini"/"fallback" + KHÔNG expose model chains.

## Fix
Rewrite theo cơ chế thật: per-task `EMBEDDING_MODELS`/`RERANK_MODELS`/`LLM_MODELS` chains (provider suy ra từ prefix, key-gated, empty → local ONNX). Thêm 3 chain field vào plugin.json userConfig + env. Khớp `CLAUDE.md` (nguồn sạch).

`server.json` verified ĐÃ accurate (mô tả chains + `API_KEYS` vẫn là cơ chế thật) → không đổi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)