### PR TITLE
fix: correct credential storage and relay/auth claims in architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Xem `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `server.py` -- FastMCP server (orchestrator, file lon nhat)
   - `config.py` -- Pydantic Settings (singleton)
   - `cache.py`, `db.py`, `embedder.py`, `reranker.py` -- Infrastructure
-  - `relay_setup.py` -- Zero-config relay: create session, poll for config
+  - `relay_setup.py` -- `apply_config` / `load_config_from_file` env-applier used by the OAuth setup form (live setup UX = OAuth-AS browser form at `<PUBLIC_URL>/authorize`; the `ensure_config` create-session/poll path is legacy/unused in production)
   - `relay_schema.py` -- Relay form schema (2 modes: local/cloud)
   - `sync/` -- Docs sync backends: `gdrive.py` (Google Drive, OAuth Device Code, httpx) + `s3.py` (S3/R2/B2 operator mode) + `base.py`
   - `token_store.py` -- Local token storage cho OAuth (~/.wet-mcp/tokens/)
@@ -77,7 +77,8 @@ mise run dev       # uv run wet-mcp
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`
-- Relay: `MCP_RELAY_URL` (required for remote-relay mode, no default — wet-mcp default is local-relay per matrix)
+- HTTP auth (live self-host): credentials are configured via the OAuth-AS browser form at `<PUBLIC_URL>/authorize`; `GET /mcp` without a Bearer token returns 401 + `www-authenticate` pointing at `/.well-known/oauth-protected-resource`. The browser form is gated by `MCP_RELAY_PASSWORD` (single shared password, gate only — empty disables it; not per-user). Multi-user remote mode also requires `CREDENTIAL_SECRET` (per-sub vault key) + `MCP_DCR_SERVER_SECRET` (proof of intentional multi-user deploy).
+- `MCP_RELAY_URL`: read only by the legacy `ensure_config` create-session/poll path (`relay_setup.py`), which has no production caller — the live setup UX is the OAuth-AS form above, not an ECDH relay.
 - Secrets: skret SSM namespace `/wet-mcp/prod` (region `ap-southeast-1`)
 
 ### Manual config example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Xem `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `server.py` -- FastMCP server (orchestrator, file lon nhat)
   - `config.py` -- Pydantic Settings (singleton)
   - `cache.py`, `db.py`, `embedder.py`, `reranker.py` -- Infrastructure
-  - `relay_setup.py` -- Zero-config relay: create session, poll for config
+  - `relay_setup.py` -- `apply_config` / `load_config_from_file` env-applier used by the OAuth setup form (live setup UX = OAuth-AS browser form at `<PUBLIC_URL>/authorize`; the `ensure_config` create-session/poll path is legacy/unused in production)
   - `relay_schema.py` -- Relay form schema (2 modes: local/cloud)
   - `sync/` -- Docs sync backends: `gdrive.py` (Google Drive, OAuth Device Code, httpx) + `s3.py` (S3/R2/B2 operator mode) + `base.py`
   - `token_store.py` -- Local token storage cho OAuth (~/.wet-mcp/tokens/)
