### PR TITLE
[PERF] Sequential async API calls instead of gather

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2024-10-30 - Sliding Window Optimizations
 **Learning:** In string processing tasks like passage extraction that use a sliding window approach with multiple query terms, repeatedly checking for terms that don't even exist in the document wastes significant CPU cycles.
 **Action:** When extracting passages, pre-filter query terms by first checking their existence in the overall text (`[term for term in query_terms if term in content]`). Additionally, record the `max_possible_score` so the algorithm can terminate early when the best possible window is found. This simple technique avoids redundant checking and provides an effective speedup.
+
+## 2026-06-13 - Parallel Async API Calls
+**Learning:** Sequential `await` loops for I/O-bound operations (like batch embedding requests) create an artificial bottleneck, where total latency scales linearly with the number of batches ((N \times D)$). Using `asyncio.gather` allows the event loop to execute these tasks concurrently, reducing total wall-clock time to approximately the duration of the slowest task ((D)$).
+**Action:** Collect independent coroutines into a list and execute them using `asyncio.gather(*tasks)`. Ensure result aggregation preserves the expected order and that retry logic is handled within the individual coroutines to maintain robustness.

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -285,13 +285,17 @@ class CloudEmbeddingBackend:
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
             batch_num = i // self.MAX_BATCH_SIZE + 1
             logger.debug(
                 f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
             )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(self._embed_batch_inner(batch, dimensions))
+
+        results = await asyncio.gather(*tasks)
+        for batch_result in results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -785,3 +785,40 @@ class TestQwen3GetModelWarning:
         mock_model.embed.return_value = iter([np.array([0.1, 0.2, 0.3])])
         with patch.object(backend, "_get_model", return_value=mock_model):
             assert await backend.check_available() == 3
+
+
+class TestCloudEmbeddingParallel:
+    """Verify that CloudEmbeddingBackend.embed_texts parallelizes requests."""
+
+    async def test_embed_texts_parallel_execution(self):
+        """Total time should be less than sequential execution time."""
+        import time
+        from unittest.mock import patch
+
+        from wet_mcp.embedder import CloudEmbeddingBackend
+
+        backend = CloudEmbeddingBackend("text-embedding-3-small")
+        # Ensure we have at least 2 batches
+        n_texts = backend.MAX_BATCH_SIZE + 1
+        texts = ["test"] * n_texts
+
+        delay = 0.5
+
+        async def mock_embed_batch_inner(batch, dimensions=None):
+            await __import__("asyncio").sleep(delay)
+            return [[0.1]] * len(batch)
+
+        with patch.object(
+            backend, "_embed_batch_inner", side_effect=mock_embed_batch_inner
+        ):
+            start_time = time.perf_counter()
+            await backend.embed_texts(texts)
+            end_time = time.perf_counter()
+
+        elapsed = end_time - start_time
+        # Sequential would be ~1.0s, parallel should be ~0.5s (plus overhead)
+        # We check it is significantly less than 2 * delay
+        assert elapsed < delay * 1.5
+        print(
+            f"Parallel execution took {elapsed:.4f}s vs expected sequential {delay * 2}s"
+        )


### PR DESCRIPTION
Optimized `CloudEmbeddingBackend.embed_texts` in `src/wet_mcp/embedder.py` by using `asyncio.gather` to execute batch embedding requests concurrently instead of sequentially. This reduces total latency for large inputs by parallelizing network I/O. Added a performance verification test in `tests/test_embedder.py` to ensure parallel execution behavior.

---
*PR created automatically by Jules for task [16504587323635859952](https://jules.google.com/task/16504587323635859952) started by @n24q02m*