### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Secure SQLite introspection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `token_store.py` module constructed file paths by directly concatenating user-controlled inputs (`provider`, `sub`) via `pathlib.Path` without validation. This allowed path traversal (e.g., using `../` or absolute paths) to read or write arbitrary files on the system with the application's permissions.
 **Learning:** Even when using higher-level path abstractions like `pathlib`, string concatenation or `/` division with unvalidated user input is unsafe because the underlying OS resolution still respects traversal sequences.
 **Prevention:** Always explicitly validate path components for dangerous characters (like `/`, `\`, and `..`) using an explicit string validation helper before passing them to file I/O operations or path constructors.
+
+## 2024-06-16 - [Secure SQLite Introspection]
+**Vulnerability:** Use of raw PRAGMA commands for SQLite database introspection (e.g., `PRAGMA table_info(table_name)`), which risks SQL injection if table names become dynamic.
+**Learning:** SQLite provides parameterized table-valued functions (e.g., `pragma_table_info(?)`) that are a safer alternative to raw PRAGMA calls, allowing dynamic introspection without string concatenation risks.
+**Prevention:** Always use parameterized table-valued PRAGMA functions (`SELECT name FROM pragma_table_info(?)`) instead of raw PRAGMAs.

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -624,7 +624,9 @@ class DocsDB:
         # presence once per call so we don't crash on older schemas.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info(?)", ("libraries",)
+            ).fetchall()
         }
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
@@ -747,7 +749,9 @@ class DocsDB:
         """
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info(?)", ("libraries",)
+            ).fetchall()
         }
         sets: list[str] = []
         params: list = []
@@ -880,7 +884,9 @@ class DocsDB:
         # Detect optional columns once so we can branch on a single INSERT.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info(?)", ("doc_chunks",)
+            ).fetchall()
         }
         phase2_cols = [
             c

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -219,7 +219,9 @@ class TestLibraryMigration:
         # Second call triggers OperationalError because column exists
         db._create_libraries_table()
         # Check if column exists
-        info = db._conn.execute("PRAGMA table_info(libraries)").fetchall()
+        info = db._conn.execute(
+            "SELECT name FROM pragma_table_info(?)", ("libraries",)
+        ).fetchall()
         cols = [c["name"] for c in info]
         assert "discovery_version" in cols
 
@@ -685,7 +687,7 @@ class TestMarkLibraryIndexed:
     def test_mark_library_indexed_legacy_db(self, db):
         """No-op if columns are missing (lines 600-601)."""
         # We can't easily mock sqlite3.Connection.execute as it's read-only.
-        # Instead, mock the return value of fetchall for PRAGMA table_info.
+        # Instead, mock the return value of fetchall for pragma_table_info.
 
         mock_results = [{"name": "id"}, {"name": "name"}]
 
@@ -702,10 +704,10 @@ class TestMarkLibraryIndexed:
             db.mark_library_indexed("legacy1", total_versions=10)
 
             # Verify it did NOT call execute with UPDATE
-            # The first call should be PRAGMA table_info
+            # The first call should be pragma_table_info
             # If it didn't return early, there would be a second call with UPDATE
             assert mock_conn.execute.call_count == 1
-            assert "PRAGMA table_info" in mock_conn.execute.call_args[0][0]
+            assert "pragma_table_info" in mock_conn.execute.call_args[0][0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🛡️ Sentinel: [SECURITY ENHANCEMENT] Secure SQLite introspection.

🚨 Severity: LOW (Enhancement)
💡 Vulnerability: The use of raw PRAGMA commands for SQLite database introspection (e.g., `PRAGMA table_info(table_name)`) can be risky if table names ever become dynamic, opening the door to SQL injection via string formatting.
🎯 Impact: While the current usage in `src/wet_mcp/db.py` uses hardcoded table names ("libraries" and "doc_chunks") and is not currently exploitable, using raw PRAGMA commands is an unsafe pattern.
🔧 Fix: Replaced `PRAGMA table_info(table_name)` with the safer, parameterized table-valued function `SELECT name FROM pragma_table_info(?)`. Updated `tests/test_db_coverage.py` to match the new syntax.
✅ Verification: Ran `uv run pytest -n0` which executed the full test suite successfully. Also formatted and linted the code.

---
*PR created automatically by Jules for task [18426950640789320697](https://jules.google.com/task/18426950640789320697) started by @n24q02m*