### PR TITLE
⚡ Bolt: Parallelize cloud embedding batches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2024-10-30 - Sliding Window Optimizations
 **Learning:** In string processing tasks like passage extraction that use a sliding window approach with multiple query terms, repeatedly checking for terms that don't even exist in the document wastes significant CPU cycles.
 **Action:** When extracting passages, pre-filter query terms by first checking their existence in the overall text (`[term for term in query_terms if term in content]`). Additionally, record the `max_possible_score` so the algorithm can terminate early when the best possible window is found. This simple technique avoids redundant checking and provides an effective speedup.
+
+## 2026-06-14 - Rate-Limited Concurrency with asyncio.Semaphore
+**Learning:** When parallelizing API requests using `asyncio.gather`, throwing all tasks into it simultaneously can lead to unbounded concurrency, which quickly triggers API rate limits (e.g., HTTP 429) or resource exhaustion.
+**Action:** Always wrap parallel network calls in a concurrency limiter, such as `asyncio.Semaphore(10)`, to safely throttle requests while still benefiting from significant latency reductions.

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -285,13 +285,28 @@ class CloudEmbeddingBackend:
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        # ⚡ Bolt Optimization: Parallelize batch embedding requests
+        # Using asyncio.gather allows concurrent execution of independent API calls,
+        # dramatically reducing overall latency for large documents compared to
+        # sequential iteration. Order is preserved by gather().
+        # We use a Semaphore to avoid unbounded concurrency and rate limits.
+        sem = asyncio.Semaphore(10)
+
+        async def _embed_with_sem(batch: list[str]) -> list[list[float]]:
+            async with sem:
+                return await self._embed_batch_inner(batch, dimensions)
+
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
             batch_num = i // self.MAX_BATCH_SIZE + 1
             logger.debug(
-                f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
+                f"Queuing embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
             )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(_embed_with_sem(batch))
+
+        results = await asyncio.gather(*tasks)
+        for batch_result in results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings


### PR DESCRIPTION
💡 What: Modified `CloudEmbeddingBackend.embed_texts` to execute API requests concurrently using `asyncio.gather` with a bounded concurrency of 10 (`asyncio.Semaphore`).
🎯 Why: Iterating sequentially over many embedding batches caused significant overhead and latency when processing large datasets. Parallelizing the network calls dramatically speeds up the embedding step.
📊 Impact: Expected to reduce wall-clock time for embedding large documents by 5-10x, bottlenecked only by the concurrency limit.
🔬 Measurement: Verify by executing large text embedding workloads or running `tests/test_embedder.py` (which inherently measures execution correctness and preservation of ordering).

---
*PR created automatically by Jules for task [2455787913321231430](https://jules.google.com/task/2455787913321231430) started by @n24q02m*