### PR TITLE
feat: bring-your-own local embedding model via env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
-    "qwen3-embed>=1.11.2b3",
+    "qwen3-embed>=1.12.0b1",
     "pillow>=12.2.0",
     "diskcache>=5.6.3",
     "cryptography>=48.0.0",

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -120,6 +120,19 @@ class Settings(BaseSettings):
     embedding_dims: int = 0  # 0 = use server default (768)
     embedding_backend: str = ""  # DEPRECATED: inferred from EMBEDDING_MODELS
 
+    # BYO local model override. When set, the LOCAL embedding/rerank backend
+    # loads this model id instead of the bundled Qwen3 default. A non-built-in
+    # id is registered with qwen3-embed at startup using the companion vars
+    # below (embedding only; rerank custom registration is a follow-up).
+    local_embedding_model: str = ""  # env LOCAL_EMBEDDING_MODEL
+    local_rerank_model: str = ""  # env LOCAL_RERANK_MODEL
+    # Companion vars for registering a custom LOCAL embedding model (BYO ONNX).
+    # Required only when LOCAL_EMBEDDING_MODEL is a non-built-in id.
+    local_embedding_pooling: str = "MEAN"  # MEAN | CLS | LAST_TOKEN | DISABLED
+    local_embedding_dim: int = 0  # required (>0) for a custom embedding model
+    local_embedding_normalize: bool = True
+    local_embedding_model_file: str = "onnx/model.onnx"
+
     # Reranking
     rerank_enabled: bool = (
         True  # Enable reranking (always available via local fallback)
@@ -315,7 +328,12 @@ class Settings(BaseSettings):
         return self.embedding_dims
 
     def resolve_local_embedding_model(self) -> str:
-        """Resolve local embedding model: GGUF if GPU + llama-cpp, else ONNX."""
+        """Resolve local embedding model: GGUF if GPU + llama-cpp, else ONNX.
+
+        LOCAL_EMBEDDING_MODEL overrides the bundled default (BYO model).
+        """
+        if self.local_embedding_model:
+            return self.local_embedding_model
         return _resolve_local_model(
             "n24q02m/Qwen3-Embedding-0.6B-ONNX",
             "n24q02m/Qwen3-Embedding-0.6B-GGUF",
@@ -348,7 +366,11 @@ class Settings(BaseSettings):
         The ONNX default is the YesNo variant (~598 MB at inference vs ~12 GB
         for the full-vocab build); it is mathematically equivalent and, since
         qwen3-embed 1.11.2b3, produces batch-invariant scores (issue #725).
+
+        LOCAL_RERANK_MODEL overrides the bundled default (BYO model).
         """
+        if self.local_rerank_model:
+            return self.local_rerank_model
         return _resolve_local_model(
             "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo",
             "n24q02m/Qwen3-Reranker-0.6B-GGUF",

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -376,6 +376,49 @@ async def _lifespan_shutdown(warmup_task: asyncio.Task | None) -> None:
     stop_searxng()
 
 
+def _maybe_register_custom_embed(local_model: str) -> None:
+    """Register a BYO local embedding model with qwen3-embed if needed.
+
+    Only fires when the user opted in via LOCAL_EMBEDDING_MODEL. Built-in
+    ``n24q02m/Qwen3-*`` ids are already known to qwen3-embed and are left
+    untouched. A custom id is registered via ``qwen3_embed.CustomModelSpec``
+    using the companion env vars so the local backend can load it. Requires
+    LOCAL_EMBEDDING_DIM (>0).
+    """
+    if not settings.local_embedding_model:
+        return
+    if local_model.startswith("n24q02m/Qwen3-"):
+        return
+    if settings.local_embedding_dim <= 0:
+        logger.error(
+            "Custom local embedding model {!r} requires LOCAL_EMBEDDING_DIM > 0; "
+            "skipping registration.",
+            local_model,
+        )
+        return
+
+    from qwen3_embed import CustomModelSpec
+
+    try:
+        CustomModelSpec(
+            model_id=local_model,
+            hf=local_model,
+            model_file=settings.local_embedding_model_file,
+            dim=settings.local_embedding_dim,
+            pooling=settings.local_embedding_pooling,
+            normalization=settings.local_embedding_normalize,
+        ).register()
+        logger.info(
+            "Registered custom local embedding model {!r} (dim={}, pooling={})",
+            local_model,
+            settings.local_embedding_dim,
+            settings.local_embedding_pooling,
+        )
+    except ValueError as e:
+        # Already registered (re-init) or invalid spec — non-fatal.
+        logger.debug("Custom embedding registration skipped: {}", e)
+
+
 async def _init_embedding_backend(mode: str) -> None:
     """Initialize the embedding backend based on credential state and config.
 
@@ -397,6 +440,7 @@ async def _init_embedding_backend(mode: str) -> None:
 
     if cred_state == CredentialState.LOCAL or backend_type == "local":
         local_model = settings.resolve_local_embedding_model()
+        _maybe_register_custom_embed(local_model)
         try:
             backend = await asyncio.to_thread(init_backend, "local", local_model)
             native_dims = await backend.check_available()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -452,6 +452,23 @@ def test_resolve_local_rerank_model():
 
 
 # -----------------------------------------------------------------------
+# BYO local model override (LOCAL_EMBEDDING_MODEL / LOCAL_RERANK_MODEL)
+# -----------------------------------------------------------------------
+
+
+def test_local_embedding_model_override(monkeypatch):
+    monkeypatch.setenv("LOCAL_EMBEDDING_MODEL", "Org/custom-embed")
+    s = Settings()
+    assert s.resolve_local_embedding_model() == "Org/custom-embed"
+
+
+def test_local_rerank_model_override(monkeypatch):
+    monkeypatch.setenv("LOCAL_RERANK_MODEL", "Org/custom-rerank")
+    s = Settings()
+    assert s.resolve_local_rerank_model() == "Org/custom-rerank"
+
+
+# -----------------------------------------------------------------------
 # Per-task model chains (model-chain migration, 2026-06-11)
 # -----------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,92 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from wet_mcp.server import extract, search
+from wet_mcp.server import _maybe_register_custom_embed, extract, search
+
+
+def test_maybe_register_custom_embed_no_optin_noop(monkeypatch):
+    """No registration when LOCAL_EMBEDDING_MODEL is unset (default local)."""
+    import qwen3_embed
+
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "local_embedding_model", "")
+    called = []
+    monkeypatch.setattr(
+        qwen3_embed.TextEmbedding,
+        "add_custom_model",
+        classmethod(lambda cls, desc, **kw: called.append((desc, kw))),
+    )
+    _maybe_register_custom_embed("local-model")
+    assert called == []
+
+
+def test_maybe_register_custom_embed_builtin_noop(monkeypatch):
+    """Built-in Qwen3 ids are left untouched (no registration call)."""
+    import qwen3_embed
+
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(
+        settings, "local_embedding_model", "n24q02m/Qwen3-Embedding-0.6B-ONNX"
+    )
+    called = []
+    monkeypatch.setattr(
+        qwen3_embed.TextEmbedding,
+        "add_custom_model",
+        classmethod(lambda cls, desc, **kw: called.append((desc, kw))),
+    )
+    _maybe_register_custom_embed("n24q02m/Qwen3-Embedding-0.6B-ONNX")
+    assert called == []
+
+
+def test_maybe_register_custom_embed_calls_add_custom_model(monkeypatch):
+    """A BYO id with dim/pooling registers via TextEmbedding.add_custom_model."""
+    import qwen3_embed
+    from qwen3_embed.common.model_description import PoolingType
+
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "local_embedding_model", "Org/custom-embed")
+    monkeypatch.setattr(settings, "local_embedding_dim", 768)
+    monkeypatch.setattr(settings, "local_embedding_pooling", "CLS")
+
+    captured = {}
+
+    def _fake(cls, desc, *, pooling, normalization):
+        captured["model"] = desc.model
+        captured["pooling"] = pooling
+        captured["normalization"] = normalization
+
+    monkeypatch.setattr(
+        qwen3_embed.TextEmbedding,
+        "add_custom_model",
+        classmethod(_fake),
+    )
+
+    _maybe_register_custom_embed("Org/custom-embed")
+
+    assert captured["model"] == "Org/custom-embed"
+    assert captured["pooling"] == PoolingType.CLS
+    assert captured["normalization"] is True
+
+
+def test_maybe_register_custom_embed_missing_dim(monkeypatch):
+    """A BYO id without LOCAL_EMBEDDING_DIM skips registration (no call)."""
+    import qwen3_embed
+
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "local_embedding_model", "Org/custom-embed")
+    monkeypatch.setattr(settings, "local_embedding_dim", 0)
+    called = []
+    monkeypatch.setattr(
+        qwen3_embed.TextEmbedding,
+        "add_custom_model",
+        classmethod(lambda cls, desc, **kw: called.append(desc)),
+    )
+    _maybe_register_custom_embed("Org/custom-embed")
+    assert called == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -1092,6 +1092,7 @@ async def test_init_embedding_backend_local_fail():
         ms.resolve_embedding_model.return_value = None
         ms.resolve_embedding_dims.return_value = 768
         ms.resolve_local_embedding_model.return_value = "local-model"
