### PR TITLE
feat: guard docs vector store against embedding-model mismatch (BYO B2)

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -120,6 +120,13 @@ class Settings(BaseSettings):
     embedding_dims: int = 0  # 0 = use server default (768)
     embedding_backend: str = ""  # DEPRECATED: inferred from EMBEDDING_MODELS
 
+    # B2: docs vector-store embedding-model identity guard. When the active
+    # embedding model/dims differ from what the store was built with, DocsDB
+    # raises EmbeddingModelMismatch by default (safe). Set this to rebuild:
+    # the vector table is dropped + re-stamped and the docs-embed pipeline
+    # repopulates it on the next pass.
+    reindex_on_model_change: bool = False  # env REINDEX_ON_MODEL_CHANGE
+
     # BYO local model override. When set, the LOCAL embedding/rerank backend
     # loads this model id instead of the bundled Qwen3 default. A non-built-in
     # id is registered with qwen3-embed at startup using the companion vars

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -23,6 +23,17 @@ from loguru import logger
 from wet_mcp.sources.docs import DISCOVERY_VERSION
 
 
+class EmbeddingModelMismatch(RuntimeError):
+    """Raised when the docs vector store was built with a different model.
+
+    The vector table stores embeddings produced by a specific embedding
+    model at a specific dimensionality. Switching models silently mixes
+    incompatible vector spaces (corruption / nonsense search). DocsDB
+    stamps the active model identity on first init and refuses to open a
+    store stamped with a different identity unless a rebuild is opted in.
+    """
+
+
 def _serialize_f32(vec: list[float]) -> bytes:
     """Serialize float vector for sqlite-vec."""
     return struct.pack(f"{len(vec)}f", *vec)
@@ -189,7 +200,13 @@ def _chunk_quality_score(content: str) -> float:
 class DocsDB:
     """SQLite-backed docs storage with FTS5 hybrid search."""
 
-    def __init__(self, db_path: Path, embedding_dims: int = 0):
+    def __init__(
+        self,
+        db_path: Path,
+        embedding_dims: int = 0,
+        model_identity: str = "",
+        reindex_on_model_change: bool = False,
+    ):
         self._db_path = db_path
         if (
             type(embedding_dims) is not int
@@ -200,6 +217,8 @@ class DocsDB:
                 f"embedding_dims must be an integer 0-65536, got {embedding_dims!r}"
             )
         self._embedding_dims = embedding_dims
+        self._model_identity = model_identity
+        self._reindex_on_model_change = reindex_on_model_change
         self._vec_enabled = False
 
         db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -229,6 +248,7 @@ class DocsDB:
                 logger.debug(f"sqlite-vec not available, FTS-only mode: {e}")
 
         self._create_tables()
+        self._guard_embedding_identity()
         logger.debug(f"DocsDB initialized at {db_path} (vec={self._vec_enabled})")
 
     def _create_tables(self) -> None:
@@ -238,6 +258,116 @@ class DocsDB:
         self._create_fts_table()
         self._create_vector_table()
         self._create_project_context_table()
