### PR TITLE
[TEST] Missing error path test in db.py - add_chunks serialization

### DIFF
--- a/tests/test_db_add_chunks_serialization.py
+++ b/tests/test_db_add_chunks_serialization.py
@@ -1,4 +1,5 @@
 import sqlite3
+from typing import Any, cast
 
 from wet_mcp.db import DocsDB
 
@@ -15,7 +16,8 @@ class TestAddChunksSerialization:
 
         chunks = [{"content": "valid_chunk"}, {"content": "error_chunk"}]
         # First embedding is valid (list of 2 floats), second is invalid (string)
-        embeddings = [[1.0, 2.0], "invalid_embedding"]
+        # Use cast(Any, ...) to satisfy ty check while passing invalid data
+        embeddings = cast(Any, [[1.0, 2.0], "invalid_embedding"])
 
         # Should NOT raise an exception and should return total chunk count
         count = db.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
@@ -47,11 +49,10 @@ class TestAddChunksSerialization:
         db._vec_enabled = True
 
         # Invalid query embedding (not a list of floats)
-        query_embedding = "invalid"
+        # Use cast(Any, ...) to satisfy ty check while passing invalid data
+        query_embedding = cast(Any, "invalid")
 
         # Should NOT raise an exception and return empty results (or at least handle error)
-        # Note: search handles serialization in the try-except block of the search method itself?
-        # Let's check the search code again.
         results = db.search("query", query_embedding=query_embedding)
         assert results == []
         db.close()

--- a/tests/test_db_add_chunks_serialization.py
+++ b/tests/test_db_add_chunks_serialization.py
@@ -1,0 +1,57 @@
+import sqlite3
+
+from wet_mcp.db import DocsDB
+
+
+class TestAddChunksSerialization:
+    def test_add_chunks_serialization_error_extra(self, tmp_path):
+        """Verify add_chunks handles embedding serialization failure and continues."""
+        # Initialize DocsDB with vector support enabled
+        db = DocsDB(tmp_path / "extra_ser.db", embedding_dims=2)
+        db._vec_enabled = True
+
+        lib_id = db.upsert_library(name="extra_lib")
+        ver_id = db.upsert_version(lib_id)
+
+        chunks = [{"content": "valid_chunk"}, {"content": "error_chunk"}]
+        # First embedding is valid (list of 2 floats), second is invalid (string)
+        embeddings = [[1.0, 2.0], "invalid_embedding"]
+
+        # Should NOT raise an exception and should return total chunk count
+        count = db.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
+        assert count == 2
+
+        # Verify both chunks were inserted into the main table
+        rows = db._conn.execute(
+            "SELECT content FROM doc_chunks ORDER BY content"
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] == "error_chunk"
+        assert rows[1][0] == "valid_chunk"
+
+        # Verify only the valid vector was inserted into the vector table
+        try:
+            vec_rows = db._conn.execute(
+                "SELECT count(*) FROM doc_chunks_vec"
+            ).fetchone()
+            assert vec_rows[0] == 1
+        except sqlite3.OperationalError:
+            # sqlite-vec not loaded/supported in this environment, which is fine
+            pass
+
+        db.close()
+
+    def test_search_serialization_error(self, tmp_path):
+        """Verify search handles query embedding serialization failure."""
+        db = DocsDB(tmp_path / "search_ser.db", embedding_dims=2)
+        db._vec_enabled = True
+
+        # Invalid query embedding (not a list of floats)
+        query_embedding = "invalid"
+
+        # Should NOT raise an exception and return empty results (or at least handle error)
+        # Note: search handles serialization in the try-except block of the search method itself?
+        # Let's check the search code again.
+        results = db.search("query", query_embedding=query_embedding)
+        assert results == []
+        db.close()

--- a/tests/test_sync_base.py
+++ b/tests/test_sync_base.py
@@ -12,7 +12,7 @@ from wet_mcp.sync.base import SyncBackend
 def test_sync_backend_is_abstract() -> None:
     """SyncBackend should not be instantiable due to abstract methods."""
     with pytest.raises(TypeError, match="Can't instantiate abstract class SyncBackend"):
-        SyncBackend()  # type: ignore
+        SyncBackend()
 
 
 class MockBackend(SyncBackend):


### PR DESCRIPTION
This PR adds test coverage for the embedding serialization error paths in `src/wet_mcp/db.py`. Specifically, it covers the `try-except` blocks in `add_chunks` and `search` methods where `_serialize_f32` is called. These tests ensure that the system handles malformed embedding data gracefully by logging a debug message and continuing processing instead of crashing. Verified locally with `uv run pytest -n0`.

---
*PR created automatically by Jules for task [12625614281261095716](https://jules.google.com/task/12625614281261095716) started by @n24q02m*