### PR TITLE
feat: register a BYO local reranker via CustomRerankerSpec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
-    "qwen3-embed>=1.12.0b1",
+    "qwen3-embed>=1.12.0b2",
     "pillow>=12.2.0",
     "diskcache>=5.6.3",
     "cryptography>=48.0.0",

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -130,7 +130,7 @@ class Settings(BaseSettings):
     # BYO local model override. When set, the LOCAL embedding/rerank backend
     # loads this model id instead of the bundled Qwen3 default. A non-built-in
     # id is registered with qwen3-embed at startup using the companion vars
-    # below (embedding only; rerank custom registration is a follow-up).
+    # below.
     local_embedding_model: str = ""  # env LOCAL_EMBEDDING_MODEL
     local_rerank_model: str = ""  # env LOCAL_RERANK_MODEL
     # Companion vars for registering a custom LOCAL embedding model (BYO ONNX).
@@ -139,6 +139,10 @@ class Settings(BaseSettings):
     local_embedding_dim: int = 0  # required (>0) for a custom embedding model
     local_embedding_normalize: bool = True
     local_embedding_model_file: str = "onnx/model.onnx"
+    # Companion var for registering a custom LOCAL reranker (BYO ONNX cross-
+    # encoder). Used only when LOCAL_RERANK_MODEL is a non-built-in id. A cross-
+    # encoder needs no dim/pooling -- just the ONNX file path within the repo.
+    local_rerank_model_file: str = "onnx/model.onnx"  # env LOCAL_RERANK_MODEL_FILE
 
     # Reranking
     rerank_enabled: bool = (

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -432,6 +432,34 @@ def _maybe_register_custom_embed(local_model: str) -> None:
         logger.debug("Custom embedding registration skipped: {}", e)
 
 
+def _maybe_register_custom_rerank(local_model: str) -> None:
+    """Register a BYO local reranker with qwen3-embed if needed.
+
+    Only fires when the user opted in via LOCAL_RERANK_MODEL. Built-in
+    ``n24q02m/Qwen3-Reranker-*`` ids are already known to qwen3-embed and are
+    left untouched. A custom id is registered via ``qwen3_embed.CustomRerankerSpec``
+    using LOCAL_RERANK_MODEL_FILE so the local cross-encoder can load it. A
+    cross-encoder needs no dim/pooling.
+    """
+    if not settings.local_rerank_model:
+        return
+    if local_model.startswith("n24q02m/Qwen3-Reranker-"):
+        return
+
+    from qwen3_embed import CustomRerankerSpec
+
+    try:
+        CustomRerankerSpec(
+            model_id=local_model,
+            hf=local_model,
+            model_file=settings.local_rerank_model_file,
+        ).register()
+        logger.info("Registered custom local reranker {!r}", local_model)
+    except ValueError as e:
+        # Already registered (re-init) or invalid spec — non-fatal.
+        logger.debug("Custom reranker registration skipped: {}", e)
+
+
 async def _init_embedding_backend(mode: str) -> None:
     """Initialize the embedding backend based on credential state and config.
 
@@ -515,6 +543,7 @@ async def _init_reranker_backend(mode: str) -> None:
 
     if cred_state == CredentialState.LOCAL or rerank_backend_type == "local":
         local_model = settings.resolve_local_rerank_model()
+        _maybe_register_custom_rerank(local_model)
         try:
             reranker = await asyncio.to_thread(init_reranker, "local", local_model)
             available = await asyncio.to_thread(reranker.check_available)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from wet_mcp.server import _maybe_register_custom_embed, extract, search
+from wet_mcp.server import (
+    _maybe_register_custom_embed,
+    _maybe_register_custom_rerank,
+    extract,
+    search,
+)
 
 
 def test_maybe_register_custom_embed_no_optin_noop(monkeypatch):
@@ -91,6 +96,73 @@ def test_maybe_register_custom_embed_missing_dim(monkeypatch):
     )
     _maybe_register_custom_embed("Org/custom-embed")
     assert called == []
+
+
+def test_maybe_register_custom_rerank_no_optin_noop(monkeypatch):
+    """No registration when LOCAL_RERANK_MODEL is unset (default local)."""
+    import qwen3_embed
+
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "local_rerank_model", "")
+    called = []
+    monkeypatch.setattr(
+        qwen3_embed.TextCrossEncoder,
+        "add_custom_model",
+        classmethod(lambda cls, desc, **kw: called.append(desc)),
+    )
+    _maybe_register_custom_rerank("local-reranker")
+    assert called == []
+
+
+def test_maybe_register_custom_rerank_builtin_noop(monkeypatch):
+    """Built-in Qwen3 reranker ids are left untouched (no registration call)."""
+    import qwen3_embed
+
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(
+        settings, "local_rerank_model", "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
+    )
+    called = []
+    monkeypatch.setattr(
+        qwen3_embed.TextCrossEncoder,
+        "add_custom_model",
+        classmethod(lambda cls, desc, **kw: called.append(desc)),
+    )
+    _maybe_register_custom_rerank("n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo")
+    assert called == []
+
+
+def test_maybe_register_custom_rerank_calls_add_custom_model(monkeypatch):
+    """A BYO reranker id registers via TextCrossEncoder.add_custom_model."""
+    import qwen3_embed
+
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "local_rerank_model", "Org/custom-reranker")
+    monkeypatch.setattr(
+        settings, "local_rerank_model_file", "onnx/model_quantized.onnx"
+    )
+
+    captured = {}
+
+    def _fake(cls, desc):
+        captured["model"] = desc.model
+        captured["model_file"] = desc.model_file
+        captured["hf"] = desc.sources.hf
+
+    monkeypatch.setattr(
+        qwen3_embed.TextCrossEncoder,
+        "add_custom_model",
+        classmethod(_fake),
+    )
+
+    _maybe_register_custom_rerank("Org/custom-reranker")
+
+    assert captured["model"] == "Org/custom-reranker"
+    assert captured["model_file"] == "onnx/model_quantized.onnx"
+    assert captured["hf"] == "Org/custom-reranker"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -2711,7 +2711,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.12.0b1"
+version = "1.12.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2722,9 +2722,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/80/fbbd7adf445a547fd4119e58b2c352b8c921df2028727453aba81c57bd0b/qwen3_embed-1.12.0b1.tar.gz", hash = "sha256:b3949f6df0e634eba5c343b04a120699122eb0b1e840a78e9117c1f6804d8580", size = 203461, upload-time = "2026-06-12T11:19:37.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/b1/20c225672a262c9facb1301dc9166e6be6dbb07a15990d2e205408afd0dd/qwen3_embed-1.12.0b2.tar.gz", hash = "sha256:ec39c0b9c270646b4ec4285df0d0ff9bec0ce916bd71967c73111d6a3a72553c", size = 204642, upload-time = "2026-06-12T12:41:00.208Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/b3/42c80b5789441061acb449eb743ae5762b7154e9c19f259ef851707fb231/qwen3_embed-1.12.0b1-py3-none-any.whl", hash = "sha256:c00fc1ef8070f1615e803926bbda4a3050bbfdcf9282c974b192591d554e6444", size = 64546, upload-time = "2026-06-12T11:19:36.324Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f8/95bbbdbfe1b7fff17d72c6264de3920b944607d2c334357039aa15370b17/qwen3_embed-1.12.0b2-py3-none-any.whl", hash = "sha256:1b0a6971047dccf6e5e29fd724b247cfccbcdad4df4c68c93082f920391915c6", size = 65310, upload-time = "2026-06-12T12:41:01.357Z" },
 ]
 
 [[package]]
@@ -3497,7 +3497,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b5"
+version = "3.3.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3563,7 +3563,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },
-    { name = "qwen3-embed", specifier = ">=1.12.0b1" },
+    { name = "qwen3-embed", specifier = ">=1.12.0b2" },
     { name = "sqlite-vec" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "waitress", marker = "sys_platform == 'win32'", specifier = ">=3.0.2" },


### PR DESCRIPTION
@
## What
Completes the BYO consumer story for **rerankers** (the embedding side shipped earlier). `LOCAL_RERANK_MODEL` could already select a different reranker id, but a non-built-in id was never registered with qwen3-embed — so loading it raised "model not supported".

- New `_maybe_register_custom_rerank(local_model)` (mirrors `_maybe_register_custom_embed`): registers a non-builtin `LOCAL_RERANK_MODEL` via `qwen3_embed.CustomRerankerSpec` before the local reranker initializes.
- Companion env `LOCAL_RERANK_MODEL_FILE` (default `onnx/model.onnx`). A cross-encoder needs no dim/pooling.
- Built-in `n24q02m/Qwen3-Reranker-*` ids are left untouched.
- Bump `qwen3-embed>=1.12.0b2` (adds `CustomRerankerSpec`).

## Tests
3 new tests in `tests/test_server.py` (no-optin / builtin / registers). Lint + ty green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@