+        ms.local_embedding_model = ""
 
         mock_init.side_effect = Exception("local init failed")
 
@@ -1109,6 +1110,7 @@ async def test_init_embedding_backend_local_not_available():
         ms.resolve_embedding_model.return_value = None
         ms.resolve_embedding_dims.return_value = 768
         ms.resolve_local_embedding_model.return_value = "local-model"
+        ms.local_embedding_model = ""
 
         mock_backend = MagicMock()
         mock_backend.check_available = AsyncMock(return_value=0)

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -37,6 +37,7 @@ def _mock_settings():
         mock.rerank_chain.return_value = ["cohere/rerank-v3.5"]
         mock.resolve_local_embedding_model.return_value = "local-model"
         mock.resolve_local_rerank_model.return_value = "local-rerank"
+        mock.local_embedding_model = ""
         mock.wet_auto_searxng = False
         mock.setup_providers.return_value = "sdk"
         mock.download_dir = "/tmp/downloads"
@@ -330,6 +331,7 @@ async def test_init_embedding_local_zero_dims():
             ms.resolve_embedding_backend.return_value = "local"
             ms.resolve_local_embedding_model.return_value = "test"
             ms.resolve_embedding_dims.return_value = 768
+            ms.local_embedding_model = ""
 
             await server._init_embedding_backend("sdk")
 