+        self._create_store_meta_table()
+        self._conn.commit()
+
+    def _create_store_meta_table(self) -> None:
+        # Key/value metadata for store-level invariants (B2: embedding-model
+        # identity guard). Stamped on first init; compared on every open.
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS store_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            )
+        """)
+
+    def _guard_embedding_identity(self) -> None:
+        """Guard the vector store against silent embedding-model swaps.
+
+        Compares the CURRENT ``(embedding_model, embedding_dims)`` to the
+        stamped values:
+
+        * fresh (no stamp) -> stamp + proceed.
+        * match -> proceed.
+        * mismatch -> raise ``EmbeddingModelMismatch`` touching NO data,
+          UNLESS ``reindex_on_model_change`` is set, in which case the
+          vector table is dropped + cleared and the identity re-stamped
+          (the docs-embed pipeline rebuilds on the next pass).
+
+        ``embedding_dims`` is the primary guard (a dims mismatch is the
+        most dangerous case — incompatible vector spaces); ``embedding_model``
+        is also compared when an identity string is available.
+        """
+        stored = {
+            r["key"]: r["value"]
+            for r in self._conn.execute(
+                "SELECT key, value FROM store_meta "
+                "WHERE key IN ('embedding_model', 'embedding_dims')"
+            ).fetchall()
+        }
+
+        current_dims = str(int(self._embedding_dims))
+        # Fresh store: stamp identity and proceed.
+        if "embedding_dims" not in stored and "embedding_model" not in stored:
+            self._stamp_embedding_identity()
+            return
+
+        stored_dims = stored.get("embedding_dims")
+        stored_model = stored.get("embedding_model", "")
+
+        dims_mismatch = stored_dims is not None and stored_dims != current_dims
+        # Only compare the model id when both sides carry one (dims-only guard
+        # otherwise — stamping dims alone still catches the dangerous case).
+        model_mismatch = bool(
+            stored_model
+            and self._model_identity
+            and stored_model != self._model_identity
+        )
+
+        if not dims_mismatch and not model_mismatch:
+            return
+
+        if self._reindex_on_model_change:
+            logger.warning(
+                "Embedding-model change detected (stored model={!r} dims={!r}, "
+                "requested model={!r} dims={!r}); REINDEX_ON_MODEL_CHANGE is set "
+                "-- dropping the vector store and re-stamping. The docs-embed "
+                "pipeline will rebuild embeddings on the next pass.",
+                stored_model,
+                stored_dims,
+                self._model_identity,
+                current_dims,
+            )
+            self._reindex_vector_store()
+            self._stamp_embedding_identity()
+            return
+
+        raise EmbeddingModelMismatch(
+            "Docs vector store was built with embedding model "
+            f"{stored_model or '<unknown>'!r} (dims={stored_dims}) but the "
+            f"server is now configured for {self._model_identity or '<unknown>'!r} "
+            f"(dims={current_dims}). Mixing these vector spaces would corrupt "
+            "search. Set REINDEX_ON_MODEL_CHANGE=true to rebuild, or restore "
+            "the previous model."
+        )
+
+    def _stamp_embedding_identity(self) -> None:
+        """Record the active embedding identity in store_meta."""
+        self._conn.execute(
+            "INSERT OR REPLACE INTO store_meta (key, value) VALUES (?, ?)",
+            ("embedding_dims", str(int(self._embedding_dims))),
+        )
+        if self._model_identity:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO store_meta (key, value) VALUES (?, ?)",
+                ("embedding_model", self._model_identity),
+            )
+        self._conn.commit()
+
+    def _reindex_vector_store(self) -> None:
+        """Drop the vector table + clear stored vectors (opt-in reindex path).
+
+        Does NOT re-run embeddings inline; the existing docs-embed pipeline
+        rebuilds on the next pass.
+        """
+        try:
+            self._conn.execute("DROP TABLE IF EXISTS doc_chunks_vec")
+            self._conn.commit()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Failed to drop vector table during reindex: {e}")
+        # Recreate the empty vector table at the current dims so the embed
+        # pipeline has a target to write into.
+        self._create_vector_table()
         self._conn.commit()
 
     def _create_project_context_table(self) -> None:

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -47,9 +47,10 @@ from wet_mcp.transport_check import is_uvx_tool_venv, uvx_searxng_blocked_error
 logger.remove()
 logger.add(sys.stderr, level=settings.log_level)
 
-# Fixed embedding dimensions for sqlite-vec.
-# All embeddings are truncated to this size so switching models never
-# breaks the vector table. Override via EMBEDDING_DIMS env var.
+# Default embedding dimensions for sqlite-vec when EMBEDDING_DIMS is unset.
+# Embeddings are truncated to this size, but a same-dim model swap still
+# yields an incompatible vector space -- DocsDB's embedding-model identity
+# guard (B2) catches that. Override via EMBEDDING_DIMS env var.
 _DEFAULT_EMBEDDING_DIMS = 768
 
 # Reranking: retrieve more candidates than final limit, then rerank.
@@ -290,7 +291,19 @@ async def _lifespan_startup() -> asyncio.Task | None:
     #    Alembic stamps the baseline + applies any forward migrations.
     docs_path = settings.get_db_path()
     docs_path.parent.mkdir(parents=True, exist_ok=True)
-    _docs_db = DocsDB(docs_path, embedding_dims=_embedding_dims)
+    # B2: embedding-model identity guard. Stamp the active model id so a
+    # later model swap cannot silently mix incompatible vector spaces.
+    # LOCAL backend -> resolved local model id; CLOUD -> head of the chain.
+    if settings.resolve_embedding_backend() == "cloud":
+        _model_identity = settings.embedding_primary() or ""
+    else:
+        _model_identity = settings.resolve_local_embedding_model()
+    _docs_db = DocsDB(
+        docs_path,
+        embedding_dims=_embedding_dims,
+        model_identity=_model_identity,
+        reindex_on_model_change=settings.reindex_on_model_change,
+    )
     try:
         from wet_mcp.migrations import run_migrations_on_startup
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -61,6 +61,7 @@ else:
     _db_mod = sys.modules["wet_mcp.db"]
 
 DocsDB = _db_mod.DocsDB
+EmbeddingModelMismatch = _db_mod.EmbeddingModelMismatch
 _build_fts_queries = _db_mod._build_fts_queries
 _chunk_quality_score = _db_mod._chunk_quality_score
 _serialize_f32 = _db_mod._serialize_f32
@@ -1716,3 +1717,126 @@ class TestVecSearchChunkLoading:
             assert any("different topic" in c for c in all_contents)
         finally:
             db.close()
+
+
+# -----------------------------------------------------------------------
+# Embedding-model identity guard (store_meta table)
+# -----------------------------------------------------------------------
+class TestEmbeddingModelIdentityGuard:
+    """Guard the docs vector store against silent embedding-model swaps.
+
+    The vector table stores embeddings with no record of which model/dims
+    produced them. Switching models silently mixes incompatible vector
+    spaces. DocsDB stamps ``(embedding_model, embedding_dims)`` in a
+    ``store_meta`` table on first init and raises ``EmbeddingModelMismatch``
+    on reopen with a different identity unless reindex is opted in.
+    """
+
+    def test_fresh_store_stamps_identity(self, tmp_path):
+        """A fresh store records the current model id + dims in store_meta."""
+        db = DocsDB(
+            tmp_path / "stamp.db",
+            embedding_dims=4,
+            model_identity="provider/model-a",
+        )
+        try:
+            rows = {
+                r["key"]: r["value"]
+                for r in db._conn.execute(
+                    "SELECT key, value FROM store_meta"
+                ).fetchall()
+            }
+            assert rows["embedding_model"] == "provider/model-a"
+            assert rows["embedding_dims"] == "4"
+        finally:
+            db.close()
+
+    def test_reopen_same_identity_proceeds(self, tmp_path):
+        """Reopening with the same (model, dims) does not raise."""
+        db_path = tmp_path / "same.db"
+        db1 = DocsDB(db_path, embedding_dims=4, model_identity="provider/model-a")
+        db1.close()
+        db2 = DocsDB(db_path, embedding_dims=4, model_identity="provider/model-a")
+        try:
+            assert db2._embedding_dims == 4
+        finally:
+            db2.close()
+
+    def test_reopen_different_identity_raises(self, tmp_path):
+        """Reopening with a different model id raises EmbeddingModelMismatch."""
+        db_path = tmp_path / "diff.db"
+        db1 = DocsDB(db_path, embedding_dims=4, model_identity="provider/model-a")
+        db1.close()
+        with pytest.raises(EmbeddingModelMismatch) as exc:
+            DocsDB(db_path, embedding_dims=4, model_identity="provider/model-b")
+        msg = str(exc.value)
+        assert "provider/model-a" in msg
+        assert "provider/model-b" in msg
+        assert "REINDEX_ON_MODEL_CHANGE" in msg
+
+    def test_reopen_different_dims_raises(self, tmp_path):
+        """A dims change alone (the most dangerous case) raises."""
+        db_path = tmp_path / "dims.db"
+        db1 = DocsDB(db_path, embedding_dims=4, model_identity="provider/model-a")
+        db1.close()
+        with pytest.raises(EmbeddingModelMismatch):
+            DocsDB(db_path, embedding_dims=8, model_identity="provider/model-a")
+
+    def test_mismatch_touches_no_data(self, tmp_path):
+        """Default mismatch path raises WITHOUT destroying stamped identity."""
+        db_path = tmp_path / "safe.db"
+        db1 = DocsDB(db_path, embedding_dims=4, model_identity="provider/model-a")
+        db1.close()
+        with pytest.raises(EmbeddingModelMismatch):
+            DocsDB(db_path, embedding_dims=4, model_identity="provider/model-b")
+        # Stored identity must be intact (untouched) after the raise.
+        db3 = DocsDB(db_path, embedding_dims=4, model_identity="provider/model-a")
+        try:
+            row = db3._conn.execute(
+                "SELECT value FROM store_meta WHERE key = 'embedding_model'"
+            ).fetchone()
+            assert row["value"] == "provider/model-a"
+        finally:
+            db3.close()
+
+    @_requires_sqlite_vec
+    def test_reindex_on_model_change_drops_and_restamps(self, tmp_path):
+        """With reindex opted in, a mismatch drops vectors + re-stamps, no raise."""
+        db_path = tmp_path / "reindex.db"
+        db1 = DocsDB(db_path, embedding_dims=4, model_identity="provider/model-a")
+        try:
+            lib_id = db1.upsert_library("reidxlib")
+            ver_id = db1.upsert_version(lib_id, "1.0")
+            db1.add_chunks(
+                ver_id,
+                lib_id,
+                [{"content": "alpha", "url": "u", "chunk_index": 0}],
+                embeddings=[[0.1, 0.2, 0.3, 0.4]],
+            )
+            vec_count = db1._conn.execute(
+                "SELECT COUNT(*) FROM doc_chunks_vec"
+            ).fetchone()[0]
+            assert vec_count == 1
+        finally:
+            db1.close()
+
+        # Reopen with a new model id + reindex enabled -> no raise, drop vectors.
+        db2 = DocsDB(
+            db_path,
+            embedding_dims=4,
+            model_identity="provider/model-b",
+            reindex_on_model_change=True,
+        )
+        try:
+            # Identity re-stamped to the new model.
+            row = db2._conn.execute(
+                "SELECT value FROM store_meta WHERE key = 'embedding_model'"
+            ).fetchone()
+            assert row["value"] == "provider/model-b"
+            # Vector table cleared (rebuild deferred to the docs-embed pipeline).
+            vec_count = db2._conn.execute(
+                "SELECT COUNT(*) FROM doc_chunks_vec"
+            ).fetchone()[0]
+            assert vec_count == 0
+        finally:
+            db2.close()


### PR DESCRIPTION
@
## What
Final Spec B task (B2): give the docs vector store an embedding-model **identity guard** so a BYO model swap cannot silently mix incompatible vector spaces.

- `store_meta` key/value table stamps `(embedding_model, embedding_dims)` on first init.
- On open, `DocsDB._guard_embedding_identity()`:
  - fresh store -> stamp + proceed
  - match -> proceed
  - **mismatch -> raise `EmbeddingModelMismatch` (touches NO data)** + remediation message
  - mismatch + `REINDEX_ON_MODEL_CHANGE=true` -> drop + recreate vector table, re-stamp (embed pipeline rebuilds next pass)
- `server.py` threads the resolved identity (LOCAL = resolved local model id, CLOUD = chain head).
- New `Settings.reindex_on_model_change` (env `REINDEX_ON_MODEL_CHANGE`, default **False** = safe).

## Why
After the BYO local-model override (#1330), switching the embedding model/dims would silently corrupt similarity search. dims is the primary guard; model id a secondary tag.

## Tests
6 new guard tests in `tests/test_db.py` (fresh/match/mismatch-model/mismatch-dims/reindex). Full suite `1837 passed, 32 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@