### PR TITLE
fix: compare mcp-core pin floor as version, not brittle substring

### DIFF
--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -2,16 +2,23 @@
 backends (CredentialBackend / CfKvBackend) AND the PerPluginStore token sub-key.
 """
 
+import re
 import tomllib
 from pathlib import Path
+
+from packaging.version import Version
 
 
 def test_mcp_core_pin_includes_token_subkey():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
-    # Storage backends shipped in 1.18.0b4; the token sub-key in 1.18.0b5.
-    assert "1.18.0b5" in core, f"expected >=1.18.0b5 floor, got: {core}"
+    # Storage backends shipped in 1.18.0b4; the token sub-key in 1.18.0b5;
+    # CfKvBackend.ready() readiness probe in 1.18.0b6. Compare the >= floor as a
+    # version (not a brittle substring) so legitimate bumps past b5 still pass.
+    m = re.search(r">=\s*([0-9][0-9A-Za-z.\-]*)", core)
+    assert m, f"no >= floor in pin: {core}"
+    assert Version(m.group(1)) >= Version("1.18.0b5"), f"floor too low: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():


### PR DESCRIPTION
Main went red on `chore(release): v3.3.0-beta.11` (all 3 OS): `test_mcp_core_pin_includes_token_subkey` hard-coded the substring `1.18.0b5`, so the legitimate bump to `>=1.18.0b6` (CfKvBackend.ready() readiness probe, #1372) failed the guard.

Fix: parse the `>=` floor and compare it as a `packaging.version.Version` against the `1.18.0b5` minimum, so future bumps (b6, 1.18.0, 1.19, ...) still satisfy the guard. `packaging` is already present (pytest dep). Verified locally: 2 passed.