### PR TITLE
fix: bump mcp-core to 1.18.0b5 for vertex_express support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Xem `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `server.py` -- FastMCP server (orchestrator, file lon nhat)
   - `config.py` -- Pydantic Settings (singleton)
   - `cache.py`, `db.py`, `embedder.py`, `reranker.py` -- Infrastructure
-  - `relay_setup.py` -- Zero-config relay: create session, poll for config
+  - `relay_setup.py` -- `apply_config` / `load_config_from_file` env-applier used by the OAuth setup form (live setup UX = OAuth-AS browser form at `<PUBLIC_URL>/authorize`; the `ensure_config` create-session/poll path is legacy/unused in production)
   - `relay_schema.py` -- Relay form schema (2 modes: local/cloud)
   - `sync/` -- Docs sync backends: `gdrive.py` (Google Drive, OAuth Device Code, httpx) + `s3.py` (S3/R2/B2 operator mode) + `base.py`
   - `token_store.py` -- Local token storage cho OAuth (~/.wet-mcp/tokens/)
@@ -77,7 +77,8 @@ mise run dev       # uv run wet-mcp
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`
-- Relay: `MCP_RELAY_URL` (required for remote-relay mode, no default — wet-mcp default is local-relay per matrix)
+- HTTP auth (live self-host): credentials are configured via the OAuth-AS browser form at `<PUBLIC_URL>/authorize`; `GET /mcp` without a Bearer token returns 401 + `www-authenticate` pointing at `/.well-known/oauth-protected-resource`. The browser form is gated by `MCP_RELAY_PASSWORD` (single shared password, gate only — empty disables it; not per-user). Multi-user remote mode also requires `CREDENTIAL_SECRET` (per-sub vault key) + `MCP_DCR_SERVER_SECRET` (proof of intentional multi-user deploy).
+- `MCP_RELAY_URL`: read only by the legacy `ensure_config` create-session/poll path (`relay_setup.py`), which has no production caller — the live setup UX is the OAuth-AS form above, not an ECDH relay.
 - Secrets: skret SSM namespace `/wet-mcp/prod` (region `ap-southeast-1`)
 
 ### Manual config example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Xem `AGENTS.md` va `README.md` de hieu architecture va configuration.
   - `server.py` -- FastMCP server (orchestrator, file lon nhat)
   - `config.py` -- Pydantic Settings (singleton)
   - `cache.py`, `db.py`, `embedder.py`, `reranker.py` -- Infrastructure
-  - `relay_setup.py` -- Zero-config relay: create session, poll for config
+  - `relay_setup.py` -- `apply_config` / `load_config_from_file` env-applier used by the OAuth setup form (live setup UX = OAuth-AS browser form at `<PUBLIC_URL>/authorize`; the `ensure_config` create-session/poll path is legacy/unused in production)
   - `relay_schema.py` -- Relay form schema (2 modes: local/cloud)
   - `sync/` -- Docs sync backends: `gdrive.py` (Google Drive, OAuth Device Code, httpx) + `s3.py` (S3/R2/B2 operator mode) + `base.py`
   - `token_store.py` -- Local token storage cho OAuth (~/.wet-mcp/tokens/)
