### PR TITLE
feat: enable username-stable-sub workspace bucket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     # pluggable credential storage backends (CredentialBackend / CfKvBackend,
     # shipped in 1.18.0b4) + PerPluginStore token sub-key (1.18.0b5) +
     # CfKvBackend.ready() E.1 readiness probe (1.18.0b6). Beta pin until 1.18.0 stable.
-    "n24q02m-mcp-core[llm]>=1.18.0b6,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b12,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.4",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2616,6 +2616,7 @@ async def run_http_server(port: int = 0) -> None:
         setup_complete_hook=wire_gdrive_callbacks,
         auth_scope=auth_scope,
         auth_disabled=auth_disabled,
+        stable_sub_enabled=True,
     )
 
 

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -13,12 +13,12 @@ def test_mcp_core_pin_includes_token_subkey():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
-    # Storage backends shipped in 1.18.0b4; the token sub-key in 1.18.0b5;
-    # CfKvBackend.ready() readiness probe in 1.18.0b6. Compare the >= floor as a
+    # Storage backends shipped in 1.18.0b12; the token sub-key in 1.18.0b12;
+    # CfKvBackend.ready() readiness probe in 1.18.0b12. Compare the >= floor as a
     # version (not a brittle substring) so legitimate bumps past b5 still pass.
     m = re.search(r">=\s*([0-9][0-9A-Za-z.\-]*)", core)
     assert m, f"no >= floor in pin: {core}"
-    assert Version(m.group(1)) >= Version("1.18.0b5"), f"floor too low: {core}"
+    assert Version(m.group(1)) >= Version("1.18.0b12"), f"floor too low: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/tests/test_stable_sub_optin.py
+++ b/tests/test_stable_sub_optin.py
@@ -1,0 +1,9 @@
+"""Guard: this server opts into username-stable-sub."""
+
+import inspect
+
+from wet_mcp import server
+
+
+def test_enables_stable_sub():
+    assert "stable_sub_enabled=True" in inspect.getsource(server)

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b10"
+version = "1.18.0b12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1806,9 +1806,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/70/043942c59667fce1b53f269f5df16cf9fb12bde1a4bbb81f52c51baac10e/n24q02m_mcp_core-1.18.0b10.tar.gz", hash = "sha256:62a7f759ddade906eb9603a67e6155b87dee79163bb7c732db0698b395214f88", size = 282027, upload-time = "2026-06-17T08:19:56.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/93/7bacfbaeaf6805fad2f4883ffb2f9aba4c2f147eb0d2d4d3d2d423733836/n24q02m_mcp_core-1.18.0b12.tar.gz", hash = "sha256:b8dffee8d18468a0ded29d7aa0eccb6af5daed62fd1ef96f8833787cbca2eb03", size = 287572, upload-time = "2026-06-18T12:36:36.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/c4/fd1626e9ab0afe60ae9880b8f5a855ad14ef1785a2598d8010b55cbee62c/n24q02m_mcp_core-1.18.0b10-py3-none-any.whl", hash = "sha256:44ea32698b985384181676ee4c3e2f2d58abae8dfc94b47eaaeee371d978b1f0", size = 156789, upload-time = "2026-06-17T08:19:54.678Z" },
+    { url = "https://files.pythonhosted.org/packages/19/98/cdf75f3d9cf5eec197384d0b5c8e0e237ac2bc03d2685f64c4e881414006/n24q02m_mcp_core-1.18.0b12-py3-none-any.whl", hash = "sha256:f87d26b576836d406fbdd43d3f6c5a398a6cd721d7db5dd51eeabe6cbe8917fc", size = 158657, upload-time = "2026-06-18T12:36:37.321Z" },
 ]
 
 [package.optional-dependencies]
@@ -3460,7 +3460,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b11"
+version = "3.3.0b12"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3521,7 +3521,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b6,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b12,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.2.1,<2.3" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
Opts this data-bearing server into the username-stable-sub feature (mcp-core 1.18.0b12, PRs #502+#503): passes stable_sub_enabled=True to run_http_server so the credential form shows the optional workspace-username field; a returning user typing the same username lands on the SAME per-sub bucket (docs/memories persist across re-auth + devices). Blank username = unchanged random behaviour. Bumps mcp-core pin floor + lockfile to 1.18.0b12 and the pin-guard test.