### PR TITLE
⚡ Bolt: [Performance] Parallelize cloud embedding batches

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -278,20 +278,27 @@ class CloudEmbeddingBackend:
             return await self._embed_batch_inner(texts, dimensions)
 
         # Split into batches
-        all_embeddings: list[list[float]] = []
         total_batches = (len(texts) + self.MAX_BATCH_SIZE - 1) // self.MAX_BATCH_SIZE
         logger.info(
             f"Splitting {len(texts)} texts into {total_batches} batches "
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
             batch_num = i // self.MAX_BATCH_SIZE + 1
             logger.debug(
                 f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
             )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(self._embed_batch_inner(batch, dimensions))
+
+        # Run all batch embedding tasks concurrently
+        results = await asyncio.gather(*tasks)
+
+        # Flatten the list of lists while preserving the original order
+        all_embeddings: list[list[float]] = []
+        for batch_result in results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings


### PR DESCRIPTION
💡 What: The `CloudEmbeddingBackend.embed_texts` method was refactored to execute batch embedding tasks concurrently using `asyncio.gather`, rather than awaiting them one-by-one in a sequential loop.
🎯 Why: When embedding a large list of texts, the process is split into chunks of `MAX_BATCH_SIZE`. Awaiting these network requests sequentially incurs high overall latency because each request must complete before the next begins. Parallelizing these requests overlaps the network latency and results in significantly faster execution times.
📊 Impact: Expected to greatly reduce embedding time for large payloads, bounded mostly by the slowest individual API request and network bandwidth, instead of scaling linearly with the number of batches.
🔬 Measurement: Verify by embedding a large dataset and measuring the wall-clock execution time; it will be approximately the time of a single slow request instead of the sum of all requests.

---
*PR created automatically by Jules for task [6891552415256953857](https://jules.google.com/task/6891552415256953857) started by @n24q02m*