### PR TITLE
[SECURITY] SQL Injection in exec_driver_sql (docs_002_libraries index)

### DIFF
--- a/src/wet_mcp/alembic/versions/docs_002_libraries.py
+++ b/src/wet_mcp/alembic/versions/docs_002_libraries.py
@@ -44,14 +44,18 @@ logger = logging.getLogger("alembic.runtime.migration")
 
 def _existing_columns(table: str) -> set[str]:
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
-    return {row[1] for row in rows}
+    rows = bind.exec_driver_sql(
+        "SELECT name FROM pragma_table_info(?)", (table,)
+    ).fetchall()
+    return {row[0] for row in rows}
 
 
 def _existing_indexes(table: str) -> set[str]:
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA index_list({table})").fetchall()
-    return {row[1] for row in rows}
+    rows = bind.exec_driver_sql(
+        "SELECT name FROM pragma_index_list(?)", (table,)
+    ).fetchall()
+    return {row[0] for row in rows}
 
 
 def _add_column_if_missing(table: str, name: str, ddl: str) -> None:


### PR DESCRIPTION
The `docs_002_libraries.py` migration was using f-strings to format table names into `PRAGMA table_info` and `PRAGMA index_list` statements, which are executed via SQLAlchemy's `exec_driver_sql`. This pattern is vulnerable to SQL injection if the table name is not strictly controlled.

This fix refactors `_existing_columns` and `_existing_indexes` to use the parameterized table-valued functions `pragma_table_info(?)` and `pragma_index_list(?)`.

Changes:
- Replaced `PRAGMA table_info({table})` with `SELECT name FROM pragma_table_info(?)`.
- Replaced `PRAGMA index_list({table})` with `SELECT name FROM pragma_index_list(?)`.
- Updated row indexing from `row[1]` to `row[0]` to account for the explicit `name` selection.

Verified by running `tests/test_migrations.py` and `tests/test_migrations_coverage.py`.

---
*PR created automatically by Jules for task [11475354933331743469](https://jules.google.com/task/11475354933331743469) started by @n24q02m*