### PR TITLE
fix: forward container env (storage backends, model chains, secrets) in CF worker

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,26 @@ export interface Env {
     query(vector: number[], opts: { topK: number; filter?: unknown }): Promise<{ matches: unknown[] }>
   }
   WET?: { idFromName(n: string): unknown; get(id: unknown): { fetch(r: Request): Promise<Response> } }
+  // Container config (wrangler.jsonc `vars`) + secrets (`wrangler secret put`),
+  // forwarded into the container process via WetContainer.envVars.
+  MCP_STORAGE_BACKEND: string
+  MCP_KV_BASE_URL: string
+  DOCS_DB_BACKEND: string
+  MCP_D1_BASE_URL: string
+  MCP_VECTORIZE_BASE_URL: string
+  MCP_VECTORIZE_IDX: string
+  EMBEDDING_MODELS: string
+  RERANK_MODELS: string
+  LLM_MODELS: string
+  SEARCH_BACKEND: string
+  PUBLIC_URL: string
+  CREDENTIAL_SECRET: string
+  JINA_AI_API_KEY: string
+  TAVILY_API_KEY: string
+  GOOGLE_VERTEX_EXPRESS_API_KEY: string
+  XAI_API_KEY: string
+  MCP_RELAY_PASSWORD: string
+  MCP_DCR_SERVER_SECRET: string
 }
 
 export default {
@@ -85,4 +105,30 @@ function extractUserId(request: Request): string {
 export class WetContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '1h'
+  // The container reaches cloud model/search APIs (Jina, Vertex, Tavily) over the
+  // public internet; kv/d1/vectorize.internal stay intercepted by the Worker.
+  enableInternet = true
+  // Forward Worker config (vars) + secrets into the container process. Without
+  // this the Python server defaults to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite
+  // on the ephemeral container FS and downloads local ONNX models.
+  envVars = {
+    MCP_STORAGE_BACKEND: this.env.MCP_STORAGE_BACKEND,
+    MCP_KV_BASE_URL: this.env.MCP_KV_BASE_URL,
+    DOCS_DB_BACKEND: this.env.DOCS_DB_BACKEND,
+    MCP_D1_BASE_URL: this.env.MCP_D1_BASE_URL,
+    MCP_VECTORIZE_BASE_URL: this.env.MCP_VECTORIZE_BASE_URL,
+    MCP_VECTORIZE_IDX: this.env.MCP_VECTORIZE_IDX,
+    EMBEDDING_MODELS: this.env.EMBEDDING_MODELS,
+    RERANK_MODELS: this.env.RERANK_MODELS,
+    LLM_MODELS: this.env.LLM_MODELS,
+    SEARCH_BACKEND: this.env.SEARCH_BACKEND,
+    PUBLIC_URL: this.env.PUBLIC_URL,
+    CREDENTIAL_SECRET: this.env.CREDENTIAL_SECRET,
+    JINA_AI_API_KEY: this.env.JINA_AI_API_KEY,
+    TAVILY_API_KEY: this.env.TAVILY_API_KEY,
+    GOOGLE_VERTEX_EXPRESS_API_KEY: this.env.GOOGLE_VERTEX_EXPRESS_API_KEY,
+    XAI_API_KEY: this.env.XAI_API_KEY,
+    MCP_RELAY_PASSWORD: this.env.MCP_RELAY_PASSWORD,
+    MCP_DCR_SERVER_SECRET: this.env.MCP_DCR_SERVER_SECRET,
+  }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,14 +24,39 @@ export interface Env {
   RERANK_MODELS: string
   LLM_MODELS: string
   SEARCH_BACKEND: string
+  WET_AUTO_SEARXNG: string
   PUBLIC_URL: string
   CREDENTIAL_SECRET: string
   JINA_AI_API_KEY: string
-  TAVILY_API_KEY: string
   GOOGLE_VERTEX_EXPRESS_API_KEY: string
   XAI_API_KEY: string
   MCP_RELAY_PASSWORD: string
   MCP_DCR_SERVER_SECRET: string
+  // search secrets — exactly one set depending on SEARCH_BACKEND
+  SEARXNG_URL?: string
+  TAVILY_API_KEY?: string
+}
+
+// Keys forwarded from the Worker env (wrangler vars + secrets) into the container
+// process. Unset/empty values are dropped so an unused optional secret (tavily vs
+// searxng) never injects a blank.
+const CONTAINER_ENV_KEYS = [
+  'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'DOCS_DB_BACKEND',
+  'MCP_D1_BASE_URL', 'MCP_VECTORIZE_BASE_URL', 'MCP_VECTORIZE_IDX',
+  'EMBEDDING_MODELS', 'RERANK_MODELS', 'LLM_MODELS',
+  'SEARCH_BACKEND', 'WET_AUTO_SEARXNG', 'SEARXNG_URL', 'TAVILY_API_KEY',
+  'PUBLIC_URL', 'CREDENTIAL_SECRET', 'JINA_AI_API_KEY',
+  'GOOGLE_VERTEX_EXPRESS_API_KEY', 'XAI_API_KEY',
+  'MCP_RELAY_PASSWORD', 'MCP_DCR_SERVER_SECRET',
+] as const
+
+function pickContainerEnv(env: Env): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of CONTAINER_ENV_KEYS) {
+    const v = (env as unknown as Record<string, unknown>)[k]
+    if (typeof v === 'string' && v !== '') out[k] = v
+  }
+  return out
 }
 
 export default {
@@ -111,24 +136,5 @@ export class WetContainer extends Container<Env> {
   // Forward Worker config (vars) + secrets into the container process. Without
   // this the Python server defaults to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite
   // on the ephemeral container FS and downloads local ONNX models.
-  envVars = {
-    MCP_STORAGE_BACKEND: this.env.MCP_STORAGE_BACKEND,
-    MCP_KV_BASE_URL: this.env.MCP_KV_BASE_URL,
-    DOCS_DB_BACKEND: this.env.DOCS_DB_BACKEND,
-    MCP_D1_BASE_URL: this.env.MCP_D1_BASE_URL,
-    MCP_VECTORIZE_BASE_URL: this.env.MCP_VECTORIZE_BASE_URL,
-    MCP_VECTORIZE_IDX: this.env.MCP_VECTORIZE_IDX,
-    EMBEDDING_MODELS: this.env.EMBEDDING_MODELS,
-    RERANK_MODELS: this.env.RERANK_MODELS,
-    LLM_MODELS: this.env.LLM_MODELS,
-    SEARCH_BACKEND: this.env.SEARCH_BACKEND,
-    PUBLIC_URL: this.env.PUBLIC_URL,
-    CREDENTIAL_SECRET: this.env.CREDENTIAL_SECRET,
-    JINA_AI_API_KEY: this.env.JINA_AI_API_KEY,
-    TAVILY_API_KEY: this.env.TAVILY_API_KEY,
-    GOOGLE_VERTEX_EXPRESS_API_KEY: this.env.GOOGLE_VERTEX_EXPRESS_API_KEY,
-    XAI_API_KEY: this.env.XAI_API_KEY,
-    MCP_RELAY_PASSWORD: this.env.MCP_RELAY_PASSWORD,
-    MCP_DCR_SERVER_SECRET: this.env.MCP_DCR_SERVER_SECRET,
-  }
+  envVars = pickContainerEnv(this.env)
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,9 @@
     {
       "name": "wet-mcp-worker",
       "class_name": "WetContainer",
-      "image": "ghcr.io/n24q02m/wet-mcp:latest",
+      // :beta carries the CF worker code + mcp-core 1.18.0b5 (vertex_express).
+      // Switch to :latest once a stable release ships the Cloudflare backends.
+      "image": "ghcr.io/n24q02m/wet-mcp:beta",
       "instance_type": "standard-1",
       "max_instances": 100
     }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,7 +39,8 @@
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
     "LLM_MODELS": "vertex_express/gemini-3.5-flash,xai/grok-4.3",
-    "SEARCH_BACKEND": "tavily"
+    "SEARCH_BACKEND": "searxng",
+    "WET_AUTO_SEARXNG": "false"
   },
   "env": {
     "production": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,7 +23,22 @@
     { "binding": "D1", "database_name": "wet-docs", "database_id": "<wet-d1-database-id>", "migrations_dir": "migrations" }
   ],
   "vectorize": [{ "binding": "VECTORIZE", "index_name": "wet-docs-vectors" }],
-  "vars": { "PUBLIC_URL": "https://wet.n24q02m.com" },
+  // Non-secret container config (forwarded into the container by WetContainer.envVars).
+  // Secrets (CREDENTIAL_SECRET, JINA_AI_API_KEY, TAVILY_API_KEY, GOOGLE_VERTEX_EXPRESS_API_KEY,
+  // XAI_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET) come from `wrangler secret put`.
+  "vars": {
+    "PUBLIC_URL": "https://wet.n24q02m.com",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal",
+    "DOCS_DB_BACKEND": "cf-d1",
+    "MCP_D1_BASE_URL": "http://d1.internal",
+    "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
+    "MCP_VECTORIZE_IDX": "wet-docs-vectors",
+    "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+    "RERANK_MODELS": "jina_ai/jina-reranker-v3",
+    "LLM_MODELS": "vertex_express/gemini-3.5-flash,xai/grok-4.3",
+    "SEARCH_BACKEND": "tavily"
+  },
   "env": {
     "production": {
       "routes": [{ "pattern": "wet.n24q02m.com", "custom_domain": true }]


### PR DESCRIPTION
WetContainer did not forward any env into the container process, so a CF deploy would silently fall back to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite on the ephemeral container FS and download local ONNX models. Add WetContainer.envVars forwarding (storage backend selectors + internal URLs + cloud model chains + PUBLIC_URL + secrets) and enableInternet=true (container reaches Jina/Vertex/Tavily). Non-secret config moved to wrangler.jsonc vars; secrets via wrangler secret put. tsc + vitest + cf dry-run green.