### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SQL injection risk in SQLite PRAGMA statements

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `token_store.py` module constructed file paths by directly concatenating user-controlled inputs (`provider`, `sub`) via `pathlib.Path` without validation. This allowed path traversal (e.g., using `../` or absolute paths) to read or write arbitrary files on the system with the application's permissions.
 **Learning:** Even when using higher-level path abstractions like `pathlib`, string concatenation or `/` division with unvalidated user input is unsafe because the underlying OS resolution still respects traversal sequences.
 **Prevention:** Always explicitly validate path components for dangerous characters (like `/`, `\`, and `..`) using an explicit string validation helper before passing them to file I/O operations or path constructors.
+
+## 2024-05-24 - SQL Injection Risk in PRAGMA Queries
+**Vulnerability:** SQLite `PRAGMA` commands like `PRAGMA table_info(table_name)` or `PRAGMA index_list(table_name)` do not support standard parameter binding (`?`), which often leads developers to use unsafe string formatting (e.g., f-strings) when the table name is variable. This introduces a risk of SQL injection if the table name originates from user input.
+**Learning:** Modern SQLite provides table-valued functions for introspection that accept bound parameters, allowing safe, parameterized execution of what would otherwise be dynamic DDL-like commands. Note that the output format might differ slightly (e.g., column index shifts when projecting specific fields like `SELECT name FROM...`).
+**Prevention:** Always use parameterized table-valued functions like `SELECT name FROM pragma_table_info(?)` or `SELECT name FROM pragma_index_list(?)` instead of string-formatted `PRAGMA` statements.

--- a/src/wet_mcp/alembic/versions/docs_002_libraries.py
+++ b/src/wet_mcp/alembic/versions/docs_002_libraries.py
@@ -44,14 +44,18 @@ logger = logging.getLogger("alembic.runtime.migration")
 
 def _existing_columns(table: str) -> set[str]:
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
-    return {row[1] for row in rows}
+    rows = bind.exec_driver_sql(
+        "SELECT name FROM pragma_table_info(?)", (table,)
+    ).fetchall()
+    return {row[0] for row in rows}
 
 
 def _existing_indexes(table: str) -> set[str]:
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA index_list({table})").fetchall()
-    return {row[1] for row in rows}
+    rows = bind.exec_driver_sql(
+        "SELECT name FROM pragma_index_list(?)", (table,)
+    ).fetchall()
+    return {row[0] for row in rows}
 
 
 def _add_column_if_missing(table: str, name: str, ddl: str) -> None:

--- a/src/wet_mcp/alembic/versions/docs_004_chunk_summaries.py
+++ b/src/wet_mcp/alembic/versions/docs_004_chunk_summaries.py
@@ -32,9 +32,9 @@ def upgrade() -> None:
     # migration on an already-upgraded DB is a no-op. PRAGMA table_info
     # returns rows shaped as (cid, name, type, notnull, dflt_value, pk).
     existing_cols = {
-        row[1]
+        row[0]
         for row in op.get_bind()
-        .exec_driver_sql("PRAGMA table_info(doc_chunks)")
+        .exec_driver_sql("SELECT name FROM pragma_table_info(?)", ("doc_chunks",))
         .fetchall()
     }
     if "summary" not in existing_cols:

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -624,7 +624,9 @@ class DocsDB:
         # presence once per call so we don't crash on older schemas.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info(?)", ("libraries",)
+            ).fetchall()
         }
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
@@ -747,7 +749,9 @@ class DocsDB:
         """
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info(?)", ("libraries",)
+            ).fetchall()
         }
         sets: list[str] = []
         params: list = []
@@ -880,7 +884,9 @@ class DocsDB:
         # Detect optional columns once so we can branch on a single INSERT.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info(?)", ("doc_chunks",)
+            ).fetchall()
         }
         phase2_cols = [
             c

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -705,7 +705,7 @@ class TestMarkLibraryIndexed:
             # The first call should be PRAGMA table_info
             # If it didn't return early, there would be a second call with UPDATE
             assert mock_conn.execute.call_count == 1
-            assert "PRAGMA table_info" in mock_conn.execute.call_args[0][0]
+            assert "pragma_table_info" in mock_conn.execute.call_args[0][0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Used string formatting (f-strings) to pass table names to `PRAGMA table_info` and `PRAGMA index_list`.
🎯 Impact: While currently safe due to hardcoded/internal table names, this pattern poses an SQL injection risk if user-controlled input ever reaches these introspection functions.
🔧 Fix: Replaced string-formatted `PRAGMA` commands with SQLite's parameterized table-valued functions (`SELECT name FROM pragma_table_info(?)` and `SELECT name FROM pragma_index_list(?)`), binding the table name safely via `?`. Shifted index projections appropriately.
✅ Verification: Ran `uv run pytest` specifically against database and migration test suites; updated mocked assertions. All tests pass with no regressions.

---
*PR created automatically by Jules for task [11304098796650248740](https://jules.google.com/task/11304098796650248740) started by @n24q02m*