### PR TITLE
⚡ Bolt: Parallelize cloud embedder batch processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-05-14 - Consolidated Scoring Loop Optimization
 **Learning:** Functions that perform multiple passes over the same content (e.g., using `re.finditer` multiple times or combining `splitlines()` loops) can be significantly optimized by consolidating logic into a single line-by-line loop. Using `str.startswith()` with a tuple is faster than anchored regex for prefix matching. Pre-filtering lines with substring checks before running expensive regex avoids unnecessary engine overhead for the majority of lines.
 **Action:** Consolidate multiple string/line scans into a single `for ln in content.splitlines()` loop in performance-critical paths.
+## 2025-05-14 - Parallelize Batch API Calls
+**Learning:** Sequential batch API processing logic (e.g., in a `for` loop) can severely bottleneck processing of large inputs. `asyncio.gather` bounded by a semaphore effectively maximizes throughput without hitting rate limits.
+**Action:** When making numerous API calls (such as chunks of a large text for embeddings), use an `asyncio.Semaphore` with `asyncio.gather` instead of awaiting sequential iterations in a loop.

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -277,13 +277,27 @@ class CloudEmbeddingBackend:
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        # ⚡ Bolt Optimization: Parallelize batch API calls to speed up large document embedding
+        # Use a semaphore to prevent unbounded concurrency and avoid API rate limits
+        sem = asyncio.Semaphore(8)
+
+        async def _embed_with_sem(
+            batch: list[str], batch_num: int
+        ) -> list[list[float]]:
+            async with sem:
+                logger.debug(
+                    f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
+                )
+                return await self._embed_batch_inner(batch, dimensions)
+
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
             batch_num = i // self.MAX_BATCH_SIZE + 1
-            logger.debug(
-                f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
-            )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(_embed_with_sem(batch, batch_num))
+
+        batch_results = await asyncio.gather(*tasks)
+        for batch_result in batch_results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings


### PR DESCRIPTION
### 💡 What
Modified `CloudEmbeddingBackend.embed_texts` to process text batches concurrently using `asyncio.gather`, bounding the number of simultaneous active requests using an `asyncio.Semaphore(8)`.

### 🎯 Why
The embedder handles long document sequences by chunking texts into batches. Before this change, the loop `await`ed each batch's result sequentially. Sequential iteration blocks the event loop on network I/O per batch. Parallel execution leverages asynchronous I/O to perform the server round trips concurrently.

### 📊 Impact
Expect speedups roughly proportional to the number of batches and API latency. Bounded concurrency at 8 workers ensures aggressive speedup while safely preventing burst rate limit rejections from the embedding provider.

### 🔬 Measurement
Verify the change locally. Any large document sequence passed to `CloudEmbeddingBackend.embed_texts` will now embed significantly faster than before. No API rate-limit errors should manifest due to the semaphore throttle. All functional behavior remains strictly identical because `asyncio.gather` returns aggregated batches in exact input order.

---
*PR created automatically by Jules for task [7261036666689287407](https://jules.google.com/task/7261036666689287407) started by @n24q02m*