@@ -77,7 +77,8 @@ mise run dev       # uv run wet-mcp
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`
-- Relay: `MCP_RELAY_URL` (required for remote-relay mode, no default — wet-mcp default is local-relay per matrix)
+- HTTP auth (live self-host): credentials are configured via the OAuth-AS browser form at `<PUBLIC_URL>/authorize`; `GET /mcp` without a Bearer token returns 401 + `www-authenticate` pointing at `/.well-known/oauth-protected-resource`. The browser form is gated by `MCP_RELAY_PASSWORD` (single shared password, gate only — empty disables it; not per-user). Multi-user remote mode also requires `CREDENTIAL_SECRET` (per-sub vault key) + `MCP_DCR_SERVER_SECRET` (proof of intentional multi-user deploy).
+- `MCP_RELAY_URL`: read only by the legacy `ensure_config` create-session/poll path (`relay_setup.py`), which has no production caller — the live setup UX is the OAuth-AS form above, not an ECDH relay.
 - Secrets: skret SSM namespace `/wet-mcp/prod` (region `ap-southeast-1`)
 
 ### Manual config example

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,7 @@ live in `src/wet_mcp/sources/_smart_chunks.py`.
 |---|---|---|
 | `~/.wet-mcp/docs.db` | Library docs index (chunks + embeddings) | SQLite WAL + sqlite-vec |
 | `~/.wet-mcp/cache.db` | Web search + extract cache (TTL gated) | SQLite WAL |
-| `~/.wet-mcp/config.enc` | Encrypted credentials (mcp-core managed) | AES-GCM, machine-bound key |
+| `~/.wet-mcp/config.json` | Encrypted credentials (mcp-core `PerPluginStore`) | AES-GCM, machine-bound key at `~/.wet-mcp/.secret` |
 | `~/.wet-mcp/downloads/` | Media download output dir | Filesystem |
 | `~/.wet-mcp/tokens/google_drive.json` | OAuth Device Code token (sync) | Filesystem 0600 perms |
 
@@ -161,12 +161,16 @@ This dispatch is shared with web-core's `selector_inference` module
 
 | Mode | Default? | Storage scope | Multi-user |
 |---|---|---|---|
-| stdio | Yes | Local user (`~/.wet-mcp/config.enc`, perm 0600) | No |
-| HTTP self-host | No | Per-JWT-sub credential vault | Yes |
+| stdio | Yes | Local user (`~/.wet-mcp/config.json`, perm 0600) | No |
+| HTTP self-host (single-user) | No | Shared local store (`~/.wet-mcp/config.json`), bind 127.0.0.1 | No |
+| HTTP self-host (multi-user) | No | Per-JWT-sub vault (`~/.wet-mcp/subs/<sub>/config.json`), bind 0.0.0.0 | Yes |
 
 The stdio default avoids OAuth complexity for single-machine personal
 use; HTTP self-host is recommended when multi-device sync, claude.ai web
-compatibility, or team sharing matters.
+compatibility, or team sharing matters. Multi-user mode is triggered by
+setting `PUBLIC_URL` (with `MCP_DCR_SERVER_SECRET` required as proof of
+intentional multi-user deployment); without it HTTP binds 127.0.0.1 and
+reuses the single-user store.
 
 ## Library docs search (Context7-parity)
 

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -323,13 +323,13 @@ def credentials_for_current_request() -> dict[str, str]:
 
 
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
-    """Save credentials from OAuth form to config.enc and apply to environment.
+    """Save credentials from OAuth form to ``config.json`` and apply to environment.
 
     ``context`` carries the per-authorize ``sub`` issued by mcp-core's local
     OAuth AS. In remote multi-user mode (``PUBLIC_URL`` set) we route the
     credentials into a per-sub bucket via :func:`store_for_sub` so concurrent
     users do not overwrite each other. In single-user mode the subject is
-    ignored and a single ``config.enc`` on the host is reused.
+    ignored and a single ``~/.wet-mcp/config.json`` on the host is reused.
 
     Called by the local OAuth AS when the user submits API keys via the
     browser form. Writes to encrypted config file, applies to env vars

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2527,7 +2527,8 @@ async def run_http_server(port: int = 0) -> None:
     """Run wet-mcp as HTTP server. Local single-user (default) or remote
     multi-user (when ``PUBLIC_URL`` env set).
 
-    Local mode binds 127.0.0.1 with a single shared ``config.enc``. Remote
+    Local mode binds 127.0.0.1 with a single shared
+    ``~/.wet-mcp/config.json`` (PerPluginStore). Remote
     multi-user mode binds 0.0.0.0:8080, requires ``MCP_DCR_SERVER_SECRET``
     as proof of intentional multi-user deployment, and scopes credentials
     per JWT ``sub`` (see ``credential_state.store_for_sub`` and the


### PR DESCRIPTION
The architecture docs drifted from the actual runtime in a few places. This corrects them against the code and a live HTTP self-host deployment.

## Storage
- `docs/ARCHITECTURE.md` storage table and mode matrix said credentials live in `~/.wet-mcp/config.enc`. The code stores them in `~/.wet-mcp/config.json` via mcp-core `PerPluginStore` (AES-GCM, machine-bound key at `~/.wet-mcp/.secret`); `config.enc` is the deprecated `config_file` path. Updated the table, the stdio mode-matrix row, and the matching docstrings in `credential_state.save_credentials` and `run_http_server`.

## Mode matrix
- The single "HTTP self-host" row conflated single-user and multi-user. Split it into single-user (shared local `config.json`, bind `127.0.0.1`, not multi-user) and multi-user (per-JWT-sub vault at `~/.wet-mcp/subs/<sub>/config.json`, bind `0.0.0.0`). Documented that multi-user is triggered by `PUBLIC_URL` plus the required `MCP_DCR_SERVER_SECRET`.

## Relay / auth (CLAUDE.md + AGENTS.md)
- `relay_setup.py` was described as "Zero-config relay: create session, poll for config". That `ensure_config` create-session/poll path has no production caller (only tests reference it). The live setup UX is the OAuth-AS browser form at `<PUBLIC_URL>/authorize`. Reworded to match.
- Replaced the `MCP_RELAY_URL` "remote-relay mode" line with the actual live HTTP auth model: `GET /mcp` without a Bearer token returns 401 + `www-authenticate` pointing at `/.well-known/oauth-protected-resource`; the browser form is gated by the single shared `MCP_RELAY_PASSWORD`; multi-user additionally needs `CREDENTIAL_SECRET` + `MCP_DCR_SERVER_SECRET`. Noted that `MCP_RELAY_URL` only feeds the legacy relay path.

No code logic changed; edits are limited to docs and docstrings.