### PR TITLE
fix: clarify embedding-model switch requires reindex (B2 guard)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ mise run dev       # uv run wet-mcp
 - Graceful fallback chains: Cloud -> Local, Tier 0 -> 1 -> 2 -> 3
 - `match action:` cho tool action dispatch
 - `asyncio.to_thread()` cho wrapping sync operations
-- Embedding luu tai 768 dims (default). Doi provider KHONG lam hu vector table
+- Embedding luu tai 768 dims (default). Doi embedding MODEL = doi vector space -> B2 identity guard CHAN boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo schema; KHONG cho mix vector tu 2 model khac nhau (cung dims van rac search).
 - Renovate: Python upgrades DISABLED
 
 ## Known bugs / gotchas (phat hien 2026-04-18 E2E)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ mise run dev       # uv run wet-mcp
 - Graceful fallback chains: Cloud -> Local, Tier 0 -> 1 -> 2 -> 3
 - `match action:` cho tool action dispatch
 - `asyncio.to_thread()` cho wrapping sync operations
-- Embedding luu tai 768 dims (default). Doi provider KHONG lam hu vector table
+- Embedding luu tai 768 dims (default). Doi embedding MODEL = doi vector space -> B2 identity guard CHAN boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo schema; KHONG cho mix vector tu 2 model khac nhau (cung dims van rac search).
 - Renovate: Python upgrades DISABLED
 
 ## Known bugs / gotchas (phat hien 2026-04-18 E2E)


### PR DESCRIPTION
The CLAUDE.md/AGENTS.md note "switching backend does NOT invalidate existing vectors" / "doi provider khong lam hu vector table" is misleading: it is true for the table *schema* (fixed 768 dims) but omits that switching the embedding **model** changes the vector space. The B2 identity guard blocks boot on model change (different model = different space, same dims still corrupts search) and requires `REINDEX_ON_MODEL_CHANGE=true` to re-embed. This clarifies the note in both CLAUDE.md and AGENTS.md.