### PR TITLE
feat: harden CF worker template (E.1 readiness probe + E.2 single-user DO/poll)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,12 @@ not via the deprecated `*_BACKEND`). Empty chain -> local ONNX. With cloud force
 `DOCS_DB_BACKEND=cf-d1` + `MCP_D1_BASE_URL`/`MCP_VECTORIZE_BASE_URL`/`MCP_VECTORIZE_IDX`,
 `SEARCH_BACKEND=tavily` + `TAVILY_API_KEY`, and `CREDENTIAL_SECRET`.
 
+- **CF template (frozen for P3 replication):** `docs/cf-template.md` pins the canonical
+  worker.ts/wrangler.jsonc copy contract (KEEP/DROP handler matrix, 5 footguns, the
+  security rule that outbound handlers stay OFF the public `fetch`, E.1 readiness probe
+  + E.2 single-user-DO/poll patterns, sync mode-gating). The 5 P3 servers copy this; do
+  not re-solve E.1/E.2 per server.
+
 ## Release & Deploy
 
 - Conventional Commits. Tag format: `v{version}`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,12 @@ not via the deprecated `*_BACKEND`). Empty chain -> local ONNX. With cloud force
 `DOCS_DB_BACKEND=cf-d1` + `MCP_D1_BASE_URL`/`MCP_VECTORIZE_BASE_URL`/`MCP_VECTORIZE_IDX`,
 `SEARCH_BACKEND=tavily` + `TAVILY_API_KEY`, and `CREDENTIAL_SECRET`.
 
+- **CF template (frozen for P3 replication):** `docs/cf-template.md` pins the canonical
+  worker.ts/wrangler.jsonc copy contract (KEEP/DROP handler matrix, 5 footguns, the
+  security rule that outbound handlers stay OFF the public `fetch`, E.1 readiness probe
+  + E.2 single-user-DO/poll patterns, sync mode-gating). The 5 P3 servers copy this; do
+  not re-solve E.1/E.2 per server.
+
 ## Release & Deploy
 
 - Conventional Commits. Tag format: `v{version}`