--- a/uv.lock
+++ b/uv.lock
@@ -2711,7 +2711,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.11.2b3"
+version = "1.12.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2722,9 +2722,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/d7/b3a9d12b8f3b4853d944c0c2ccc6ca5da6d3685fd6226ca31e3ded363846/qwen3_embed-1.11.2b3.tar.gz", hash = "sha256:f6ba46d82a700802e21af9b0dd97487452380ad59244c30c7fc32146c83915f4", size = 186919, upload-time = "2026-06-11T13:13:37.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/80/fbbd7adf445a547fd4119e58b2c352b8c921df2028727453aba81c57bd0b/qwen3_embed-1.12.0b1.tar.gz", hash = "sha256:b3949f6df0e634eba5c343b04a120699122eb0b1e840a78e9117c1f6804d8580", size = 203461, upload-time = "2026-06-12T11:19:37.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/db/3de1a318fc166f6105717904fbe04b591ce10de4efb39017dcf6eaaeded1/qwen3_embed-1.11.2b3-py3-none-any.whl", hash = "sha256:dd849152ac99964b9b77b83007eef78ee52d677e78117fe1da86bce27e75f925", size = 60801, upload-time = "2026-06-11T13:13:38.721Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b3/42c80b5789441061acb449eb743ae5762b7154e9c19f259ef851707fb231/qwen3_embed-1.12.0b1-py3-none-any.whl", hash = "sha256:c00fc1ef8070f1615e803926bbda4a3050bbfdcf9282c974b192591d554e6444", size = 64546, upload-time = "2026-06-12T11:19:36.324Z" },
 ]
 
 [[package]]
@@ -3563,7 +3563,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },
-    { name = "qwen3-embed", specifier = ">=1.11.2b3" },
+    { name = "qwen3-embed", specifier = ">=1.12.0b1" },
     { name = "sqlite-vec" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "waitress", marker = "sys_platform == 'win32'", specifier = ">=3.0.2" },


### PR DESCRIPTION
Spec B Part B (wet).

The local embed/rerank model id was hardcoded — no env override. Added `LOCAL_EMBEDDING_MODEL` / `LOCAL_RERANK_MODEL` overrides honored in `resolve_local_*_model()` (YesNo rerank default preserved). When `LOCAL_EMBEDDING_MODEL` is a non-built-in id, the server registers it with qwen3-embed via `CustomModelSpec` (companion env: `LOCAL_EMBEDDING_POOLING`/`_DIM`/`_NORMALIZE`/`_MODEL_FILE`) before constructing the local backend.

Custom-RERANK registration deferred (qwen3-embed exposes a one-call spec for embedding only; `LOCAL_RERANK_MODEL` override still works for known reranker ids). Pin `qwen3-embed>=1.12.0b1`. Gate green (1831 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)