### PR TITLE
[SECURITY] SQL Injection in execute (ALTER TABLE doc_chunks)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,6 @@
 ## 2024-10-30 - Sliding Window Optimizations
 **Learning:** In string processing tasks like passage extraction that use a sliding window approach with multiple query terms, repeatedly checking for terms that don't even exist in the document wastes significant CPU cycles.
 **Action:** When extracting passages, pre-filter query terms by first checking their existence in the overall text (`[term for term in query_terms if term in content]`). Additionally, record the `max_possible_score` so the algorithm can terminate early when the best possible window is found. This simple technique avoids redundant checking and provides an effective speedup.
+## 2025-05-15 - [Security] SQL Injection in DDL Fix
+**Learning:** SQLite ALTER TABLE statements cannot be parameterized using standard bind variables. Using f-strings or string concatenation for DDL is a common pattern that triggers security alerts.
+**Action:** Implement a whitelist-based validation layer for DDL statements. Use a centralized helper method with explicit security suppressions (# nosemgrep, # nosec) only after strict input validation against the whitelist.

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -93,6 +93,30 @@ _DOC_CHUNKS_COLUMNS = {
     "summary_provider",
 }
 
+# Security: Allowlist for idempotent schema migrations (legacy DB support)
+_ALLOWED_ALTER_COLUMNS = {
+    "libraries": {
+        "discovery_version INTEGER DEFAULT 0",
+        "canonical_name TEXT",
+        "homepage TEXT",
+        "github_url TEXT",
+        "package_managers TEXT",
+        "tier INTEGER NOT NULL DEFAULT 2",
+        "last_indexed_at REAL",
+        "total_versions INTEGER NOT NULL DEFAULT 0",
+    },
+    "versions": {
+        "release_date REAL",
+        "source_url TEXT",
+    },
+    "doc_chunks": {
+        "section TEXT",
+        "topic TEXT",
+        "content_hash TEXT",
+        "token_count INTEGER",
+    },
+}
+
 # Directive-heavy content (mkdocs leftover, rst directives)
 _DIRECTIVE_RE = re.compile(r"^(?:!!!|:::|\.\.)\s", re.MULTILINE)
 
@@ -385,6 +409,23 @@ class DocsDB:
             ON project_context(last_used_at)
         """)
 
+    def _add_column_idempotent(self, table: str, col_ddl: str) -> None:
+        """Add a column to a table if it does not exist, with security validation."""
+        if table not in _ALLOWED_ALTER_COLUMNS:
+            raise ValueError(f"Unauthorized table for ALTER: {table}")
+        if col_ddl not in _ALLOWED_ALTER_COLUMNS[table]:
+            raise ValueError(f"Unauthorized DDL for ALTER {table}: {col_ddl}")
+
+        try:
+            # Security: Inputs are validated against _ALLOWED_ALTER_COLUMNS whitelist.
+            # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query
+            self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {col_ddl}")  # nosec
+            self._conn.commit()
+            col_name = col_ddl.split()[0]
+            logger.debug(f"Migrated {table} table: added {col_name}")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
     def _create_libraries_table(self) -> None:
         # Libraries metadata (Phase 2 schema; pre-Alembic legacy databases
         # are upgraded to this shape by alembic/versions/docs_002_libraries.py).
@@ -413,8 +454,6 @@ class DocsDB:
         """)
 
         # Idempotent column adds for legacy DBs that pre-date Alembic.
-        # Each ALTER is wrapped in a try/except so re-running on a fresh
-        # head-shape table does not raise.
         for col_ddl in (
             "discovery_version INTEGER DEFAULT 0",
             "canonical_name TEXT",
@@ -425,13 +464,7 @@ class DocsDB:
             "last_indexed_at REAL",
             "total_versions INTEGER NOT NULL DEFAULT 0",
         ):
-            try:
-                self._conn.execute(f"ALTER TABLE libraries ADD COLUMN {col_ddl}")
-                self._conn.commit()
-                col_name = col_ddl.split()[0]
-                logger.debug(f"Migrated libraries table: added {col_name}")
-            except sqlite3.OperationalError:
-                pass  # Column already exists
+            self._add_column_idempotent("libraries", col_ddl)
 
     def _create_versions_table(self) -> None:
         # Versions (Phase 2 schema with release_date + source_url).
@@ -453,11 +486,7 @@ class DocsDB:
         """)
         # Idempotent column adds for legacy DBs.
         for col_ddl in ("release_date REAL", "source_url TEXT"):
-            try:
-                self._conn.execute(f"ALTER TABLE versions ADD COLUMN {col_ddl}")
-                self._conn.commit()
-            except sqlite3.OperationalError:
-                pass
+            self._add_column_idempotent("versions", col_ddl)
 
     def _create_doc_chunks_table(self) -> None:
         # Document chunks (Phase 2 schema with section/topic/content_hash/token_count).
@@ -487,11 +516,7 @@ class DocsDB:
             "content_hash TEXT",
             "token_count INTEGER",
         ):
-            try:
-                self._conn.execute(f"ALTER TABLE doc_chunks ADD COLUMN {col_ddl}")
-                self._conn.commit()
-            except sqlite3.OperationalError:
-                pass
+            self._add_column_idempotent("doc_chunks", col_ddl)
         self._conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_chunks_version
             ON doc_chunks(version_id)


### PR DESCRIPTION
Fixed a security vulnerability where `ALTER TABLE` statements were constructed using f-strings without proper parameterization or validation. While SQLite does not support parameterizing DDL, this pattern is unsafe and triggers security scanners.

Changes:
- Added `_ALLOWED_ALTER_COLUMNS` whitelist for idempotent schema migrations.
- Implemented `_add_column_idempotent` helper method that validates inputs against the whitelist before execution.
- Refactored `_create_libraries_table`, `_create_versions_table`, and `_create_doc_chunks_table` to use the safe helper.
- Added security annotations to satisfy static analysis tools.

---
*PR created automatically by Jules for task [5514992331339577741](https://jules.google.com/task/5514992331339577741) started by @n24q02m*