### PR TITLE
fix: sync README tagline to current capability description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/wet-mcp
 
-**5-strategy web search + extract + media MCP server, web-core ScrapingAgent backend.**
+**Web search, content extraction, and library docs for AI agents -- 5-strategy scraping, runs without API keys.**
 
 | Phase | Status | Scope |
 |---|---|---|


### PR DESCRIPTION
Sync the README tagline to the cleaned-up, jargon-free repo description (drop dated/internal jargon and brittle tool counts; frame by capability).