@@ -77,7 +77,8 @@ mise run dev       # uv run wet-mcp
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`
-- Relay: `MCP_RELAY_URL` (required for remote-relay mode, no default — wet-mcp default is local-relay per matrix)
+- HTTP auth (live self-host): credentials are configured via the OAuth-AS browser form at `<PUBLIC_URL>/authorize`; `GET /mcp` without a Bearer token returns 401 + `www-authenticate` pointing at `/.well-known/oauth-protected-resource`. The browser form is gated by `MCP_RELAY_PASSWORD` (single shared password, gate only — empty disables it; not per-user). Multi-user remote mode also requires `CREDENTIAL_SECRET` (per-sub vault key) + `MCP_DCR_SERVER_SECRET` (proof of intentional multi-user deploy).
+- `MCP_RELAY_URL`: read only by the legacy `ensure_config` create-session/poll path (`relay_setup.py`), which has no production caller — the live setup UX is the OAuth-AS form above, not an ECDH relay.
 - Secrets: skret SSM namespace `/wet-mcp/prod` (region `ap-southeast-1`)
 
 ### Manual config example

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,7 @@ live in `src/wet_mcp/sources/_smart_chunks.py`.
 |---|---|---|
 | `~/.wet-mcp/docs.db` | Library docs index (chunks + embeddings) | SQLite WAL + sqlite-vec |
 | `~/.wet-mcp/cache.db` | Web search + extract cache (TTL gated) | SQLite WAL |
-| `~/.wet-mcp/config.enc` | Encrypted credentials (mcp-core managed) | AES-GCM, machine-bound key |
+| `~/.wet-mcp/config.json` | Encrypted credentials (mcp-core `PerPluginStore`) | AES-GCM, machine-bound key at `~/.wet-mcp/.secret` |
 | `~/.wet-mcp/downloads/` | Media download output dir | Filesystem |
 | `~/.wet-mcp/tokens/google_drive.json` | OAuth Device Code token (sync) | Filesystem 0600 perms |
 
@@ -161,12 +161,16 @@ This dispatch is shared with web-core's `selector_inference` module
 
 | Mode | Default? | Storage scope | Multi-user |
 |---|---|---|---|
-| stdio | Yes | Local user (`~/.wet-mcp/config.enc`, perm 0600) | No |
-| HTTP self-host | No | Per-JWT-sub credential vault | Yes |
+| stdio | Yes | Local user (`~/.wet-mcp/config.json`, perm 0600) | No |
+| HTTP self-host (single-user) | No | Shared local store (`~/.wet-mcp/config.json`), bind 127.0.0.1 | No |
+| HTTP self-host (multi-user) | No | Per-JWT-sub vault (`~/.wet-mcp/subs/<sub>/config.json`), bind 0.0.0.0 | Yes |
 
 The stdio default avoids OAuth complexity for single-machine personal
 use; HTTP self-host is recommended when multi-device sync, claude.ai web
-compatibility, or team sharing matters.
+compatibility, or team sharing matters. Multi-user mode is triggered by
+setting `PUBLIC_URL` (with `MCP_DCR_SERVER_SECRET` required as proof of
+intentional multi-user deployment); without it HTTP binds 127.0.0.1 and
+reuses the single-user store.
 
 ## Library docs search (Context7-parity)
 

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -323,13 +323,13 @@ def credentials_for_current_request() -> dict[str, str]:
 
 
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
-    """Save credentials from OAuth form to config.enc and apply to environment.
+    """Save credentials from OAuth form to ``config.json`` and apply to environment.
 
     ``context`` carries the per-authorize ``sub`` issued by mcp-core's local
     OAuth AS. In remote multi-user mode (``PUBLIC_URL`` set) we route the
     credentials into a per-sub bucket via :func:`store_for_sub` so concurrent
     users do not overwrite each other. In single-user mode the subject is
-    ignored and a single ``config.enc`` on the host is reused.
+    ignored and a single ``~/.wet-mcp/config.json`` on the host is reused.
 
     Called by the local OAuth AS when the user submits API keys via the
     browser form. Writes to encrypted config file, applies to env vars

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2527,7 +2527,8 @@ async def run_http_server(port: int = 0) -> None:
     """Run wet-mcp as HTTP server. Local single-user (default) or remote
     multi-user (when ``PUBLIC_URL`` env set).
 
-    Local mode binds 127.0.0.1 with a single shared ``config.enc``. Remote
+    Local mode binds 127.0.0.1 with a single shared
+    ``~/.wet-mcp/config.json`` (PerPluginStore). Remote
     multi-user mode binds 0.0.0.0:8080, requires ``MCP_DCR_SERVER_SECRET``
     as proof of intentional multi-user deployment, and scopes credentials
     per JWT ``sub`` (see ``credential_state.store_for_sub`` and the

--- a/uv.lock
+++ b/uv.lock
@@ -1813,7 +1813,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b2"
+version = "1.18.0b5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1828,9 +1828,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/ed/59f51b85af63f4986918e6d76ccd7e8bb177706aeb397629d7cc76da5bcd/n24q02m_mcp_core-1.18.0b2.tar.gz", hash = "sha256:30baf5173e460ef20f1b24ac91e6310b8d7737696be033138a4b05785cb4b5a9", size = 256688, upload-time = "2026-06-11T05:07:18.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ee/982810a18e8ed8fb72bd93d0bc4cf4cea96ac3a705879ffe90739aeee767/n24q02m_mcp_core-1.18.0b5.tar.gz", hash = "sha256:05c68523b428bc5145d32d4cb6daeb2808550691956a194b399daa66b5675368", size = 274193, upload-time = "2026-06-14T04:00:56.416Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/47/1182dda7b70180245e57d5e6316940e219faf46d6692be2d8edf8d2c603d/n24q02m_mcp_core-1.18.0b2-py3-none-any.whl", hash = "sha256:905efd3e25ceb8ab6d14132a8f6e660bde6ba324bf0363342b1a5d87f09dd242", size = 139516, upload-time = "2026-06-11T05:07:19.407Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2b/dca7a6cfea2c356e0b9165a4940e6efb1cea1a099348dcb06061d7c92153/n24q02m_mcp_core-1.18.0b5-py3-none-any.whl", hash = "sha256:6640023ed5308d837b6d6e76d1431763efe9fab99a5908051971720f4bd9d9fc", size = 150469, upload-time = "2026-06-14T04:00:57.785Z" },
 ]
 
 [package.optional-dependencies]
@@ -3115,14 +3115,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/37/cc24e33974e1439cf5ca62b0735b63026eabb768f472d8775f52d5851ed9/starlette-1.3.0.tar.gz", hash = "sha256:bb58cbb7a699da4ee4be9ed4cdfe4bc5b0390aa6dac1d1ac714ebebe8dc3c8df", size = 2702493, upload-time = "2026-06-11T06:27:41.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/42/56d31c5ee52dab0ad893d67d4f9c00f5ba2b4c5d87f392eca2c3fdce01cf/starlette-1.3.0-py3-none-any.whl", hash = "sha256:ff4ca1bc23de6a45cdfbbeb9b3caaea524c9221cdd8a6684ad7a4f651a83890b", size = 73492, upload-time = "2026-06-11T06:27:40.444Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump n24q02m-mcp-core 1.18.0b2 -> 1.18.0b5 to enable the vertex_express adapter (mcp_core/llm/vertex_express.py) so the LLM_MODELS chain primary vertex_express/gemini-3.5-flash works. Verified on staging: b2 lacks vertex_express, chat falls back to xai/grok-4.3. Lock-only change.