--- a/docs/cf-template.md
+++ b/docs/cf-template.md
@@ -1,0 +1,80 @@
+# Cloudflare worker template (FROZEN for P3 replication)
+
+`src/worker.ts` + `wrangler.jsonc` in this repo are the canonical CF template for
+the n24q02m MCP stack. P3 servers (imagine, notion, email, telegram, mnemo) copy
+them verbatim, changing only the Durable Object class name, the binding name, the
+plugin/image/PUBLIC_URL strings, and the kept/dropped outbound handlers below.
+Hardened for E.1 + E.2 (PR series cf-p3-01); do not re-solve those per server.
+
+## Copy procedure
+1. Copy `wet/src/worker.ts` -> `<server>/src/worker.ts`.
+2. Rename `WetContainer` -> `<Name>Container`; `WET` binding -> `<NAME>`.
+3. Update the image ref (`registry.cloudflare.com/<ACCOUNT_ID>/<server>:beta`) and
+   `PUBLIC_URL`/route to `<server>.n24q02m.com`.
+4. Apply the KEEP/DROP handler matrix below.
+5. Copy `wrangler.jsonc`; drop the `d1_databases` / `vectorize` blocks for KV-only servers.
+
+## ALWAYS KEEP (every server)
+- `export { ContainerProxy }` (footgun #2).
+- `pickContainerEnv` + the `CONTAINER_ENV_KEYS` allowlist (rename keys per server).
+- `extractUserId` INCLUDING the single-user `idFromName("default")` contract (E.2 part a).
+- The public `fetch` does **per-user DO routing ONLY**. It MUST NOT dispatch the
+  kv/d1/vectorize handlers (see Security below). `export` the `OUTBOUND_BY_HOST`
+  registry so unit tests invoke a handler directly instead of through `fetch`.
+- `kvOutbound` INCLUDING the `GET __ready -> {ready:true}` readiness branch (E.1).
+- `OUTBOUND_BY_HOST` registry + the `<Name>Container.outboundByHost = OUTBOUND_BY_HOST`
+  ASSIGNMENT after the class (footgun #1 — NEVER a `static` field).
+- The Container DO shape (`defaultPort`, `sleepAfter`, `enableInternet`, `envVars`).
+
+## KEEP ONLY IF USED
+- `d1Outbound` + `D1` binding -> ONLY if the server uses D1 (mnemo only).
+- `vectorizeOutbound` + `VECTORIZE` binding -> ONLY if the server uses Vectorize (mnemo only).
+- imagine / notion / email / telegram are KV-only: drop both handlers + bindings; keep `kvOutbound`.
+
+## Security (non-negotiable)
+- **Outbound handlers stay OFF the public `fetch` entrypoint.** The container's
+  kv/d1/vectorize.internal outbound is serviced via `@cloudflare/containers`'
+  `ContainerProxy` + the `outboundByHost` registry assignment — an internal,
+  container-only path. Dispatching them from the public `fetch` (e.g. keying on
+  `new URL(request.url).hostname`) lets an external caller spoof the hostname to
+  `kv.internal` and read/write/**DELETE** the credential KV namespace
+  unauthenticated (HIGH finding, commit security review 2026-06-15). Test the
+  handlers by calling `OUTBOUND_BY_HOST['kv.internal'](req, env)` directly; add a
+  regression test asserting `worker.fetch` with an internal hostname is NOT
+  serviced by a handler (returns the DO-routing `not found`, never a KV op).
+
+## E.1 / E.2 (already solved in the template — inherit, do not re-solve)
+- E.1 race: `kvOutbound` answers `GET __ready` (via ContainerProxy); the container
+  setup path awaits `CfKvBackend.ready()` (mcp-core >=1.18.0b6) before the first
+  credential PUT. Client backstop: `cf_full_flow.py get_token(save_retries=8)`
+  retry-on-500.
+- E.2 window: single-user `idFromName("default")` collapses setup+serving to one DO;
+  the setup path polls `poll_until_readable(sub)` (presence of the raw ciphertext
+  blob) before reporting success. Client backstop: `cf_full_flow.py
+  _call(retries=20, delay=8)` awaiting-setup poll.
+
+## 5 footguns (silent failure if violated)
+1. `outboundByHost` is an ASSIGNMENT after the class, never a `static` field.
+2. `export { ContainerProxy }` from the entrypoint.
+3. KV blobs read/written as `arrayBuffer` (binary AES-GCM ciphertext).
+4. CF has no `/.dockerenv`; detect container via `MCP_TRANSPORT=http`.
+5. CF managed registry only (`registry.cloudflare.com/<ACCOUNT_ID>`); re-pushing the
+   same tag does NOT roll a running app -> delete+recreate; `wrangler kv` needs `--remote`.
+
+## Sync mode-gating (servers with a docs/memory DB: wet, mnemo)
+- On CF (`DOCS_DB_BACKEND=cf-d1`) the GDrive/S3 DB-sync is REDUNDANT (D1+Vectorize is
+  the durable store) -> gate it OFF explicitly on the backend selector. Keep it ON for
+  local / self-host (`sqlite` + disk) for backup/portability. See overview §6.5.
+
+## Per-server success criteria (work-order-v3 DONE gate)
+- Deploy to CF managed registry; `/.well-known/oauth-protected-resource` -> 200;
+  `GET /mcp` (no token) -> 401 + www-authenticate.
+- Full OAuth password flow self-test PASS (replicate `cf_full_flow.py`): login ->
+  save credential (retry-on-500) -> authenticated tool call via relay.
+- STATE SURVIVES delete+recreate (the key gate; first boot is not enough).
+- Per-sub isolation: 2 distinct JWT subs -> separate state, no bleed.
+- T0 (precommit + CI) green; Protocol Test B (ClientSession all-tool-all-mode) PASS.
+- STABLE dispatched ONLY on explicit user request.
+
+Template frozen 2026-06-15 (cf-p3-01). Changes here require re-deploying + re-verifying
+wet, then re-syncing all 5 downstream copies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,9 @@ dependencies = [
     "aiolimiter>=1.2.1",
     # Relay setup (zero-env-config) + LLM passthrough (litellm via [llm] extra) +
     # pluggable credential storage backends (CredentialBackend / CfKvBackend,
-    # shipped in 1.18.0b4) + PerPluginStore token sub-key (1.18.0b5). Beta pin
-    # until 1.18.0 stable.
-    "n24q02m-mcp-core[llm]>=1.18.0b5,<2",
+    # shipped in 1.18.0b4) + PerPluginStore token sub-key (1.18.0b5) +
+    # CfKvBackend.ready() E.1 readiness probe (1.18.0b6). Beta pin until 1.18.0 stable.
+    "n24q02m-mcp-core[llm]>=1.18.0b6,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.4",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -323,6 +323,20 @@ def credentials_for_current_request() -> dict[str, str]:
     return read_for_sub(sub)
 
 
+def _await_backend_ready() -> None:
+    """E.1: when the active backend is CF KV, poll its readiness probe before the
+    first credential write so the PUT never races outbound-interception. No-op for
+    LocalFs (stdio/VM) and any backend without a ``ready()`` method.
+    """
+    backend = backend_from_env()
+    ready = getattr(backend, "ready", None)
+    if callable(ready) and not ready():
+        logger.warning(
+            "CF KV backend not ready before credential save; "
+            "relying on client retry-on-500 backstop"
+        )
+
+
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
     """Save credentials from OAuth form to ``config.json`` and apply to environment.
 
@@ -341,6 +355,11 @@ def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | 
     for the form to display.
     """
     global _state
+
+    # E.1: gate the first KV PUT on outbound-interception readiness (no-op for
+    # LocalFs / any backend without ready()). One probe per setup submit, at the
+    # single chokepoint both branches pass through.
+    _await_backend_ready()
 
     # Remote multi-user branch: scope credential storage by JWT sub so
     # concurrent /authorize sessions do not clobber each other. The GDrive

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -337,6 +337,34 @@ def _await_backend_ready() -> None:
         )
 
 
+def poll_until_readable(sub: str | None, retries: int = 8, delay: float = 0.5) -> bool:
+    """E.2: after a credential save, confirm the key is read-back-able from the
+    backend before reporting setup success, closing the KV cross-colo
+    eventual-consistency window (~60s) where the serving DO still sees "not
+    configured". Returns True once the blob is present, False if it never
+    propagates within the budget (caller proceeds; the client awaiting-setup poll
+    in ``cf_full_flow.py`` is the backstop). Reads raw ciphertext (presence is the
+    signal; no decrypt needed).
+    """
+    import time
+
+    backend = backend_from_env()
+    key = f"{PLUGIN_NAME}/subs/{sub}/config" if sub else f"{PLUGIN_NAME}/config"
+    for attempt in range(retries):
+        try:
+            if backend.get(key) is not None:
+                return True
+        except Exception:
+            pass  # transient read error during propagation -> keep polling
+        if attempt + 1 < retries:
+            time.sleep(delay)
+    logger.warning(
+        f"credential key {key} not yet readable after save; "
+        "relying on client awaiting-setup poll backstop"
+    )
+    return False
+
+
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
     """Save credentials from OAuth form to ``config.json`` and apply to environment.
 
@@ -371,6 +399,7 @@ def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | 
         if not sub:
             raise RuntimeError("multi-user mode: SubjectContext sub required")
         store_for_sub(sub, config)
+        poll_until_readable(sub)  # E.2: confirm propagation before reporting success
         _state = CredentialState.CONFIGURED
         logger.info(f"Credentials saved for sub={sub} via remote multi-user form")
 
@@ -429,6 +458,7 @@ def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | 
 
     # Persist to per-plugin store (~/.wet-mcp/config.json)
     PerPluginStore(PLUGIN_NAME, backend=backend_from_env()).save(config)
+    poll_until_readable(None)  # E.2: confirm propagation before reporting success
 
     # Apply to environment for immediate use
     apply_config(config)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -129,8 +129,25 @@ const vectorizeOutbound: OutboundHandler<Env> = async (request, env) => {
   return new Response('not found', { status: 404 })
 }
 
+// Outbound handler registry, keyed by internal hostname. Both production (via
+// @cloudflare/containers -> WetContainer.outboundByHost) and the direct fetch
+// dispatch below share this single source of truth, so they can never drift.
+const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
+  'kv.internal': kvOutbound,
+  'd1.internal': d1Outbound,
+  'vectorize.internal': vectorizeOutbound,
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    // Direct outbound entry: a request addressed to one of the internal hosts is
+    // serviced by its handler (the same registry the container proxy uses). This
+    // makes the handlers unit-testable and gives the kv.internal readiness probe
+    // a reachable endpoint.
+    const host = new URL(request.url).hostname
+    const handler = OUTBOUND_BY_HOST[host]
+    if (handler) return handler(request, env)
+
     // Inbound production request -> route to the per-user container DO.
     if (env.WET) {
       const userId = extractUserId(request)
@@ -172,9 +189,7 @@ export class WetContainer extends Container<Env> {
 }
 
 // Register outbound interception. MUST be an assignment (invokes the inherited
-// `static set outboundByHost`) — a class field would bypass the setter.
-WetContainer.outboundByHost = {
-  'kv.internal': kvOutbound as OutboundHandler,
-  'd1.internal': d1Outbound as OutboundHandler,
-  'vectorize.internal': vectorizeOutbound as OutboundHandler,
-}
+// `static set outboundByHost`) — a class field would bypass the setter. Reuses
+// OUTBOUND_BY_HOST so the proxy registry and the direct fetch dispatch are one
+// source of truth (footgun #1: assignment, never a static field).
+WetContainer.outboundByHost = OUTBOUND_BY_HOST as Record<string, OutboundHandler>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -167,7 +167,10 @@ export default {
 
 function extractUserId(request: Request): string {
   // JWT sub from the Bearer token (verified by mcp-core OAuth middleware in the
-  // container). Single-instance-per-user: fall back to "default" when absent.
+  // container). SINGLE-USER CONTRACT (E.2): no token or no `sub` -> the reserved
+  // id "default", so setup and serving collapse onto ONE Durable Object id and
+  // the credential write+read avoid a cross-colo KV hop. Per-`sub` tokens get
+  // their own isolated DO (multi-user). Downstream servers MUST keep this.
   const auth = request.headers.get('authorization') ?? ''
   const m = auth.match(/^Bearer\s+(.+)$/)
   if (!m) return 'default'

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -88,6 +88,13 @@ function pickContainerEnv(env: Env): Record<string, string> {
 const kvOutbound: OutboundHandler<Env> = async (request, env) => {
   const url = new URL(request.url)
   const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  // Readiness probe (E.1): once this handler answers, outbound interception is
+  // wired, so the container's first credential PUT is safe. Mirrors
+  // vectorizeOutbound's GET -> {ready:true}. Reserved key, checked before the
+  // normal key lookup so it never shadows a real KV key.
+  if (request.method === 'GET' && key === '__ready') {
+    return Response.json({ ready: true })
+  }
   if (request.method === 'GET') {
     // Credential blobs are binary (nonce + AES-GCM ciphertext); read/write as
     // ArrayBuffer so bytes round-trip without UTF-8 corruption.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -136,10 +136,12 @@ const vectorizeOutbound: OutboundHandler<Env> = async (request, env) => {
   return new Response('not found', { status: 404 })
 }
 
-// Outbound handler registry, keyed by internal hostname. Both production (via
-// @cloudflare/containers -> WetContainer.outboundByHost) and the direct fetch
-// dispatch below share this single source of truth, so they can never drift.
-const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
+// Outbound handler registry, keyed by internal hostname. Production container
+// outbound (kv/d1/vectorize.internal) reaches these via @cloudflare/containers'
+// ContainerProxy + the WetContainer.outboundByHost assignment below — NOT via the
+// public `fetch` export. Exported so unit tests can invoke a handler directly
+// instead of routing an internal-host request through the public entrypoint.
+export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
   'kv.internal': kvOutbound,
   'd1.internal': d1Outbound,
   'vectorize.internal': vectorizeOutbound,
@@ -147,15 +149,14 @@ const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    // Direct outbound entry: a request addressed to one of the internal hosts is
-    // serviced by its handler (the same registry the container proxy uses). This
-    // makes the handlers unit-testable and gives the kv.internal readiness probe
-    // a reachable endpoint.
-    const host = new URL(request.url).hostname
-    const handler = OUTBOUND_BY_HOST[host]
-    if (handler) return handler(request, env)
-
-    // Inbound production request -> route to the per-user container DO.
+    // Public entrypoint: ONLY routes inbound requests to the per-user container
+    // DO. The kv/d1/vectorize.internal outbound handlers are deliberately NOT
+    // dispatched here — exposing them on the public fetch surface would let an
+    // external caller (request hostname spoofed to kv.internal) read/write/delete
+    // the credential KV namespace unauthenticated. Production container outbound
+    // reaches them via @cloudflare/containers' ContainerProxy + the
+    // WetContainer.outboundByHost registry below; unit tests call the handlers
+    // directly via the OUTBOUND_BY_HOST export.
     if (env.WET) {
       const userId = extractUserId(request)
       const stub = env.WET.get(env.WET.idFromName(userId))

--- a/tests/test_credential_save_gates.py
+++ b/tests/test_credential_save_gates.py
@@ -76,3 +76,27 @@ def test_ready_not_called_for_backend_without_ready(monkeypatch):
     # must not raise (no ready()) and must still persist the credential blob
     cs.save_credentials({"JINA_AI_API_KEY": "k"}, context={})
     assert "wet/config" in backend.store
+
+
+def test_poll_until_readable_returns_once_present(monkeypatch):
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret")
+    backend = _ReadyTrackingBackend()
+    monkeypatch.setattr(cs, "backend_from_env", lambda: backend)
+    # single-user key becomes readable after the save
+    backend.store["wet/config"] = b"ciphertext"
+    assert cs.poll_until_readable(None, retries=5, delay=0) is True
+
+
+def test_poll_until_readable_times_out_gracefully(monkeypatch):
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret")
+    backend = _ReadyTrackingBackend()  # store stays empty -> never readable
+    monkeypatch.setattr(cs, "backend_from_env", lambda: backend)
+    assert cs.poll_until_readable("user-1", retries=3, delay=0) is False
+
+
+def test_poll_until_readable_checks_sub_key(monkeypatch):
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret")
+    backend = _ReadyTrackingBackend()
+    monkeypatch.setattr(cs, "backend_from_env", lambda: backend)
+    backend.store["wet/subs/user-1/config"] = b"ciphertext"
+    assert cs.poll_until_readable("user-1", retries=5, delay=0) is True

--- a/tests/test_credential_save_gates.py
+++ b/tests/test_credential_save_gates.py
@@ -1,0 +1,78 @@
+"""E.1/E.2 setup-path gates: readiness-before-PUT + post-save poll."""
+
+from __future__ import annotations
+
+import wet_mcp.credential_state as cs
+
+
+class _ReadyTrackingBackend:
+    """InMemory-like backend that records ready()/put() call ordering."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.store: dict[str, bytes] = {}
+        self._ready_returns = True
+
+    def ready(self, retries: int = 8, delay: float = 0.5) -> bool:
+        self.events.append("ready")
+        return self._ready_returns
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def put(self, key, blob):
+        self.events.append("put")
+        self.store[key] = blob
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+class _NoReadyBackend:
+    """A backend WITHOUT a ready() method (like LocalFsBackend) -> _await must no-op."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def put(self, key, blob):
+        self.store[key] = blob
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+def test_ready_is_awaited_before_first_put(monkeypatch):
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret")
+    monkeypatch.delenv("PUBLIC_URL", raising=False)  # single-user branch
+    # Isolate the readiness gate from apply_config's provider re-init side effects.
+    monkeypatch.setattr("wet_mcp.relay_setup.apply_config", lambda config: None)
+    # isolate from the single-user GDrive device-code network call + spawn-cleanup timer
+    monkeypatch.setattr("wet_mcp.config.settings.google_drive_client_id", "")
+    monkeypatch.setattr(cs, "_schedule_spawn_cleanup", lambda *a, **k: None)
+    backend = _ReadyTrackingBackend()
+    monkeypatch.setattr(cs, "backend_from_env", lambda: backend)
+
+    cs.save_credentials({"JINA_AI_API_KEY": "k"}, context={})
+
+    # readiness probe ran BEFORE the credential PUT
+    assert backend.events[0] == "ready"
+    assert "put" in backend.events
+    assert backend.events.index("ready") < backend.events.index("put")
+
+
+def test_ready_not_called_for_backend_without_ready(monkeypatch):
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret")
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    monkeypatch.setattr("wet_mcp.relay_setup.apply_config", lambda config: None)
+    # isolate from the single-user GDrive device-code network call + spawn-cleanup timer
+    monkeypatch.setattr("wet_mcp.config.settings.google_drive_client_id", "")
+    monkeypatch.setattr(cs, "_schedule_spawn_cleanup", lambda *a, **k: None)
+    backend = _NoReadyBackend()  # no ready() attr -> _await_backend_ready must no-op
+    monkeypatch.setattr(cs, "backend_from_env", lambda: backend)
+
+    # must not raise (no ready()) and must still persist the credential blob
+    cs.save_credentials({"JINA_AI_API_KEY": "k"}, context={})
+    assert "wet/config" in backend.store

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -51,4 +51,18 @@ describe('outbound handlers', () => {
     const body = (await res.json()) as { matches: unknown[] }
     expect(body.matches.length).toBe(1)
   })
+
+  it('KV readiness probe: GET __ready -> {ready:true}', async () => {
+    const env = fakeEnv()
+    const res = await worker.fetch(new Request('http://kv.internal/__ready'), env as never)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ready: true })
+  })
+
+  it('KV readiness probe does not shadow a real missing key', async () => {
+    const env = fakeEnv()
+    // a real key that happens to be absent still 404s (the probe is the reserved __ready only)
+    const res = await worker.fetch(new Request('http://kv.internal/wet%2Fsubs%2Fu1%2Fconfig'), env as never)
+    expect(res.status).toBe(404)
+  })
 })

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -66,3 +66,49 @@ describe('outbound handlers', () => {
     expect(res.status).toBe(404)
   })
 })
+
+describe('single-user DO contract (E.2)', () => {
+  function envWithDoSpy() {
+    const calls: string[] = []
+    return {
+      calls,
+      env: {
+        WET: {
+          idFromName: (n: string) => {
+            calls.push(n)
+            return { name: n }
+          },
+          get: (_id: unknown) => ({ fetch: async () => new Response('routed', { status: 200 }) }),
+        },
+      },
+    }
+  }
+
+  it('no Bearer token -> routes to the "default" DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://wet.n24q02m.com/mcp'), env as never)
+    expect(res.status).toBe(200)
+    expect(calls).toEqual(['default'])
+  })
+
+  it('Bearer token without sub -> routes to the "default" DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    // header.payload.sig where payload has no `sub`
+    const jwt = `h.${btoa(JSON.stringify({ aud: 'x' }))}.s`
+    await worker.fetch(
+      new Request('https://wet.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      env as never,
+    )
+    expect(calls).toEqual(['default'])
+  })
+
+  it('Bearer token with sub -> routes to that sub DO (per-user isolation)', async () => {
+    const { calls, env } = envWithDoSpy()
+    const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
+    await worker.fetch(
+      new Request('https://wet.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      env as never,
+    )
+    expect(calls).toEqual(['user-123'])
+  })
+})

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import worker from '../src/worker'
+import worker, { OUTBOUND_BY_HOST } from '../src/worker'
 
 function fakeEnv() {
   const kv = new Map<string, string>()
@@ -21,20 +21,27 @@ function fakeEnv() {
   }
 }
 
+// Invoke an outbound handler DIRECTLY (the production path is the container proxy
+// via WetContainer.outboundByHost; the handlers are NOT reachable through the
+// public `fetch` entrypoint, so tests exercise them through the exported registry).
+const kvH = OUTBOUND_BY_HOST['kv.internal']!
+const d1H = OUTBOUND_BY_HOST['d1.internal']!
+const vectorizeH = OUTBOUND_BY_HOST['vectorize.internal']!
+
 describe('outbound handlers', () => {
   it('KV get 404 then put then get 200', async () => {
     const env = fakeEnv()
-    let res = await worker.fetch(new Request('http://kv.internal/wet%2Fconfig'), env as never)
+    let res = await kvH(new Request('http://kv.internal/wet%2Fconfig'), env as never)
     expect(res.status).toBe(404)
-    res = await worker.fetch(new Request('http://kv.internal/wet%2Fconfig', { method: 'PUT', body: 'blob' }), env as never)
+    res = await kvH(new Request('http://kv.internal/wet%2Fconfig', { method: 'PUT', body: 'blob' }), env as never)
     expect(res.status).toBe(200)
-    res = await worker.fetch(new Request('http://kv.internal/wet%2Fconfig'), env as never)
+    res = await kvH(new Request('http://kv.internal/wet%2Fconfig'), env as never)
     expect(await res.text()).toBe('blob')
   })
 
   it('D1 query uses prepared statement', async () => {
     const env = fakeEnv()
-    const res = await worker.fetch(
+    const res = await d1H(
       new Request('http://d1.internal/query', { method: 'POST', body: JSON.stringify({ sql: 'SELECT 1', params: [] }) }),
       env as never,
     )
@@ -44,7 +51,7 @@ describe('outbound handlers', () => {
 
   it('Vectorize query returns matches', async () => {
     const env = fakeEnv()
-    const res = await worker.fetch(
+    const res = await vectorizeH(
       new Request('http://vectorize.internal/query', { method: 'POST', body: JSON.stringify({ vector: [0.1], topK: 1 }) }),
       env as never,
     )
@@ -54,7 +61,7 @@ describe('outbound handlers', () => {
 
   it('KV readiness probe: GET __ready -> {ready:true}', async () => {
     const env = fakeEnv()
-    const res = await worker.fetch(new Request('http://kv.internal/__ready'), env as never)
+    const res = await kvH(new Request('http://kv.internal/__ready'), env as never)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ ready: true })
   })
@@ -62,8 +69,19 @@ describe('outbound handlers', () => {
   it('KV readiness probe does not shadow a real missing key', async () => {
     const env = fakeEnv()
     // a real key that happens to be absent still 404s (the probe is the reserved __ready only)
-    const res = await worker.fetch(new Request('http://kv.internal/wet%2Fsubs%2Fu1%2Fconfig'), env as never)
+    const res = await kvH(new Request('http://kv.internal/wet%2Fsubs%2Fu1%2Fconfig'), env as never)
     expect(res.status).toBe(404)
+  })
+})
+
+describe('public fetch entrypoint does NOT expose outbound handlers (security)', () => {
+  it('a public request with an internal hostname is NOT serviced by a handler', async () => {
+    const env = fakeEnv() // no WET binding -> DO routing path returns 404
+    // Even if an external caller spoofs the hostname to kv.internal, the public
+    // fetch must NOT read/write the credential KV — it only routes to the DO.
+    const res = await worker.fetch(new Request('http://kv.internal/wet%2Fconfig'), env as never)
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('not found')
   })
 })
 

--- a/uv.lock
+++ b/uv.lock
@@ -1813,7 +1813,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b5"
+version = "1.18.0b6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1828,9 +1828,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ee/982810a18e8ed8fb72bd93d0bc4cf4cea96ac3a705879ffe90739aeee767/n24q02m_mcp_core-1.18.0b5.tar.gz", hash = "sha256:05c68523b428bc5145d32d4cb6daeb2808550691956a194b399daa66b5675368", size = 274193, upload-time = "2026-06-14T04:00:56.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/8f/9ce65d1341ff74e1962556b3ede6041eeac676b8b061ddd7af69360559af/n24q02m_mcp_core-1.18.0b6.tar.gz", hash = "sha256:633cdb9a023aa31c20dee513e56bd2d4715ea98aee3912b4c7d52446e2b3c693", size = 275601, upload-time = "2026-06-15T13:04:15.295Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/2b/dca7a6cfea2c356e0b9165a4940e6efb1cea1a099348dcb06061d7c92153/n24q02m_mcp_core-1.18.0b5-py3-none-any.whl", hash = "sha256:6640023ed5308d837b6d6e76d1431763efe9fab99a5908051971720f4bd9d9fc", size = 150469, upload-time = "2026-06-14T04:00:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/29/65/9a7e9510c944961e5c32d58bbf53ee7d96dd1db2219e8e9db25b4da49506/n24q02m_mcp_core-1.18.0b6-py3-none-any.whl", hash = "sha256:739fcdbac3cc4ab07fb21401f87143f50edf12d88f5a072d77bc5415e8da8d64", size = 151539, upload-time = "2026-06-15T13:04:16.536Z" },
 ]
 
 [package.optional-dependencies]
@@ -3495,7 +3495,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b8"
+version = "3.3.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3556,7 +3556,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b5,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b6,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.2.1,<2.3" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
Hardens the canonical CF worker template — prerequisite for the P3 5-server migration; the 5 servers copy this hardened template.

- **E.1** (credential-save outbound-interception race -> flaky 500): `kv.internal` `__ready` readiness probe in `kvOutbound` + `CfKvBackend.ready()` (mcp-core 1.18.0b6) awaited before the first credential PUT. Client retry-on-500 stays as the backstop.
- **E.2** (KV cross-colo eventual consistency -> 'not configured' after setup): explicit single-user `idFromName("default")` DO contract + post-save `poll_until_readable` before reporting success.
- **Security**: outbound handlers are NOT exposed on the public `fetch` entrypoint (an external caller spoofing the request hostname to `kv.internal` would otherwise read/write/delete the credential KV). Handlers run only via the @cloudflare/containers ContainerProxy + `outboundByHost`; unit tests call them directly via the exported `OUTBOUND_BY_HOST`.
- **Freeze**: `docs/cf-template.md` pins the copy-from-wet contract (KEEP/DROP matrix, 5 footguns, security rule, sync mode-gating) for imagine/notion/email/telegram/mnemo.

Worker tests 9/9, credential-gate tests 5/5, full pytest green.