### PR TITLE
[TEST] Missing edge case test in setup.py - missing searxng package dir

### DIFF
--- a/tests/test_setup_coverage_fix.py
+++ b/tests/test_setup_coverage_fix.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from wet_mcp.setup import patch_searxng_version, patch_searxng_windows
+
+
+@patch("wet_mcp.setup.logger")
+@patch("wet_mcp.setup.Path")
+@patch("wet_mcp.setup._find_searx_package_dir")
+def test_patch_searxng_version_no_dir_robust(mock_find_dir, mock_path, mock_logger):
+    """Verify patch_searxng_version returns early without any side effects if searx dir is missing."""
+    mock_find_dir.return_value = None
+
+    patch_searxng_version()
+
+    # Should exit early without any Path operations
+    mock_path.assert_not_called()
+    # Should not log anything on early return
+    mock_logger.debug.assert_not_called()
+    mock_logger.warning.assert_not_called()
+    mock_logger.error.assert_not_called()
+
+
+@patch("wet_mcp.setup.platform.system")
+@patch("wet_mcp.setup.logger")
+@patch("wet_mcp.setup.Path")
+@patch("wet_mcp.setup._find_searx_package_dir")
+def test_patch_searxng_windows_no_dir_robust(
+    mock_find_dir, mock_path, mock_logger, mock_system
+):
+    """Verify patch_searxng_windows returns early without any side effects if searx dir is missing on Windows."""
+    mock_system.return_value = "Windows"
+    mock_find_dir.return_value = None
+
+    patch_searxng_windows()
+
+    # Should exit early without any Path operations
+    mock_path.assert_not_called()
+    # Should not log anything on early return
+    mock_logger.debug.assert_not_called()
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
This PR addresses a testing gap in `src/wet_mcp/setup.py`. Specifically, it adds robust test cases for the early return branches in `patch_searxng_version` and `patch_searxng_windows` when the SearXNG package directory cannot be found (i.e., `_find_searx_package_dir()` returns `None`).

While general coverage was high, these specific no-op paths were not explicitly validated for lack of side effects. The new tests ensure that:
1. No `Path` objects are instantiated or used for filesystem operations when the directory is missing.
2. No log messages (debug, warning, or error) are emitted on these early return paths.
3. The functions exit gracefully without raising exceptions.

All tests, including the existing 1873 tests, pass successfully.

---
*PR created automatically by Jules for task [17767671293191396020](https://jules.google.com/task/17767671293191396020) started by @n24q02m*