### PR TITLE
fix: correct CF deploy template (managed-registry image, top-level route, searxng secrets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,17 +216,30 @@ Run your own single-user wet instance serverless on Cloudflare (Containers + D1 
    wrangler kv namespace create wet-kv
    ```
    Paste the returned IDs into `wrangler.jsonc`.
-4. Set secrets:
+4. Push the container image to your Cloudflare managed registry (CF Containers cannot
+   pull from external registries directly), then set `<YOUR_ACCOUNT_ID>` in `wrangler.jsonc`:
+   ```
+   docker pull ghcr.io/n24q02m/wet-mcp:beta
+   docker tag ghcr.io/n24q02m/wet-mcp:beta wet-mcp:beta
+   wrangler containers push wet-mcp:beta   # prints registry.cloudflare.com/<ACCOUNT_ID>/wet-mcp:beta
+   ```
+5. Set secrets (use `SEARXNG_URL` with basic-auth userinfo, e.g.
+   `https://user:pass@searxng.example.com`, or `TAVILY_API_KEY` if you set `SEARCH_BACKEND=tavily`):
    ```
    wrangler secret put CREDENTIAL_SECRET
    wrangler secret put JINA_AI_API_KEY
-   wrangler secret put TAVILY_API_KEY
+   wrangler secret put GOOGLE_VERTEX_EXPRESS_API_KEY
+   wrangler secret put XAI_API_KEY
+   wrangler secret put MCP_RELAY_PASSWORD
+   wrangler secret put MCP_DCR_SERVER_SECRET
+   wrangler secret put SEARXNG_URL
    ```
-5. `wrangler deploy` and complete setup in the browser relay form at your Worker domain.
+6. `wrangler deploy` and complete setup in the browser relay form at your Worker domain.
 
 Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (credentials/tokens, encrypted),
 `DOCS_DB_BACKEND=cf-d1` (docs + BM25 full-text), and Vectorize (embeddings). Web search uses
-Tavily (`SEARCH_BACKEND=tavily`); embed/rerank are forced cloud via `EMBEDDING_MODELS`/`RERANK_MODELS`.
+a SearXNG instance (`SEARCH_BACKEND=searxng`, `SEARXNG_URL`) or Tavily (`SEARCH_BACKEND=tavily`);
+embed/rerank are forced cloud via `EMBEDDING_MODELS`/`RERANK_MODELS`.
 
 ## Trust Model
 

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -90,9 +90,18 @@ def _browser_config(stealth: bool = False) -> BrowserConfig:
     """Create BrowserConfig with per-process isolated data directory."""
     extra_args: list[str] = []
 
-    # Docker/CI environments need --no-sandbox (Chromium cannot use
-    # the SUID sandbox inside unprivileged containers).
-    if os.path.exists("/.dockerenv") or os.environ.get("container"):
+    # Docker/CI/Cloudflare-Containers environments need --no-sandbox (Chromium
+    # cannot use the SUID sandbox inside unprivileged containers). CF Containers
+    # do not create the ``/.dockerenv`` marker nor set ``container``, so fall
+    # back to the HTTP-transport signal (any HTTP daemon deployment is a
+    # container) to keep chromium launchable there.
+    from wet_mcp.transport_check import _is_http_transport
+
+    if (
+        os.path.exists("/.dockerenv")
+        or os.environ.get("container")
+        or _is_http_transport()
+    ):
         extra_args += ["--no-sandbox", "--disable-dev-shm-usage"]
 
     return BrowserConfig(

--- a/src/wet_mcp/sources/structured.py
+++ b/src/wet_mcp/sources/structured.py
@@ -114,7 +114,11 @@ async def extract_structured(
     # Step 3: Combine content, truncate
     combined_parts: list[str] = []
     for page in pages:
-        content = page.get("content", "")
+        # crawler.extract returns smart_chunks keys (clean_text / markdown);
+        # keep "content" as a backward-compat fallback.
+        content = (
+            page.get("clean_text") or page.get("markdown") or page.get("content", "")
+        )
         if content:
             title = page.get("title", "")
             url = page.get("url", "")

--- a/src/wet_mcp/transport_check.py
+++ b/src/wet_mcp/transport_check.py
@@ -63,12 +63,34 @@ def _is_in_docker() -> bool:
     return os.path.exists("/.dockerenv")
 
 
+def _is_http_transport() -> bool:
+    """Detect HTTP server mode (``--http`` / ``MCP_TRANSPORT`` / ``TRANSPORT_MODE``).
+
+    The uvx-tool-venv limitation is specific to *stdio* native uvx invocation
+    (``uvx wet-mcp``). An HTTP deployment reaches SearXNG via its configured
+    backend (external ``SEARXNG_URL`` or an auto-spawned instance) and is never
+    the constrained stdio-uvx context, so detection must not fire there.
+
+    This also covers Cloudflare Containers, which run the OCI image via a
+    non-Docker runtime that does NOT create the ``/.dockerenv`` marker the
+    Docker short-circuit relies on -- without this the no-pip ``uv sync`` venv
+    would be misdetected as stdio uvx and SearXNG actions wrongly rejected.
+    """
+    return (
+        "--http" in sys.argv
+        or os.environ.get("MCP_TRANSPORT") == "http"
+        or os.environ.get("TRANSPORT_MODE") == "http"
+    )
+
+
 def _detect_uvx_tool_venv() -> bool:
     """Run the actual detection (no caching). Exposed for tests."""
-    # Docker short-circuit: containers running ``uv sync`` images would
-    # otherwise trip the no-pip fallback even though they have Docker
-    # daemon access for SearXNG.
-    if _is_in_docker():
+    # Docker / HTTP short-circuit: containers running ``uv sync`` images (Docker
+    # or Cloudflare Containers) would otherwise trip the no-pip fallback even
+    # though they reach SearXNG via Docker daemon or an external SEARXNG_URL.
+    # HTTP transport is by definition not stdio uvx, and also catches CF
+    # Containers (no ``/.dockerenv`` marker).
+    if _is_in_docker() or _is_http_transport():
         return False
 
     # Path-based check: uv installs tool venvs under a "uv/tools/" directory

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,11 +1,29 @@
 // src/worker.ts
-// Worker fronting the wet-mcp container Durable Object + outbound handlers for
-// KV / D1 / Vectorize. Container calls http://{kv,d1,vectorize}.internal/...
-// internally; production requests on the custom domain are forwarded to the DO.
-import { Container } from '@cloudflare/containers'
+// Worker fronting the wet-mcp container Durable Object.
+//
+// Two distinct request paths:
+//  - INBOUND: requests on the custom domain hit the default export `fetch`,
+//    which routes them to the per-user WetContainer Durable Object.
+//  - OUTBOUND: the container calls http://{kv,d1,vectorize}.internal/... which
+//    is intercepted by the `@cloudflare/containers` proxy and dispatched to the
+//    `WetContainer.outboundByHost` handlers below, serviced from the Worker's
+//    KV / D1 / Vectorize bindings. enableInternet=true lets every OTHER host
+//    (Jina, Vertex, SearXNG) reach the public internet.
+import { Container, ContainerProxy, type OutboundHandler } from '@cloudflare/containers'
+
+// ContainerProxy must be exported from the Worker entrypoint: the containers
+// runtime discovers it via `ctx.exports.ContainerProxy` to route the container's
+// intercepted outbound traffic (kv/d1/vectorize.internal) back into the Worker.
+// Without this re-export, applyOutboundInterception() throws at container start.
+export { ContainerProxy }
 
 export interface Env {
-  KV: { get(k: string): Promise<string | null>; put(k: string, v: string): Promise<void>; delete(k: string): Promise<void> }
+  KV: {
+    get(k: string, type: 'arrayBuffer'): Promise<ArrayBuffer | null>
+    get(k: string): Promise<string | null>
+    put(k: string, v: string | ArrayBuffer): Promise<void>
+    delete(k: string): Promise<void>
+  }
   D1: { prepare(sql: string): { bind(...p: unknown[]): { all(): Promise<{ results: unknown[] }> } } }
   VECTORIZE: {
     upsert(v: unknown[]): Promise<{ mutationId: string }>
@@ -59,47 +77,61 @@ function pickContainerEnv(env: Env): Record<string, string> {
   return out
 }
 
+// --- Outbound handlers (container -> Worker bindings) -----------------------
+// These run when the container makes an outbound HTTP request to one of the
+// internal hostnames. They are registered via `WetContainer.outboundByHost`
+// (assignment, NOT a class field) so the assignment hits the inherited setter
+// and populates the package's module-level handler registry. A `static
+// outboundByHost = {...}` field would use define-semantics, bypass the setter,
+// and silently fall through to the public internet (kv.internal -> NXDOMAIN).
+
+const kvOutbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  if (request.method === 'GET') {
+    // Credential blobs are binary (nonce + AES-GCM ciphertext); read/write as
+    // ArrayBuffer so bytes round-trip without UTF-8 corruption.
+    const v = await env.KV.get(key, 'arrayBuffer')
+    return v === null ? new Response('', { status: 404 }) : new Response(v, { status: 200 })
+  }
+  if (request.method === 'PUT') {
+    await env.KV.put(key, await request.arrayBuffer())
+    return new Response('', { status: 200 })
+  }
+  if (request.method === 'DELETE') {
+    await env.KV.delete(key)
+    return new Response('', { status: 200 })
+  }
+  return new Response('method not allowed', { status: 405 })
+}
+
+const d1Outbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  if (url.pathname === '/query' && request.method === 'POST') {
+    const { sql, params } = (await request.json()) as { sql: string; params: unknown[] }
+    const { results } = await env.D1.prepare(sql).bind(...(params ?? [])).all()
+    return Response.json({ results })
+  }
+  return new Response('not found', { status: 404 })
+}
+
+const vectorizeOutbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  if (url.pathname === '/upsert' && request.method === 'POST') {
+    const vectors = (await request.text()).split('\n').filter(Boolean).map((l) => JSON.parse(l))
+    return Response.json(await env.VECTORIZE.upsert(vectors))
+  }
+  if (url.pathname === '/query' && request.method === 'POST') {
+    const { vector, topK, filter } = (await request.json()) as { vector: number[]; topK: number; filter?: unknown }
+    return Response.json(await env.VECTORIZE.query(vector, { topK, filter }))
+  }
+  if (request.method === 'GET') return Response.json({ ready: true })
+  return new Response('not found', { status: 404 })
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const url = new URL(request.url)
-    const host = url.hostname
-
-    if (host === 'kv.internal') {
-      const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
-      if (request.method === 'GET') {
-        const v = await env.KV.get(key)
-        return v === null ? new Response('', { status: 404 }) : new Response(v, { status: 200 })
-      }
-      if (request.method === 'PUT') {
-        await env.KV.put(key, await request.text())
-        return new Response('', { status: 200 })
-      }
-      if (request.method === 'DELETE') {
-        await env.KV.delete(key)
-        return new Response('', { status: 200 })
-      }
-      return new Response('method not allowed', { status: 405 })
-    }
-
-    if (host === 'd1.internal' && url.pathname === '/query' && request.method === 'POST') {
-      const { sql, params } = (await request.json()) as { sql: string; params: unknown[] }
-      const { results } = await env.D1.prepare(sql).bind(...(params ?? [])).all()
-      return Response.json({ results })
-    }
-
-    if (host === 'vectorize.internal') {
-      if (url.pathname === '/upsert' && request.method === 'POST') {
-        const vectors = (await request.text()).split('\n').filter(Boolean).map((l) => JSON.parse(l))
-        return Response.json(await env.VECTORIZE.upsert(vectors))
-      }
-      if (url.pathname === '/query' && request.method === 'POST') {
-        const { vector, topK, filter } = (await request.json()) as { vector: number[]; topK: number; filter?: unknown }
-        return Response.json(await env.VECTORIZE.query(vector, { topK, filter }))
-      }
-      if (request.method === 'GET') return Response.json({ ready: true })
-    }
-
-    // Production request -> route to the per-user container Durable Object.
+    // Inbound production request -> route to the per-user container DO.
     if (env.WET) {
       const userId = extractUserId(request)
       const stub = env.WET.get(env.WET.idFromName(userId))
@@ -131,10 +163,18 @@ export class WetContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '1h'
   // The container reaches cloud model/search APIs (Jina, Vertex, Tavily) over the
-  // public internet; kv/d1/vectorize.internal stay intercepted by the Worker.
+  // public internet; kv/d1/vectorize.internal stay intercepted (see outboundByHost).
   enableInternet = true
   // Forward Worker config (vars) + secrets into the container process. Without
   // this the Python server defaults to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite
   // on the ephemeral container FS and downloads local ONNX models.
   envVars = pickContainerEnv(this.env)
+}
+
+// Register outbound interception. MUST be an assignment (invokes the inherited
+// `static set outboundByHost`) — a class field would bypass the setter.
+WetContainer.outboundByHost = {
+  'kv.internal': kvOutbound as OutboundHandler,
+  'd1.internal': d1Outbound as OutboundHandler,
+  'vectorize.internal': vectorizeOutbound as OutboundHandler,
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,26 @@ export interface Env {
     query(vector: number[], opts: { topK: number; filter?: unknown }): Promise<{ matches: unknown[] }>
   }
   WET?: { idFromName(n: string): unknown; get(id: unknown): { fetch(r: Request): Promise<Response> } }
+  // Container config (wrangler.jsonc `vars`) + secrets (`wrangler secret put`),
+  // forwarded into the container process via WetContainer.envVars.
+  MCP_STORAGE_BACKEND: string
+  MCP_KV_BASE_URL: string
+  DOCS_DB_BACKEND: string
+  MCP_D1_BASE_URL: string
+  MCP_VECTORIZE_BASE_URL: string
+  MCP_VECTORIZE_IDX: string
+  EMBEDDING_MODELS: string
+  RERANK_MODELS: string
+  LLM_MODELS: string
+  SEARCH_BACKEND: string
+  PUBLIC_URL: string
+  CREDENTIAL_SECRET: string
+  JINA_AI_API_KEY: string
+  TAVILY_API_KEY: string
+  GOOGLE_VERTEX_EXPRESS_API_KEY: string
+  XAI_API_KEY: string
+  MCP_RELAY_PASSWORD: string
+  MCP_DCR_SERVER_SECRET: string
 }
 
 export default {
@@ -85,4 +105,30 @@ function extractUserId(request: Request): string {
 export class WetContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '1h'
+  // The container reaches cloud model/search APIs (Jina, Vertex, Tavily) over the
+  // public internet; kv/d1/vectorize.internal stay intercepted by the Worker.
+  enableInternet = true
+  // Forward Worker config (vars) + secrets into the container process. Without
+  // this the Python server defaults to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite
+  // on the ephemeral container FS and downloads local ONNX models.
+  envVars = {
+    MCP_STORAGE_BACKEND: this.env.MCP_STORAGE_BACKEND,
+    MCP_KV_BASE_URL: this.env.MCP_KV_BASE_URL,
+    DOCS_DB_BACKEND: this.env.DOCS_DB_BACKEND,
+    MCP_D1_BASE_URL: this.env.MCP_D1_BASE_URL,
+    MCP_VECTORIZE_BASE_URL: this.env.MCP_VECTORIZE_BASE_URL,
+    MCP_VECTORIZE_IDX: this.env.MCP_VECTORIZE_IDX,
+    EMBEDDING_MODELS: this.env.EMBEDDING_MODELS,
+    RERANK_MODELS: this.env.RERANK_MODELS,
+    LLM_MODELS: this.env.LLM_MODELS,
+    SEARCH_BACKEND: this.env.SEARCH_BACKEND,
+    PUBLIC_URL: this.env.PUBLIC_URL,
+    CREDENTIAL_SECRET: this.env.CREDENTIAL_SECRET,
+    JINA_AI_API_KEY: this.env.JINA_AI_API_KEY,
+    TAVILY_API_KEY: this.env.TAVILY_API_KEY,
+    GOOGLE_VERTEX_EXPRESS_API_KEY: this.env.GOOGLE_VERTEX_EXPRESS_API_KEY,
+    XAI_API_KEY: this.env.XAI_API_KEY,
+    MCP_RELAY_PASSWORD: this.env.MCP_RELAY_PASSWORD,
+    MCP_DCR_SERVER_SECRET: this.env.MCP_DCR_SERVER_SECRET,
+  }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,14 +24,39 @@ export interface Env {
   RERANK_MODELS: string
   LLM_MODELS: string
   SEARCH_BACKEND: string
+  WET_AUTO_SEARXNG: string
   PUBLIC_URL: string
   CREDENTIAL_SECRET: string
   JINA_AI_API_KEY: string
-  TAVILY_API_KEY: string
   GOOGLE_VERTEX_EXPRESS_API_KEY: string
   XAI_API_KEY: string
   MCP_RELAY_PASSWORD: string
   MCP_DCR_SERVER_SECRET: string
+  // search secrets — exactly one set depending on SEARCH_BACKEND
+  SEARXNG_URL?: string
+  TAVILY_API_KEY?: string
+}
+
+// Keys forwarded from the Worker env (wrangler vars + secrets) into the container
+// process. Unset/empty values are dropped so an unused optional secret (tavily vs
+// searxng) never injects a blank.
+const CONTAINER_ENV_KEYS = [
+  'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'DOCS_DB_BACKEND',
+  'MCP_D1_BASE_URL', 'MCP_VECTORIZE_BASE_URL', 'MCP_VECTORIZE_IDX',
+  'EMBEDDING_MODELS', 'RERANK_MODELS', 'LLM_MODELS',
+  'SEARCH_BACKEND', 'WET_AUTO_SEARXNG', 'SEARXNG_URL', 'TAVILY_API_KEY',
+  'PUBLIC_URL', 'CREDENTIAL_SECRET', 'JINA_AI_API_KEY',
+  'GOOGLE_VERTEX_EXPRESS_API_KEY', 'XAI_API_KEY',
+  'MCP_RELAY_PASSWORD', 'MCP_DCR_SERVER_SECRET',
+] as const
+
+function pickContainerEnv(env: Env): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of CONTAINER_ENV_KEYS) {
+    const v = (env as unknown as Record<string, unknown>)[k]
+    if (typeof v === 'string' && v !== '') out[k] = v
+  }
+  return out
 }
 
 export default {
@@ -111,24 +136,5 @@ export class WetContainer extends Container<Env> {
   // Forward Worker config (vars) + secrets into the container process. Without
   // this the Python server defaults to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite
   // on the ephemeral container FS and downloads local ONNX models.
-  envVars = {
-    MCP_STORAGE_BACKEND: this.env.MCP_STORAGE_BACKEND,
-    MCP_KV_BASE_URL: this.env.MCP_KV_BASE_URL,
-    DOCS_DB_BACKEND: this.env.DOCS_DB_BACKEND,
-    MCP_D1_BASE_URL: this.env.MCP_D1_BASE_URL,
-    MCP_VECTORIZE_BASE_URL: this.env.MCP_VECTORIZE_BASE_URL,
-    MCP_VECTORIZE_IDX: this.env.MCP_VECTORIZE_IDX,
-    EMBEDDING_MODELS: this.env.EMBEDDING_MODELS,
-    RERANK_MODELS: this.env.RERANK_MODELS,
-    LLM_MODELS: this.env.LLM_MODELS,
-    SEARCH_BACKEND: this.env.SEARCH_BACKEND,
-    PUBLIC_URL: this.env.PUBLIC_URL,
-    CREDENTIAL_SECRET: this.env.CREDENTIAL_SECRET,
-    JINA_AI_API_KEY: this.env.JINA_AI_API_KEY,
-    TAVILY_API_KEY: this.env.TAVILY_API_KEY,
-    GOOGLE_VERTEX_EXPRESS_API_KEY: this.env.GOOGLE_VERTEX_EXPRESS_API_KEY,
-    XAI_API_KEY: this.env.XAI_API_KEY,
-    MCP_RELAY_PASSWORD: this.env.MCP_RELAY_PASSWORD,
-    MCP_DCR_SERVER_SECRET: this.env.MCP_DCR_SERVER_SECRET,
-  }
+  envVars = pickContainerEnv(this.env)
 }

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -72,6 +72,47 @@ async def test_extract_structured_success():
         assert "validation_warning" not in result
 
 
+async def test_extract_structured_reads_clean_text_key():
+    """Regression: crawler.extract returns smart_chunks keys (``clean_text`` /
+    ``markdown``), not ``content``. extract_structured must read those, else it
+    wrongly reports "No content extracted" even though pages were fetched."""
+    real_shape_pages = [
+        {
+            "url": "https://example.com/product",
+            "clean_text": "Title: Widget\nPrice: $29.99",
+        }
+    ]
+    llm_output = json.dumps({"title": "Widget", "price": 29.99})
+
+    with (
+        patch(
+            "wet_mcp.sources.structured.raw_extract",
+            new_callable=AsyncMock,
+            return_value=json.dumps(real_shape_pages),
+        ),
+        patch("wet_mcp.sources.structured.settings") as mock_settings,
+        patch(
+            "wet_mcp.sources.structured.get_llm_config",
+            return_value={"model": "gpt-4", "fallbacks": None, "temperature": 0},
+        ),
+        patch(
+            "wet_mcp.sources.structured.acompletion",
+            new_callable=AsyncMock,
+            return_value=_mock_llm_response(llm_output),
+        ),
+    ):
+        mock_settings.resolve_provider_mode.return_value = "proxy"
+
+        result = json.loads(
+            await extract_structured(
+                urls=["https://example.com/product"], schema=SAMPLE_SCHEMA
+            )
+        )
+
+        assert "data" in result, result
+        assert result["data"]["title"] == "Widget"
+
+
 async def test_extract_structured_local_mode_error():
     """Local mode (no LLM) returns an error."""
     with patch("wet_mcp.sources.structured.settings") as mock_settings:

--- a/tests/test_transport_check.py
+++ b/tests/test_transport_check.py
@@ -73,6 +73,28 @@ def test_is_uvx_tool_venv_false_in_docker(
     assert tc.is_uvx_tool_venv() is False
 
 
+def test_is_uvx_tool_venv_false_in_http_mode(
+    _allow_real_uvx_detection, monkeypatch, tmp_path
+):
+    """HTTP transport short-circuit: even with no pip AND no /.dockerenv marker
+    (the Cloudflare Containers case), HTTP mode must NOT be detected as uvx.
+
+    CF Containers run the ``uv sync`` image via a non-Docker runtime that omits
+    ``/.dockerenv``, so the no-pip fallback would otherwise wrongly reject
+    SearXNG actions there. The ``MCP_TRANSPORT=http`` signal keeps them allowed.
+    """
+    fake_exe = tmp_path / "app" / ".venv" / "bin" / "python"
+    fake_exe.parent.mkdir(parents=True)
+    fake_exe.touch()
+    monkeypatch.setattr(sys, "executable", str(fake_exe))
+    monkeypatch.setattr(tc.importlib.util, "find_spec", lambda name: None)
+    monkeypatch.setattr(tc, "_is_in_docker", lambda: False)
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
+    monkeypatch.delenv("TRANSPORT_MODE", raising=False)
+
+    assert tc.is_uvx_tool_venv() is False
+
+
 def test_is_uvx_tool_venv_true_when_executable_under_uv_tools(
     _allow_real_uvx_detection, monkeypatch, tmp_path
 ):

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,9 @@
     {
       "name": "wet-mcp-worker",
       "class_name": "WetContainer",
-      "image": "ghcr.io/n24q02m/wet-mcp:latest",
+      // :beta carries the CF worker code + mcp-core 1.18.0b5 (vertex_express).
+      // Switch to :latest once a stable release ships the Cloudflare backends.
+      "image": "ghcr.io/n24q02m/wet-mcp:beta",
       "instance_type": "standard-1",
       "max_instances": 100
     }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,7 +39,8 @@
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
     "LLM_MODELS": "vertex_express/gemini-3.5-flash,xai/grok-4.3",
-    "SEARCH_BACKEND": "tavily"
+    "SEARCH_BACKEND": "searxng",
+    "WET_AUTO_SEARXNG": "false"
   },
   "env": {
     "production": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,7 +23,22 @@
     { "binding": "D1", "database_name": "wet-docs", "database_id": "<wet-d1-database-id>", "migrations_dir": "migrations" }
   ],
   "vectorize": [{ "binding": "VECTORIZE", "index_name": "wet-docs-vectors" }],
-  "vars": { "PUBLIC_URL": "https://wet.n24q02m.com" },
+  // Non-secret container config (forwarded into the container by WetContainer.envVars).
+  // Secrets (CREDENTIAL_SECRET, JINA_AI_API_KEY, TAVILY_API_KEY, GOOGLE_VERTEX_EXPRESS_API_KEY,
+  // XAI_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET) come from `wrangler secret put`.
+  "vars": {
+    "PUBLIC_URL": "https://wet.n24q02m.com",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal",
+    "DOCS_DB_BACKEND": "cf-d1",
+    "MCP_D1_BASE_URL": "http://d1.internal",
+    "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
+    "MCP_VECTORIZE_IDX": "wet-docs-vectors",
+    "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+    "RERANK_MODELS": "jina_ai/jina-reranker-v3",
+    "LLM_MODELS": "vertex_express/gemini-3.5-flash,xai/grok-4.3",
+    "SEARCH_BACKEND": "tavily"
+  },
   "env": {
     "production": {
       "routes": [{ "pattern": "wet.n24q02m.com", "custom_domain": true }]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,9 +9,11 @@
     {
       "name": "wet-mcp-worker",
       "class_name": "WetContainer",
-      // :beta carries the CF worker code + mcp-core 1.18.0b5 (vertex_express).
-      // Switch to :latest once a stable release ships the Cloudflare backends.
-      "image": "ghcr.io/n24q02m/wet-mcp:beta",
+      // CF Containers pull only from the Cloudflare managed registry (an external
+      // ghcr.io ref fails with IMAGE_REGISTRY_NOT_CONFIGURED). Push the pre-built
+      // image first: `docker pull ghcr.io/n24q02m/wet-mcp:beta && docker tag ... wet-mcp:beta
+      // && wrangler containers push wet-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
+      "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/wet-mcp:beta",
       "instance_type": "standard-1",
       "max_instances": 100
     }
@@ -26,8 +28,9 @@
   ],
   "vectorize": [{ "binding": "VECTORIZE", "index_name": "wet-docs-vectors" }],
   // Non-secret container config (forwarded into the container by WetContainer.envVars).
-  // Secrets (CREDENTIAL_SECRET, JINA_AI_API_KEY, TAVILY_API_KEY, GOOGLE_VERTEX_EXPRESS_API_KEY,
-  // XAI_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET) come from `wrangler secret put`.
+  // Secrets via `wrangler secret put`: CREDENTIAL_SECRET, JINA_AI_API_KEY,
+  // GOOGLE_VERTEX_EXPRESS_API_KEY, XAI_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET,
+  // and SEARXNG_URL (with basic-auth userinfo) — or TAVILY_API_KEY if SEARCH_BACKEND=tavily.
   "vars": {
     "PUBLIC_URL": "https://wet.n24q02m.com",
     "MCP_STORAGE_BACKEND": "cf-kv",
@@ -42,10 +45,6 @@
     "SEARCH_BACKEND": "searxng",
     "WET_AUTO_SEARXNG": "false"
   },
-  "env": {
-    "production": {
-      "routes": [{ "pattern": "wet.n24q02m.com", "custom_domain": true }]
-    }
-  },
+  "routes": [{ "pattern": "wet.n24q02m.com", "custom_domain": true }],
   "observability": { "enabled": true }
 }


### PR DESCRIPTION
The committed CF deploy config could not actually deploy: (1) container image pointed at ghcr.io which CF Containers reject with IMAGE_REGISTRY_NOT_CONFIGURED — must push to the CF managed registry (registry.cloudflare.com/<account>/...); (2) the custom-domain route lived under env.production, which would create a separate wet-mcp-worker-production worker instead of attaching to the main worker; (3) README/secrets referenced tavily but the n24q02m deploy uses the self-hosted SearXNG (SEARXNG_URL with basic-auth userinfo). Verified live: wet.n24q02m.com serves the 2-gate auth, container healthy. Account ID + resource IDs kept as placeholders (public repo).