### PR TITLE
[TEST] implement missing fields in DocsDB.stats and add db_path property

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -251,6 +251,11 @@ class DocsDB:
         self._guard_embedding_identity()
         logger.debug(f"DocsDB initialized at {db_path} (vec={self._vec_enabled})")
 
+    @property
+    def db_path(self) -> Path:
+        """Return the path to the database file."""
+        return self._db_path
+
     def _create_tables(self) -> None:
         self._create_libraries_table()
         self._create_versions_table()
@@ -578,14 +583,28 @@ class DocsDB:
     # -----------------------------------------------------------------------
 
     def stats(self) -> dict:
-        """Return database statistics."""
+        """Get database statistics."""
         lib_count = self._conn.execute("SELECT COUNT(*) FROM libraries").fetchone()[0]
+        version_count = self._conn.execute("SELECT COUNT(*) FROM versions").fetchone()[
+            0
+        ]
         chunk_count = self._conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[
             0
         ]
+        # In WAL mode, much of the data may be in the -wal file.
+        # We sum them to get the real on-disk footprint.
+        p = Path(self.db_path)
+        db_size_bytes = p.stat().st_size
+        wal_p = p.with_name(p.name + "-wal")
+        if wal_p.exists():
+            db_size_bytes += wal_p.stat().st_size
+
+        db_size_mb = round(db_size_bytes / 1024 / 1024, 2)
         return {
             "libraries": lib_count,
+            "versions": version_count,
             "chunks": chunk_count,
+            "db_size_mb": db_size_mb,
             "vec_enabled": self._vec_enabled,
         }
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1444,7 +1444,9 @@ class TestStats:
         """Stats on empty DB returns zeros."""
         stats = db.stats()
         assert stats["libraries"] == 0
+        assert stats["versions"] == 0
         assert stats["chunks"] == 0
+        assert stats["db_size_mb"] >= 0
         assert stats["vec_enabled"] is False
 
     def test_stats_with_data(self, db_with_data):
@@ -1452,7 +1454,9 @@ class TestStats:
         db = db_with_data[0]
         stats = db.stats()
         assert stats["libraries"] == 1
+        assert stats["versions"] == 1
         assert stats["chunks"] == 4
+        assert stats["db_size_mb"] > 0
         assert stats["vec_enabled"] is False
 
     @_requires_sqlite_vec

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -619,7 +619,9 @@ class TestStats:
         db, _, _ = populated_db
         s = db.stats()
         assert s["libraries"] >= 1
+        assert s["versions"] >= 1
         assert s["chunks"] >= 4
+        assert s["db_size_mb"] > 0
         assert s["vec_enabled"] is False
 
 


### PR DESCRIPTION
This PR addresses the issue of untested and incomplete statistics in `src/wet_mcp/db.py`.

### Changes Made:
1.  **Enhanced `DocsDB.stats()`**: Updated the method to return `versions` count and `db_size_mb` in addition to existing fields.
2.  **WAL-Aware Size Calculation**: The `db_size_mb` calculation now sums the main database file and the `-wal` file (if present) to provide an accurate on-disk footprint while the database is active.
3.  **Added `db_path` Property**: Added a public `@property def db_path(self) -> Path` to the `DocsDB` class.
4.  **Updated Tests**: Modified `tests/test_db.py` and `tests/test_db_coverage.py` to assert the presence and accuracy of the new fields in both empty and populated database states.

### Verification:
- Ran all database-related tests (142 passed).
- Confirmed coverage for the `stats()` method and the new `db_path` property.
- Ran `ruff` for formatting and linting.

---
*PR created automatically by Jules for task [8855610469022634441](https://jules.google.com/task/8855610469022634441) started by @n24q02m*