### PR TITLE
feat: capability provider chains — search/browser/captcha/embed-rerank toggles (WS-2/3/4/5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
 requires-python = "==3.13.*"
 dependencies = [
     # Shared web infrastructure (SSRF, SearXNG, URL utils, ScrapingAgent + Crawl4AI transitive).
-    # wet consumes only web-core's PUBLIC SSRF surface (is_safe_url / safe_httpx_client);
-    # security.py + tests no longer reach into private internals, so web-core 2.2.x's
-    # factory refactor (_ssrf_event_hook -> _ssrf_event_hook_factory) is transparent here.
-    "n24q02m-web-core>=2.2.1,<2.3",
+    # wet consumes web-core's SSRF surface (is_safe_url / safe_httpx_client) AND, since 2.3.0,
+    # the remote render backends (CFBrowserRenderingClient / BrowserlessClient /
+    # RemoteRenderStrategy) for the browser provider chain + the under-rendered escalation fix.
+    "n24q02m-web-core>=2.3.0b1,<3",
     # MCP Server
     "mcp[cli]",
     # HTTP Client
@@ -57,8 +57,10 @@ dependencies = [
     # Relay setup (zero-env-config) + LLM passthrough (litellm via [llm] extra) +
     # pluggable credential storage backends (CredentialBackend / CfKvBackend,
     # shipped in 1.18.0b4) + PerPluginStore token sub-key (1.18.0b5) +
-    # CfKvBackend.ready() E.1 readiness probe (1.18.0b6). Beta pin until 1.18.0 stable.
-    "n24q02m-mcp-core[llm]>=1.18.0b12,<2",
+    # CfKvBackend.ready() E.1 readiness probe (1.18.0b6) + the mcp_core.chains
+    # capability provider-chain primitive (resolve_backend / run_with_fallback,
+    # 1.18.0b13) used by the search chain + disable-local toggles. Beta pin until 1.18.0 stable.
+    "n24q02m-mcp-core[llm]>=1.18.0b13,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.4",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from mcp_core.chains import resolve_backend
 from mcp_core.llm.providers import key_env_for_model
 from pydantic import SecretStr
 from pydantic_settings import BaseSettings
@@ -82,12 +83,46 @@ class Settings(BaseSettings):
 
     # Pluggable web search backend selector. "searxng" (default, local) or
     # "tavily" (cloud adapter for CF where embedded SearXNG cannot run).
-    search_backend: str = "searxng"  # env SEARCH_BACKEND: searxng | tavily
+    search_backend: str = (
+        "searxng"  # env SEARCH_BACKEND: searxng | tavily | brave | exa
+    )
     tavily_api_key: str = ""  # env TAVILY_API_KEY
+
+    # SEARCH_BACKENDS: CSV provider chain with runtime fallback (try each, on
+    # error/empty -> next, return first non-empty). Empty -> falls back to the
+    # single SEARCH_BACKEND for back-compat (= a chain of length 1). Providers:
+    # searxng (self-host) | tavily | brave | exa (cloud).
+    search_backends: str = ""  # env SEARCH_BACKENDS
+    brave_api_key: str = ""  # env BRAVE_API_KEY
+    exa_api_key: str = ""  # env EXA_API_KEY
+    # Disable-local toggle for search (cross-cutting, see mcp_core.chains): skip
+    # the auto-local SearXNG spawn. An external SEARXNG_URL or cloud backends
+    # still work; only the heavy local SearXNG auto-start is suppressed.
+    disable_local_search: bool = False  # env DISABLE_LOCAL_SEARCH
 
     # Crawler
     crawler_headless: bool = True
     crawler_timeout: int = 60
+
+    # Browser backend chain for the headless (JS-render) leg. BROWSER_BACKENDS
+    # CSV (order = agent escalation/fallback): native (in-process chromium) |
+    # cf-browser-rendering (Cloudflare REST) | browserless (self-host REST).
+    # Empty -> native locally; the deploy sets it explicitly on container
+    # transports to offload rendering. DISABLE_LOCAL_BROWSER drops the heavy
+    # in-process native chromium (the browser capability's disable-local toggle).
+    browser_backends: str = ""  # env BROWSER_BACKENDS
+    disable_local_browser: bool = False  # env DISABLE_LOCAL_BROWSER
+    cf_account_id: str = ""  # env CF_ACCOUNT_ID
+    cf_browser_rendering_token: str = ""  # env CF_BROWSER_RENDERING_TOKEN
+    browserless_url: str = ""  # env BROWSERLESS_URL
+    browserless_token: str = ""  # env BROWSERLESS_TOKEN
+
+    # Optional, key-gated CAPTCHA escalation tier (CapSolver). Off unless a key
+    # is set (user brings their own — per-sub, user-funded). When set, a
+    # CaptchaStrategy is appended as the last escalation tier and only acts on a
+    # detected reCAPTCHA/Cloudflare Turnstile. Solves the CAPTCHA layer only, not
+    # IP reputation.
+    capsolver_api_key: str = ""  # env CAPSOLVER_API_KEY
 
     # SearXNG Management
     # web-core runner tries Docker fallback first, then subprocess install.
@@ -138,6 +173,15 @@ class Settings(BaseSettings):
     rerank_models: str = ""
     # DEPRECATED (2026-06-11): folded into EMBEDDING_MODELS/RERANK_MODELS,
     # honored one release with a warning. Backend now inferred.
+
+    # Per-capability disable-local toggles (cross-cutting; see mcp_core.chains).
+    # Turn OFF the heavy local qwen3 ONNX fallback (~570MB download) WITHOUT
+    # pinning a specific cloud model. Toggle on + no cloud chain => the feature
+    # is gracefully UNAVAILABLE (clear status), never silently forced to a
+    # provider. Independent per task: a user may disable local embed but keep
+    # local rerank, or vice versa.
+    disable_local_embed: bool = False  # env DISABLE_LOCAL_EMBED
+    disable_local_rerank: bool = False  # env DISABLE_LOCAL_RERANK
 
     # Embedding
     embedding_model: str = ""  # DEPRECATED: folded into EMBEDDING_MODELS
@@ -228,6 +272,34 @@ class Settings(BaseSettings):
     def get_cache_db_path(self) -> Path:
         """Get resolved web cache database path."""
         return self.get_data_dir() / "cache.db"
+
+    def auto_searxng_enabled(self) -> bool:
+        """Whether to auto-spawn a local SearXNG.
+
+        ``DISABLE_LOCAL_SEARCH`` suppresses the heavy local SearXNG auto-start
+        (the search capability's disable-local toggle) regardless of
+        ``WET_AUTO_SEARXNG``; an external ``SEARXNG_URL`` or the cloud search
+        backends still serve search.
+        """
+        return self.wet_auto_searxng and not self.disable_local_search
+
+    def browser_backend_chain(self) -> list[str]:
+        """Ordered headless backends for the JS-render leg.
+
+        ``BROWSER_BACKENDS`` CSV; empty -> ``['native']`` (in-process chromium).
+        ``DISABLE_LOCAL_BROWSER`` drops the ``native`` leg (the browser
+        capability's disable-local toggle) so a slim container renders only via
+        the cloud/self-host backends.
+        """
+        raw = (os.getenv("BROWSER_BACKENDS", self.browser_backends) or "").strip()
+        names: list[str] = (
+            [n.strip().lower() for n in raw.split(",") if n.strip()]
+            if raw
+            else ["native"]
+        )
+        if self.disable_local_browser:
+            names = [n for n in names if n != "native"]
+        return names
 
     # --- API key management ---
 
@@ -375,11 +447,16 @@ class Settings(BaseSettings):
         )
 
     def resolve_embedding_backend(self) -> str:
-        """Resolve embedding backend: 'local' or 'cloud'.
+        """Resolve embedding backend: 'cloud', 'local', or 'unavailable'.
 
-        Always returns a valid backend (never empty). Backend is inferred
-        from EMBEDDING_MODELS (non-empty chain -> cloud, empty -> local);
-        the deprecated EMBEDDING_BACKEND env var is honored for one release.
+        3-way resolution via the shared mcp-core primitive:
+        - 'cloud'       -- a non-empty EMBEDDING_MODELS chain (with keys).
+        - 'local'       -- empty chain AND the local leg is enabled.
+        - 'unavailable' -- empty chain AND DISABLE_LOCAL_EMBED is set (the
+          local qwen3 ONNX download is skipped and no cloud chain is
+          configured, so embedding is gracefully unavailable -- NOT forced).
+
+        The deprecated EMBEDDING_BACKEND env var is honored for one release.
         """
         if self.embedding_backend:
             logger.warning(
@@ -391,7 +468,10 @@ class Settings(BaseSettings):
                 if self.embedding_backend in ("cloud", "litellm")
                 else self.embedding_backend
             )
-        return "cloud" if self.embedding_chain() else "local"
+        return resolve_backend(
+            has_cloud_chain=bool(self.embedding_chain()),
+            local_enabled=not self.disable_local_embed,
+        ).value
 
     # --- Reranking resolution ---
 
@@ -412,11 +492,12 @@ class Settings(BaseSettings):
         )
 
     def resolve_rerank_backend(self) -> str:
-        """Resolve reranking backend: 'cloud', 'local', or '' (disabled).
+        """Resolve reranking backend: 'cloud', 'local', 'unavailable', or '' (disabled).
 
-        Disabled when rerank_enabled is False. Otherwise inferred from
-        RERANK_MODELS (non-empty chain -> cloud, empty -> local); the
-        deprecated RERANK_BACKEND env var is honored for one release.
+        '' when rerank_enabled is False. Otherwise 3-way via the shared
+        mcp-core primitive (same semantics as resolve_embedding_backend, keyed
+        on RERANK_MODELS + DISABLE_LOCAL_RERANK); the deprecated RERANK_BACKEND
+        env var is honored for one release.
         """
         if not self.rerank_enabled:
             return ""
@@ -429,7 +510,10 @@ class Settings(BaseSettings):
                 if self.rerank_backend in ("cloud", "litellm")
                 else self.rerank_backend
             )
-        return "cloud" if self.rerank_chain() else "local"
+        return resolve_backend(
+            has_cloud_chain=bool(self.rerank_chain()),
+            local_enabled=not self.disable_local_rerank,
+        ).value
 
     # --- Provider mode resolution ---
 

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -24,6 +24,8 @@ _LLM_SUGGESTED = [
     "anthropic/claude-haiku-4-5",
     "xai/grok-4-fast",
 ]
+# Named search backends (no model-prefix inference; resolved via providerKeys).
+_SEARCH_BACKENDS = ["searxng", "tavily", "brave", "exa"]
 
 
 def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
@@ -45,7 +47,8 @@ RELAY_SCHEMA: dict[str, Any] = {
         "Pick models per task (order = fallback). Leave a task empty for "
         "local ONNX (embedding/rerank) — LLM features need at least one model. "
         "Key fields appear automatically for the providers your models use. "
-        "Search + extraction are always local (no key needed)."
+        "Search runs local SearXNG by default; add cloud providers "
+        "(Tavily/Brave/Exa) for a fallback chain. Extraction is always local."
     ),
     "fields": [
         {
@@ -75,6 +78,22 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": False,
             "placeholder": "add LLM model…",
         },
+        {
+            "key": "SEARCH_BACKENDS",
+            "label": "Search providers",
+            "type": "search-chain",
+            "task": "search",
+            "suggestedModels": _SEARCH_BACKENDS,
+            "providerKeys": {
+                "tavily": "TAVILY_API_KEY",
+                "brave": "BRAVE_API_KEY",
+                "exa": "EXA_API_KEY",
+            },
+            "hasLocal": True,
+            "noun": "providers",
+            "localLabel": "local SearXNG",
+            "placeholder": "add search provider…",
+        },
         _key_field(
             "JINA_AI_API_KEY", "Jina AI API Key", "jina_...", "https://jina.ai/api-key"
         ),
@@ -103,6 +122,21 @@ RELAY_SCHEMA: dict[str, Any] = {
             "https://console.anthropic.com/settings/keys",
         ),
         _key_field("XAI_API_KEY", "xAI API Key", "xai-...", "https://console.x.ai/"),
+        _key_field(
+            "TAVILY_API_KEY",
+            "Tavily API Key",
+            "tvly-...",
+            "https://app.tavily.com/home",
+        ),
+        _key_field(
+            "BRAVE_API_KEY",
+            "Brave Search API Key",
+            "BSA...",
+            "https://api-dashboard.search.brave.com/app/keys",
+        ),
+        _key_field(
+            "EXA_API_KEY", "Exa API Key", "exa_...", "https://dashboard.exa.ai/api-keys"
+        ),
         {
             "key": "GITHUB_TOKEN",
             "label": "GitHub Personal Access Token",
@@ -112,12 +146,24 @@ RELAY_SCHEMA: dict[str, Any] = {
             "helpText": "Optional. Bumps GitHub API rate limit (60->5000 req/hr) for library docs discovery.",
             "required": False,
         },
+        {
+            "key": "CAPSOLVER_API_KEY",
+            "label": "CapSolver API Key",
+            "type": "password",
+            "placeholder": "CAP-...",
+            "helpUrl": "https://dashboard.capsolver.com/",
+            "helpText": "Optional. Solves reCAPTCHA / Cloudflare Turnstile on protected pages during extraction.",
+            "required": False,
+        },
     ],
     "capabilityInfo": [
         {
             "label": "Search",
-            "priority": "SearXNG (auto-start local)",
-            "description": "Web search via SearXNG. Auto-starts locally, no API key needed.",
+            "priority": "configurable",
+            "description": (
+                "Web search. Local SearXNG auto-starts by default (no key); add "
+                "cloud providers (Tavily/Brave/Exa) above for a fallback chain."
+            ),
         },
         {
             "label": "Extraction",

--- a/src/wet_mcp/searxng_runner.py
+++ b/src/wet_mcp/searxng_runner.py
@@ -128,8 +128,10 @@ async def ensure_searxng() -> str:
 
     Falls back to ``settings.searxng_url`` on failure.
     """
-    if not settings.wet_auto_searxng:
-        logger.info("Auto SearXNG disabled, using external URL")
+    if not settings.auto_searxng_enabled():
+        logger.info(
+            "Auto SearXNG disabled (WET_AUTO_SEARXNG off or DISABLE_LOCAL_SEARCH set), using external URL"
+        )
         return settings.searxng_url
 
     try:

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -88,10 +88,13 @@ def make_docs_db():
             vectorize_backend_from_env(),
             embedding_dims=dims,
         )
-    if settings.resolve_embedding_backend() == "cloud":
+    embed_backend = settings.resolve_embedding_backend()
+    if embed_backend == "cloud":
         model_identity = settings.embedding_primary() or ""
-    else:
+    elif embed_backend == "local":
         model_identity = settings.resolve_local_embedding_model()
+    else:  # unavailable -- local disabled + no cloud chain; no active embed model
+        model_identity = ""
     return DocsDB(
         settings.get_db_path(),
         embedding_dims=dims,
@@ -299,7 +302,7 @@ async def _lifespan_startup() -> asyncio.Task | None:
     # pointing to Docker mode. Warming SearXNG in uvx mode wastes a Docker
     # spawn the user will never get value from.
     warmup_task: asyncio.Task | None = None
-    if settings.wet_auto_searxng and not is_uvx_tool_venv():
+    if settings.auto_searxng_enabled() and not is_uvx_tool_venv():
         warmup_task = asyncio.create_task(_warmup_searxng())
 
     # 2. Initialize web cache
@@ -510,6 +513,12 @@ async def _init_embedding_backend(mode: str) -> None:
 
     backend_type = settings.resolve_embedding_backend()
 
+    if backend_type == "unavailable":
+        logger.info(
+            "Embedding: unavailable (DISABLE_LOCAL_EMBED set + no cloud model configured)"
+        )
+        return
+
     if cred_state == CredentialState.LOCAL or backend_type == "local":
         local_model = settings.resolve_local_embedding_model()
         _maybe_register_custom_embed(local_model)
@@ -568,6 +577,12 @@ async def _init_reranker_backend(mode: str) -> None:
 
     if not rerank_backend_type:
         logger.info("Reranking disabled")
+        return
+
+    if rerank_backend_type == "unavailable":
+        logger.info(
+            "Reranker: unavailable (DISABLE_LOCAL_RERANK set + no cloud model configured)"
+        )
         return
 
     from wet_mcp.reranker import init_reranker
@@ -891,10 +906,6 @@ async def search(  # noqa: PLR0913
                     except json.JSONDecodeError:
                         pass
                     return cached_content
-            try:
-                backend = search_backends.search_backend_from_env()
-            except ValueError as exc:
-                return f"Error: {exc}"
             # Optional query expansion (LLM-driven, opt-in)
             search_query = normalized_query or query
             if expand:
@@ -904,11 +915,15 @@ async def search(  # noqa: PLR0913
                 if len(expanded) > 1:
                     search_query = " OR ".join(expanded)
 
-            # Only the local SearXNG backend needs the embedded instance started;
-            # point it at the live URL (auto-start may pick a dynamic port).
-            if isinstance(backend, search_backends.SearxngBackend):
+            # When the SearXNG backend is in the chain, resolve its live URL via
+            # ensure_searxng (which itself honors DISABLE_LOCAL_SEARCH /
+            # WET_AUTO_SEARXNG: it auto-starts the embedded instance only when
+            # enabled, else returns the configured external URL). Pass it to the
+            # chain so its SearxngBackend hits the right (possibly dynamic) port.
+            live_searxng_url: str | None = None
+            if "searxng" in search_backends.chain_backend_names():
                 try:
-                    backend.url = await asyncio.wait_for(
+                    live_searxng_url = await asyncio.wait_for(
                         ensure_searxng(), timeout=_SEARXNG_TIMEOUT
                     )
                 except TimeoutError:
@@ -917,7 +932,7 @@ async def search(  # noqa: PLR0913
                     return f"Error: SearXNG startup failed: {exc}"
 
             result = await _with_timeout(
-                backend.search(
+                search_backends.run_search_chain(
                     query=search_query,
                     categories=categories,
                     max_results=max_results * _RERANK_CANDIDATE_MULTIPLIER,
@@ -925,6 +940,7 @@ async def search(  # noqa: PLR0913
                     language=language,
                     include_domains=include_domains,
                     exclude_domains=exclude_domains,
+                    searxng_url=live_searxng_url,
                 ),
                 "search",
             )

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -215,14 +215,63 @@ _scraping_agent: ScrapingAgent | None = None
 _agent_lock = asyncio.Lock()
 
 
+def _build_headless_strategies(stealth: bool) -> dict[str, Any]:
+    """Resolve the BROWSER_BACKENDS chain into named headless strategies.
+
+    Each headless backend (native chromium / Cloudflare Browser Rendering /
+    self-host browserless) enters the agent chain as its own strategy, so the
+    agent's existing escalate-on-validation-failure machinery provides runtime
+    fallback between them (e.g. a 5xx/timeout on CF advances to browserless).
+    Backends whose credentials are missing are skipped with a warning. If the
+    chain resolves to nothing AND local browser is NOT disabled, fall back to
+    native so local extraction keeps a JS-render escalation; if local IS
+    disabled with no cloud creds, the headless leg is intentionally absent
+    (extract degrades to basic_http/tls_spoof).
+    """
+    from web_core.browsers import BrowserlessClient, CFBrowserRenderingClient
+    from web_core.scraper.strategies import RemoteRenderStrategy
+
+    out: dict[str, Any] = {}
+    for backend in settings.browser_backend_chain():
+        try:
+            if backend == "native":
+                out["headless"] = HeadlessStrategy(
+                    timeout=settings.crawler_timeout, stealth=stealth
+                )
+            elif backend == "cf-browser-rendering":
+                client = CFBrowserRenderingClient(
+                    settings.cf_account_id,
+                    settings.cf_browser_rendering_token,
+                    timeout=settings.crawler_timeout,
+                )
+                out["cf_render"] = RemoteRenderStrategy(client)
+            elif backend == "browserless":
+                client = BrowserlessClient(
+                    settings.browserless_url,
+                    token=settings.browserless_token,
+                    timeout=settings.crawler_timeout,
+                )
+                out["browserless"] = RemoteRenderStrategy(client)
+            else:
+                logger.warning(f"Unknown browser backend {backend!r}; skipping")
+        except ValueError as exc:
+            logger.warning(f"Skipping browser backend {backend!r}: {exc}")
+    if not out and not settings.disable_local_browser:
+        out["headless"] = HeadlessStrategy(
+            timeout=settings.crawler_timeout, stealth=stealth
+        )
+    return out
+
+
 def _build_scraping_agent(stealth: bool = True) -> ScrapingAgent:
     """Build a ScrapingAgent with the canonical wet strategy chain.
 
-    Order matches spec §4.2 escalation: ``basic_http`` → ``tls_spoof`` →
-    ``headless``. ``api_direct``/``patchright``/``captcha`` are intentionally
-    omitted from the default chain (api_direct rarely beats basic_http on
-    arbitrary URLs; patchright + captcha pull in heavier optional deps and
-    are reserved for Phase 3 ``interact`` work).
+    Order matches spec §4.2 escalation: ``basic_http`` → ``tls_spoof`` → the
+    headless provider chain (``native`` / ``cf-browser-rendering`` /
+    ``browserless``, resolved from BROWSER_BACKENDS). ``api_direct``/
+    ``patchright`` are intentionally omitted (api_direct rarely beats basic_http
+    on arbitrary URLs; patchright pulls in heavier optional deps); ``captcha`` is
+    appended separately as a key-gated tier (see _build_scraping_agent callers).
 
     ``respect_robots`` stays False to preserve wet's historical behaviour;
     callers wanting robots compliance can override via env in a follow-up.
@@ -230,8 +279,18 @@ def _build_scraping_agent(stealth: bool = True) -> ScrapingAgent:
     strategies: dict[str, Any] = {
         "basic_http": BasicHTTPStrategy(timeout=settings.crawler_timeout),
         "tls_spoof": TLSSpoofStrategy(timeout=settings.crawler_timeout),
-        "headless": HeadlessStrategy(timeout=settings.crawler_timeout, stealth=stealth),
     }
+    strategies.update(_build_headless_strategies(stealth))
+    # Optional, key-gated CAPTCHA tier: appended LAST so it is only reached after
+    # the lighter strategies fail validation (e.g. on a Cloudflare Turnstile).
+    # Lazy-imported so the heavier CapSolver/patchright path loads only when a key
+    # is set. Solves the captcha layer only, not IP reputation.
+    if settings.capsolver_api_key:
+        from web_core.scraper.strategies import CaptchaStrategy
+
+        strategies["captcha"] = CaptchaStrategy(
+            capsolver_api_key=settings.capsolver_api_key
+        )
     return ScrapingAgent(strategies=strategies, respect_robots=False)
 
 

--- a/src/wet_mcp/sources/search_backends.py
+++ b/src/wet_mcp/sources/search_backends.py
@@ -10,6 +10,8 @@ import os
 from typing import Protocol
 
 import httpx
+from loguru import logger
+from mcp_core.chains import run_with_fallback
 
 from wet_mcp.config import settings
 
@@ -105,23 +107,281 @@ class TavilyBackend:
             return json.dumps({"error": f"Tavily search failed: {type(e).__name__}"})
 
 
-def search_backend_from_env() -> SearchBackend:
-    name = (os.getenv("SEARCH_BACKEND", settings.search_backend) or "searxng").lower()
+class BraveBackend:
+    """Brave Web Search API (https://api.search.brave.com/res/v1/web/search).
+
+    GET with header ``X-Subscription-Token``; results live at ``web.results[]``
+    (verified against current Brave docs 2026-06-19).
+    """
+
+    _URL = "https://api.search.brave.com/res/v1/web/search"
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 10,
+        time_range=None,
+        language=None,
+        include_domains=None,
+        exclude_domains=None,
+        categories="general",
+    ) -> str:
+        params: dict[str, str | int] = {
+            "q": query,
+            "count": min(max(max_results, 1), 20),
+        }
+        if time_range:
+            # Brave freshness codes: pd (day) / pw (week) / pm (month) / py (year).
+            freshness = {"day": "pd", "week": "pw", "month": "pm", "year": "py"}.get(
+                time_range
+            )
+            if freshness:
+                params["freshness"] = freshness
+        if language:
+            params["search_lang"] = language
+        headers = {"X-Subscription-Token": self.api_key, "Accept": "application/json"}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(self._URL, params=params, headers=headers)
+                if resp.status_code != 200:
+                    return json.dumps({"error": f"Brave HTTP {resp.status_code}"})
+                results = resp.json().get("web", {}).get("results", [])
+                mapped = [
+                    {
+                        "url": r.get("url", ""),
+                        "title": r.get("title", ""),
+                        "snippet": r.get("description", r.get("title", "")),
+                        "source": "brave",
+                    }
+                    for r in results
+                ]
+                return json.dumps(
+                    {"results": mapped, "total": len(mapped), "query": query},
+                    ensure_ascii=False,
+                    indent=2,
+                )
+        except (
+            httpx.HTTPError
+        ) as e:  # transport — type name only (never echo, may carry the token)
+            return json.dumps({"error": f"Brave request failed: {type(e).__name__}"})
+        except (
+            Exception
+        ) as e:  # tool contract: error string, never raise; type name only
+            return json.dumps({"error": f"Brave search failed: {type(e).__name__}"})
+
+
+class ExaBackend:
+    """Exa search API (https://api.exa.ai/search).
+
+    POST with header ``x-api-key``; body ``{query, numResults}`` plus a small
+    ``contents.text`` request so each result carries a snippet. Results live at
+    ``results[]`` (verified against current Exa docs 2026-06-19).
+    """
+
+    _URL = "https://api.exa.ai/search"
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 10,
+        time_range=None,
+        language=None,
+        include_domains=None,
+        exclude_domains=None,
+        categories="general",
+    ) -> str:
+        body: dict[str, object] = {
+            "query": query,
+            "numResults": min(max(max_results, 1), 100),
+            "contents": {"text": {"maxCharacters": 300}},
+        }
+        if include_domains:
+            body["includeDomains"] = include_domains
+        if exclude_domains:
+            body["excludeDomains"] = exclude_domains
+        headers = {"x-api-key": self.api_key, "Content-Type": "application/json"}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(self._URL, json=body, headers=headers)
+                if resp.status_code != 200:
+                    return json.dumps({"error": f"Exa HTTP {resp.status_code}"})
+                results = resp.json().get("results", [])
+                mapped = [
+                    {
+                        "url": r.get("url", ""),
+                        "title": r.get("title", ""),
+                        "snippet": (r.get("text") or r.get("title", ""))[:300],
+                        "source": "exa",
+                    }
+                    for r in results
+                ]
+                return json.dumps(
+                    {"results": mapped, "total": len(mapped), "query": query},
+                    ensure_ascii=False,
+                    indent=2,
+                )
+        except (
+            httpx.HTTPError
+        ) as e:  # transport — type name only (never echo, may carry the key)
+            return json.dumps({"error": f"Exa request failed: {type(e).__name__}"})
+        except (
+            Exception
+        ) as e:  # tool contract: error string, never raise; type name only
+            return json.dumps({"error": f"Exa search failed: {type(e).__name__}"})
+
+
+def _make_backend(name: str, searxng_url: str | None = None) -> SearchBackend:
+    """Construct a single backend by name. Raises ValueError on missing key/unknown.
+
+    ``searxng_url`` overrides ``settings.searxng_url`` for the SearXNG backend
+    (the live auto-started URL, which may use a dynamic port) without mutating
+    the global settings.
+    """
+    if name == "searxng":
+        return SearxngBackend(searxng_url or settings.searxng_url)
     if name == "tavily":
         key = os.getenv("TAVILY_API_KEY", settings.tavily_api_key)
         if not key:
-            raise ValueError(
-                "TAVILY_API_KEY env var required for SEARCH_BACKEND=tavily"
-            )
+            raise ValueError("TAVILY_API_KEY required for the tavily search backend")
         return TavilyBackend(key)
-    if name == "searxng":
-        return SearxngBackend(settings.searxng_url)
-    raise ValueError(f"Unknown SEARCH_BACKEND: {name}")
+    if name == "brave":
+        key = os.getenv("BRAVE_API_KEY", settings.brave_api_key)
+        if not key:
+            raise ValueError("BRAVE_API_KEY required for the brave search backend")
+        return BraveBackend(key)
+    if name == "exa":
+        key = os.getenv("EXA_API_KEY", settings.exa_api_key)
+        if not key:
+            raise ValueError("EXA_API_KEY required for the exa search backend")
+        return ExaBackend(key)
+    raise ValueError(f"Unknown search backend: {name}")
+
+
+def search_backend_from_env() -> SearchBackend:
+    """Single-backend resolver (back-compat). Raises on missing key/unknown name."""
+    name = (os.getenv("SEARCH_BACKEND", settings.search_backend) or "searxng").lower()
+    return _make_backend(name)
+
+
+def chain_backend_names() -> list[str]:
+    """The ordered backend names in the chain (no construction, no keys needed).
+
+    Reads the CSV ``SEARCH_BACKENDS``; empty -> the single ``SEARCH_BACKEND``
+    (back-compat). Used to decide whether the embedded SearXNG must be started
+    before running the chain.
+    """
+    raw = (os.getenv("SEARCH_BACKENDS", settings.search_backends) or "").strip()
+    if not raw:
+        raw = (
+            os.getenv("SEARCH_BACKEND", settings.search_backend) or "searxng"
+        ).strip()
+    return [n.strip().lower() for n in raw.split(",") if n.strip()]
+
+
+def search_backends_from_env(searxng_url: str | None = None) -> list[SearchBackend]:
+    """Resolve the ordered SEARCH_BACKENDS chain.
+
+    Reads the CSV ``SEARCH_BACKENDS``; empty -> falls back to the single
+    ``SEARCH_BACKEND`` (back-compat). Backends that cannot be built (missing
+    key) are SKIPPED with a warning so a partially-configured chain still works
+    with whatever providers are available. ``searxng_url`` overrides the SearXNG
+    backend URL (the live auto-started instance).
+    """
+    backends: list[SearchBackend] = []
+    for name in chain_backend_names():
+        try:
+            backends.append(_make_backend(name, searxng_url))
+        except ValueError as exc:
+            logger.warning(f"Skipping search backend {name!r}: {exc}")
+    return backends
+
+
+def _search_result_is_empty(payload: str) -> bool:
+    """A search result JSON string counts as empty (advance the chain) when it
+    is an error envelope or carries no results."""
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return True
+    if not isinstance(data, dict):
+        return True
+    if data.get("error"):
+        return True
+    return not data.get("results")
+
+
+async def run_search_chain(
+    query: str,
+    max_results: int = 10,
+    time_range=None,
+    language=None,
+    include_domains=None,
+    exclude_domains=None,
+    categories="general",
+    searxng_url: str | None = None,
+) -> str:
+    """Run the SEARCH_BACKENDS chain with runtime fallback.
+
+    Tries each backend in order; on a raised error OR an empty/error result it
+    advances to the next, returning the first non-empty result (the shared
+    ``mcp_core.chains.run_with_fallback`` primitive). Returns an empty-results
+    envelope when every backend is exhausted. ``searxng_url`` is the live
+    auto-started SearXNG URL (when SearXNG is in the chain).
+    """
+    backends = search_backends_from_env(searxng_url)
+    if not backends:
+        requested = chain_backend_names()
+        msg = (
+            f"Search backends {requested} are missing API keys; configure a key or add searxng"
+            if requested
+            else "No search backend configured"
+        )
+        return json.dumps(
+            {"results": [], "total": 0, "query": query, "error": msg},
+            ensure_ascii=False,
+        )
+    thunks = [
+        (
+            lambda b=b: b.search(
+                query=query,
+                max_results=max_results,
+                time_range=time_range,
+                language=language,
+                include_domains=include_domains,
+                exclude_domains=exclude_domains,
+                categories=categories,
+            )
+        )
+        for b in backends
+    ]
+    result = await run_with_fallback(
+        thunks,
+        is_empty=_search_result_is_empty,
+        on_error=lambda idx, exc: logger.warning(
+            f"Search backend #{idx} raised: {type(exc).__name__}"
+        ),
+    )
+    if result is None:
+        return json.dumps(
+            {"results": [], "total": 0, "query": query}, ensure_ascii=False
+        )
+    return result
 
 
 __all__ = [
+    "BraveBackend",
+    "ExaBackend",
     "SearchBackend",
     "SearxngBackend",
     "TavilyBackend",
+    "chain_backend_names",
+    "run_search_chain",
     "search_backend_from_env",
+    "search_backends_from_env",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Pytest configuration and fixtures."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -15,10 +15,23 @@ def _stub_phase2_lifespan_hooks():
     Stub them out by default so tests that drive the lifespan don't hit
     real disk; tests that need the real migrations / warmup call them
     directly (test_migrations.py, test_tier1_warmup.py).
+
+    Also stubs the embedding/reranker backend FACTORIES so the lifespan's
+    fire-and-forget background init task (``wet-init-backends``) never loads a
+    real local ONNX model (~570MB download) nor makes a real cloud provider
+    call -- either of which hangs a cold CI runner long after a test's own
+    patches have exited. Tests that exercise these init factories patch the
+    same targets themselves; their patch overrides this default.
     """
+    embed_backend = MagicMock()
+    embed_backend.check_available = AsyncMock(return_value=768)
+    rerank = MagicMock()
+    rerank.check_available = MagicMock(return_value=True)
     with (
         patch("wet_mcp.migrations.run_migrations_on_startup"),
         patch("wet_mcp.sources.tier1_warmup.maybe_warm"),
+        patch("wet_mcp.embedder.init_backend", return_value=embed_backend),
+        patch("wet_mcp.reranker.init_reranker", return_value=rerank),
     ):
         yield
 

--- a/tests/test_browser_backends.py
+++ b/tests/test_browser_backends.py
@@ -1,0 +1,137 @@
+"""WS-2/WS-4: browser backend provider chain factory + key-gated captcha tier."""
+
+from __future__ import annotations
+
+from wet_mcp.config import Settings, settings
+from wet_mcp.sources.crawler import _build_headless_strategies, _build_scraping_agent
+
+# ---------------------------------------------------------------------------
+# browser_backend_chain (config)
+# ---------------------------------------------------------------------------
+
+
+def test_browser_chain_default_native(monkeypatch):
+    monkeypatch.delenv("BROWSER_BACKENDS", raising=False)
+    assert Settings(
+        browser_backends="", disable_local_browser=False
+    ).browser_backend_chain() == ["native"]
+
+
+def test_browser_chain_csv(monkeypatch):
+    monkeypatch.delenv("BROWSER_BACKENDS", raising=False)
+    s = Settings(
+        browser_backends="cf-browser-rendering, browserless",
+        disable_local_browser=False,
+    )
+    assert s.browser_backend_chain() == ["cf-browser-rendering", "browserless"]
+
+
+def test_browser_chain_disable_local_drops_native(monkeypatch):
+    monkeypatch.delenv("BROWSER_BACKENDS", raising=False)
+    s = Settings(
+        browser_backends="native,cf-browser-rendering", disable_local_browser=True
+    )
+    assert s.browser_backend_chain() == ["cf-browser-rendering"]
+
+
+def test_browser_chain_env_overrides_setting(monkeypatch):
+    monkeypatch.setenv("BROWSER_BACKENDS", "browserless")
+    assert Settings(browser_backends="native").browser_backend_chain() == [
+        "browserless"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _build_headless_strategies (crawler factory)
+# ---------------------------------------------------------------------------
+
+
+def _set_browser(monkeypatch, **kwargs):
+    monkeypatch.delenv("BROWSER_BACKENDS", raising=False)
+    defaults = {
+        "browser_backends": "native",
+        "disable_local_browser": False,
+        "cf_account_id": "",
+        "cf_browser_rendering_token": "",
+        "browserless_url": "",
+        "browserless_token": "",
+        "capsolver_api_key": "",
+    }
+    defaults.update(kwargs)
+    for k, v in defaults.items():
+        monkeypatch.setattr(settings, k, v, raising=False)
+
+
+def test_headless_native_default(monkeypatch):
+    _set_browser(monkeypatch, browser_backends="native")
+    strats = _build_headless_strategies(stealth=True)
+    assert "headless" in strats
+
+
+def test_headless_cf_backend_when_creds_present(monkeypatch):
+    _set_browser(
+        monkeypatch,
+        browser_backends="cf-browser-rendering",
+        cf_account_id="acct",
+        cf_browser_rendering_token="tok",
+    )
+    strats = _build_headless_strategies(stealth=True)
+    assert "cf_render" in strats
+    assert "headless" not in strats
+
+
+def test_headless_browserless_backend(monkeypatch):
+    _set_browser(
+        monkeypatch,
+        browser_backends="browserless",
+        browserless_url="https://bl.example.com",
+    )
+    strats = _build_headless_strategies(stealth=True)
+    assert "browserless" in strats
+
+
+def test_headless_skips_missing_creds_and_falls_back_to_native(monkeypatch):
+    # cf requested but no creds + local NOT disabled -> native fallback.
+    _set_browser(monkeypatch, browser_backends="cf-browser-rendering")
+    strats = _build_headless_strategies(stealth=True)
+    assert "headless" in strats
+    assert "cf_render" not in strats
+
+
+def test_headless_empty_when_local_disabled_and_no_cloud_creds(monkeypatch):
+    _set_browser(
+        monkeypatch, browser_backends="cf-browser-rendering", disable_local_browser=True
+    )
+    strats = _build_headless_strategies(stealth=True)
+    assert strats == {}  # gracefully no headless leg
+
+
+def test_headless_chain_order_native_after_cloud(monkeypatch):
+    _set_browser(
+        monkeypatch,
+        browser_backends="cf-browser-rendering,native",
+        cf_account_id="acct",
+        cf_browser_rendering_token="tok",
+    )
+    strats = _build_headless_strategies(stealth=True)
+    assert set(strats) == {"cf_render", "headless"}
+
+
+# ---------------------------------------------------------------------------
+# Key-gated captcha tier (WS-4)
+# ---------------------------------------------------------------------------
+
+
+def test_captcha_tier_added_when_key_set(monkeypatch):
+    _set_browser(monkeypatch, capsolver_api_key="CAP-xxx")
+    agent = _build_scraping_agent(stealth=True)
+    assert "captcha" in agent.strategies
+    # Appended LAST so it is reached only after the lighter strategies.
+    assert list(agent.strategies)[-1] == "captcha"
+
+
+def test_captcha_tier_absent_when_no_key(monkeypatch):
+    _set_browser(monkeypatch, capsolver_api_key="")
+    agent = _build_scraping_agent(stealth=True)
+    assert "captcha" not in agent.strategies
+    assert "basic_http" in agent.strategies

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -173,6 +173,103 @@ def test_resolve_rerank_backend_local_when_empty():
 
 
 # -----------------------------------------------------------------------
+# Disable-local toggle (DISABLE_LOCAL_EMBED / DISABLE_LOCAL_RERANK)
+# 3-way resolution truth table — the conflation fix.
+# -----------------------------------------------------------------------
+
+
+def test_embedding_unavailable_when_local_disabled_and_no_chain():
+    """DISABLE_LOCAL_EMBED + empty chain -> 'unavailable' (NOT forced to a model)."""
+    settings = Settings(
+        embedding_backend="", embedding_models="", disable_local_embed=True
+    )
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert settings.resolve_embedding_backend() == "unavailable"
+
+
+def test_embedding_cloud_wins_even_when_local_disabled():
+    """A configured cloud chain still resolves to 'cloud' with local disabled."""
+    settings = Settings(
+        embedding_backend="",
+        embedding_models="gemini/gemini-embedding-001",
+        disable_local_embed=True,
+    )
+    assert settings.resolve_embedding_backend() == "cloud"
+
+
+def test_embedding_local_when_toggle_off_and_no_chain():
+    """Toggle off (default) + empty chain -> 'local' (unchanged behaviour)."""
+    settings = Settings(
+        embedding_backend="", embedding_models="", disable_local_embed=False
+    )
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert settings.resolve_embedding_backend() == "local"
+
+
+def test_rerank_unavailable_when_local_disabled_and_no_chain():
+    """DISABLE_LOCAL_RERANK + empty chain (rerank enabled) -> 'unavailable'."""
+    settings = Settings(
+        rerank_enabled=True,
+        rerank_backend="",
+        rerank_models="",
+        disable_local_rerank=True,
+    )
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert settings.resolve_rerank_backend() == "unavailable"
+
+
+def test_rerank_disabled_overrides_toggle():
+    """rerank_enabled=False still wins -> '' even with the toggle set."""
+    settings = Settings(rerank_enabled=False, disable_local_rerank=True)
+    assert settings.resolve_rerank_backend() == ""
+
+
+def test_auto_searxng_enabled_default():
+    """Default: auto-spawn local SearXNG enabled."""
+    assert (
+        Settings(
+            wet_auto_searxng=True, disable_local_search=False
+        ).auto_searxng_enabled()
+        is True
+    )
+
+
+def test_disable_local_search_suppresses_auto_spawn():
+    """DISABLE_LOCAL_SEARCH suppresses the auto-spawn even with WET_AUTO_SEARXNG on."""
+    assert (
+        Settings(
+            wet_auto_searxng=True, disable_local_search=True
+        ).auto_searxng_enabled()
+        is False
+    )
+
+
+def test_auto_searxng_disabled_when_wet_auto_off():
+    assert (
+        Settings(
+            wet_auto_searxng=False, disable_local_search=False
+        ).auto_searxng_enabled()
+        is False
+    )
+
+
+def test_embed_and_rerank_toggles_are_independent():
+    """A user may disable local embed but keep local rerank (and vice versa)."""
+    settings = Settings(
+        embedding_backend="",
+        embedding_models="",
+        rerank_backend="",
+        rerank_models="",
+        rerank_enabled=True,
+        disable_local_embed=True,
+        disable_local_rerank=False,
+    )
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert settings.resolve_embedding_backend() == "unavailable"
+        assert settings.resolve_rerank_backend() == "local"
+
+
+# -----------------------------------------------------------------------
 # Embedding model resolution
 # -----------------------------------------------------------------------
 

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -26,11 +26,15 @@ class TestRelaySchema:
 
     def test_schema_has_provider_and_chain_fields(self):
         fields = RELAY_SCHEMA["fields"]
-        # 3 model-chain tasks + 6 derived provider keys + ANTHROPIC + GITHUB_TOKEN
+        # 3 model-chain tasks + 1 search-chain + 11 password keys (9 derived
+        # model/search provider keys jina/gemini/openai/cohere/anthropic/xai/
+        # tavily/brave/exa + plain GITHUB_TOKEN + plain CAPSOLVER_API_KEY).
         chains = [f for f in fields if f.get("type") == "model-chain"]
+        search_chains = [f for f in fields if f.get("type") == "search-chain"]
         keys = [f for f in fields if f.get("type") == "password"]
         assert len(chains) == 3
-        assert len(keys) == 7
+        assert len(search_chains) == 1
+        assert len(keys) == 11
 
     def test_schema_field_keys(self):
         field_keys = [f["key"] for f in RELAY_SCHEMA["fields"]]

--- a/tests/test_search_backends.py
+++ b/tests/test_search_backends.py
@@ -5,9 +5,15 @@ import httpx
 import pytest
 
 from wet_mcp.sources.search_backends import (
+    BraveBackend,
+    ExaBackend,
     SearxngBackend,
     TavilyBackend,
+    _search_result_is_empty,
+    chain_backend_names,
+    run_search_chain,
     search_backend_from_env,
+    search_backends_from_env,
 )
 
 
@@ -49,20 +55,21 @@ def test_factory_tavily_requires_key(monkeypatch):
         search_backend_from_env()
 
 
-async def test_server_search_routes_through_backend(monkeypatch):
-    monkeypatch.setenv("SEARCH_BACKEND", "searxng")
-    fake = unittest.mock.AsyncMock()
-    fake.search = unittest.mock.AsyncMock(
-        return_value='{"results": [], "total": 0, "query": "q"}'
+async def test_server_search_routes_through_chain(monkeypatch):
+    # A non-searxng chain avoids the embedded SearXNG spawn; run_search_chain is
+    # the single integration point the server now calls.
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
+    fake_chain = unittest.mock.AsyncMock(
+        return_value='{"results": [{"url": "https://e/1", "title": "R1", "snippet": "s"}], "total": 1, "query": "q"}'
     )
     with unittest.mock.patch(
-        "wet_mcp.sources.search_backends.search_backend_from_env", return_value=fake
+        "wet_mcp.sources.search_backends.run_search_chain", fake_chain
     ):
         from wet_mcp.server import search
 
         result = await search(action="search", query="python tutorial", max_results=5)
         assert "results" in result
-        fake.search.assert_awaited()
+        fake_chain.assert_awaited()
 
 
 async def test_tavily_error_never_leaks_api_key():
@@ -79,14 +86,153 @@ async def test_tavily_error_never_leaks_api_key():
     assert "error" in json.loads(out)
 
 
-async def test_server_search_tavily_missing_key_returns_error(monkeypatch):
-    monkeypatch.setenv("SEARCH_BACKEND", "tavily")
+async def test_server_search_tavily_missing_key_degrades_gracefully(monkeypatch):
+    # New chain behaviour: a backend whose key is missing is SKIPPED; when the
+    # whole chain is empty the result is a clear (non-fatal) "missing API keys"
+    # envelope rather than the old hard "Error: TAVILY_API_KEY required".
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily")
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
     from wet_mcp.config import settings
 
     monkeypatch.setattr(settings, "tavily_api_key", "", raising=False)
+    monkeypatch.setattr(settings, "search_backends", "tavily", raising=False)
     from wet_mcp.server import search
 
+    # The search action wraps results in untrusted-content guards, so assert on
+    # substrings rather than parsing.
     result = await search(action="search", query="python tutorial")
-    assert result.startswith("Error")
-    assert "TAVILY_API_KEY" in result
+    assert "missing API keys" in result
+    assert "tavily" in result
+
+
+# ---------------------------------------------------------------------------
+# Brave + Exa backends
+# ---------------------------------------------------------------------------
+
+
+async def test_brave_maps_web_results():
+    with unittest.mock.patch("httpx.AsyncClient.get") as get:
+        resp = unittest.mock.AsyncMock()
+        resp.status_code = 200
+        resp.json = unittest.mock.Mock(
+            return_value={
+                "web": {
+                    "results": [
+                        {"url": "https://b/1", "title": "B1", "description": "d1"}
+                    ]
+                }
+            }
+        )
+        get.return_value = resp
+        out = json.loads(await BraveBackend("k").search("q", max_results=1))
+        assert out["total"] == 1
+        assert out["results"][0]["url"] == "https://b/1"
+        assert out["results"][0]["snippet"] == "d1"
+        assert out["results"][0]["source"] == "brave"
+
+
+async def test_brave_http_error_returns_error_json():
+    with unittest.mock.patch("httpx.AsyncClient.get") as get:
+        resp = unittest.mock.AsyncMock()
+        resp.status_code = 429
+        get.return_value = resp
+        assert "error" in json.loads(await BraveBackend("k").search("q"))
+
+
+async def test_brave_error_never_leaks_key():
+    secret = "brave-test-token-not-real"  # noqa: S105 - low-entropy fake for leak test
+    with unittest.mock.patch(
+        "httpx.AsyncClient.get",
+        side_effect=httpx.ConnectError(f"failed token={secret}"),
+    ):
+        out = await BraveBackend(secret).search("q")
+    assert secret not in out
+
+
+async def test_exa_maps_results_with_text_snippet():
+    with unittest.mock.patch("httpx.AsyncClient.post") as post:
+        resp = unittest.mock.AsyncMock()
+        resp.status_code = 200
+        resp.json = unittest.mock.Mock(
+            return_value={
+                "results": [{"url": "https://x/1", "title": "X1", "text": "y" * 500}]
+            }
+        )
+        post.return_value = resp
+        out = json.loads(await ExaBackend("k").search("q", max_results=1))
+        assert out["results"][0]["source"] == "exa"
+        assert len(out["results"][0]["snippet"]) == 300  # truncated
+
+
+# ---------------------------------------------------------------------------
+# Chain resolution + runtime fallback
+# ---------------------------------------------------------------------------
+
+
+def test_chain_backend_names_csv(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "searxng, tavily , brave")
+    assert chain_backend_names() == ["searxng", "tavily", "brave"]
+
+
+def test_chain_falls_back_to_single_backend(monkeypatch):
+    monkeypatch.delenv("SEARCH_BACKENDS", raising=False)
+    monkeypatch.setenv("SEARCH_BACKEND", "tavily")
+    monkeypatch.setenv("TAVILY_API_KEY", "k")
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "search_backends", "", raising=False)
+    assert chain_backend_names() == ["tavily"]
+
+
+def test_chain_skips_missing_key_backends(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "tavily,searxng")
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "search_backends", "tavily,searxng", raising=False)
+    monkeypatch.setattr(settings, "tavily_api_key", "", raising=False)
+    backends = search_backends_from_env()
+    # tavily skipped (no key); only searxng remains.
+    assert len(backends) == 1
+    assert isinstance(backends[0], SearxngBackend)
+
+
+def test_search_result_is_empty_predicate():
+    assert _search_result_is_empty('{"error": "boom"}') is True
+    assert _search_result_is_empty('{"results": []}') is True
+    assert _search_result_is_empty("not json") is True
+    assert _search_result_is_empty('{"results": [{"url": "x"}]}') is False
+
+
+async def test_run_search_chain_falls_back_on_empty(monkeypatch):
+    # First backend returns empty, second returns a hit -> second wins.
+    empty = unittest.mock.AsyncMock(
+        return_value='{"results": [], "total": 0, "query": "q"}'
+    )
+    hit = unittest.mock.AsyncMock(
+        return_value='{"results": [{"url": "https://h/1"}], "total": 1, "query": "q"}'
+    )
+    b0 = unittest.mock.Mock()
+    b0.search = empty
+    b1 = unittest.mock.Mock()
+    b1.search = hit
+    with unittest.mock.patch(
+        "wet_mcp.sources.search_backends.search_backends_from_env",
+        return_value=[b0, b1],
+    ):
+        out = json.loads(await run_search_chain("q"))
+        assert out["results"][0]["url"] == "https://h/1"
+        empty.assert_awaited()
+        hit.assert_awaited()
+
+
+async def test_run_search_chain_empty_when_no_backends(monkeypatch):
+    monkeypatch.setenv("SEARCH_BACKENDS", "brave")
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "search_backends", "brave", raising=False)
+    monkeypatch.setattr(settings, "brave_api_key", "", raising=False)
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    out = json.loads(await run_search_chain("q"))
+    assert out["results"] == []
+    assert "brave" in out["error"]

--- a/tests/test_searxng_runner.py
+++ b/tests/test_searxng_runner.py
@@ -15,8 +15,14 @@ from wet_mcp.searxng_runner import ensure_searxng, stop_searxng
 def mock_settings():
     with patch("wet_mcp.searxng_runner.settings") as mock:
         mock.wet_auto_searxng = True
+        mock.disable_local_search = False
         mock.searxng_url = "http://external:8080"
         mock.wet_searxng_port = 8080
+        # Reflect the real auto_searxng_enabled() logic against the mock fields
+        # (a bare MagicMock method would return a truthy Mock, defeating the test).
+        mock.auto_searxng_enabled.side_effect = lambda: (
+            mock.wet_auto_searxng and not mock.disable_local_search
+        )
         yield mock
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -173,7 +173,10 @@ async def test_search_success():
         patch("wet_mcp.sources.searxng.search", new_callable=AsyncMock) as mock_search,
     ):
         mock_ensure.return_value = "http://localhost:8080"
-        mock_search.return_value = "Search Results"
+        mock_search.return_value = (
+            '{"results": [{"url": "https://e", "title": "T", "snippet": "Search Results"}], '
+            '"total": 1, "query": "test query"}'
+        )
 
         result = await search(action="search", query="test query")
 
@@ -589,7 +592,10 @@ async def test_search_expand_flag():
         patch(
             "wet_mcp.sources.searxng.search",
             new_callable=AsyncMock,
-            return_value="Search Results",
+            return_value=(
+                '{"results": [{"url": "https://e", "title": "T", "snippet": "Search Results"}], '
+                '"total": 1, "query": "q"}'
+            ),
         ) as mock_search,
         patch(
             "wet_mcp.sources.search_strategies.expand_query",

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -228,7 +228,10 @@ async def test_search_tool_search():
         patch("wet_mcp.sources.searxng.search", new_callable=AsyncMock) as mock_search,
     ):
         mock_ensure.return_value = "http://searxng"
-        mock_search.return_value = "search_result"
+        mock_search.return_value = (
+            '{"results": [{"url": "https://e", "title": "T", "snippet": "search_result"}], '
+            '"total": 1, "query": "test"}'
+        )
         res = await server.search("search", query="test")
         assert "search_result" in res
 
@@ -898,6 +901,7 @@ async def test_lifespan_startup_sync_enabled():
     ):
         ms.setup_providers.return_value = "sdk"
         ms.wet_auto_searxng = False
+        ms.auto_searxng_enabled.return_value = False
         ms.wet_cache = False
         ms.sync_enabled = True
         ms.sync_s3_bucket = ""
@@ -931,6 +935,7 @@ async def test_lifespan_shutdown_sync_enabled():
     ):
         ms.setup_providers.return_value = "sdk"
         ms.wet_auto_searxng = False
+        ms.auto_searxng_enabled.return_value = False
         ms.wet_cache = False
         ms.sync_enabled = True
         ms.sync_s3_bucket = ""

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -92,13 +92,14 @@ async def test_lifespan_startup_no_github_token():
     ):
         cfg.setup_providers.return_value = "sdk"
         cfg.wet_auto_searxng = False
+        cfg.auto_searxng_enabled.return_value = False
         cfg.wet_cache = False
         cfg.sync_enabled = False
         cfg.sync_s3_bucket = ""
         cfg.resolve_embedding_dims.return_value = 768
         cfg.get_db_path.return_value = MagicMock()
         task = await server._lifespan_startup()
-        assert task is None  # wet_auto_searxng is False
+        assert task is None  # auto SearXNG disabled
 
 
 async def test_lifespan_startup_with_auto_searxng():
@@ -117,6 +118,7 @@ async def test_lifespan_startup_with_auto_searxng():
     ):
         cfg.setup_providers.return_value = "sdk"
         cfg.wet_auto_searxng = True
+        cfg.auto_searxng_enabled.return_value = True
         cfg.wet_cache = False
         cfg.sync_enabled = False
         cfg.sync_s3_bucket = ""
@@ -150,6 +152,7 @@ async def test_lifespan_startup_backends_init_failure():
     ):
         cfg.setup_providers.return_value = "sdk"
         cfg.wet_auto_searxng = False
+        cfg.auto_searxng_enabled.return_value = False
         cfg.wet_cache = False
         cfg.sync_enabled = False
         cfg.sync_s3_bucket = ""
@@ -176,6 +179,7 @@ async def test_lifespan_startup_sync_enabled():
     ):
         cfg.setup_providers.return_value = "sdk"
         cfg.wet_auto_searxng = False
+        cfg.auto_searxng_enabled.return_value = False
         cfg.wet_cache = False
         cfg.sync_enabled = True
         cfg.sync_s3_bucket = ""

--- a/tests/test_transport_check.py
+++ b/tests/test_transport_check.py
@@ -219,7 +219,10 @@ async def test_search_action_proceeds_when_not_uvx(monkeypatch):
         patch("wet_mcp.sources.searxng.search", new_callable=AsyncMock) as mock_search,
     ):
         mock_ensure.return_value = "http://localhost:8080"
-        mock_search.return_value = "Search Results"
+        mock_search.return_value = (
+            '{"results": [{"url": "https://e", "title": "T", "snippet": "Search Results"}], '
+            '"total": 1, "query": "hello world"}'
+        )
 
         result = await srv.search(action="search", query="hello world")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b12"
+version = "1.18.0b13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1806,9 +1806,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/93/7bacfbaeaf6805fad2f4883ffb2f9aba4c2f147eb0d2d4d3d2d423733836/n24q02m_mcp_core-1.18.0b12.tar.gz", hash = "sha256:b8dffee8d18468a0ded29d7aa0eccb6af5daed62fd1ef96f8833787cbca2eb03", size = 287572, upload-time = "2026-06-18T12:36:36.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/de/63e21abb61c6463bf9ef5700b96f97c41755272154eac550cbf9eb0283f3/n24q02m_mcp_core-1.18.0b13.tar.gz", hash = "sha256:d8d56e7bbc89305e86ba3d5a61f3ae269063ec7f533a3b76e761dc36b7dc196b", size = 292494, upload-time = "2026-06-19T07:03:07.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/98/cdf75f3d9cf5eec197384d0b5c8e0e237ac2bc03d2685f64c4e881414006/n24q02m_mcp_core-1.18.0b12-py3-none-any.whl", hash = "sha256:f87d26b576836d406fbdd43d3f6c5a398a6cd721d7db5dd51eeabe6cbe8917fc", size = 158657, upload-time = "2026-06-18T12:36:37.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ac/97a7befbeb87e04a10c673468fff7cd02909914209cd2dee5571f000da25/n24q02m_mcp_core-1.18.0b13-py3-none-any.whl", hash = "sha256:7ca71aa27a01eb6e44e3144346c6fddaae980f092a106e440aa30cf22e5a8439", size = 161881, upload-time = "2026-06-19T07:03:06.06Z" },
 ]
 
 [package.optional-dependencies]
@@ -1818,7 +1818,7 @@ llm = [
 
 [[package]]
 name = "n24q02m-web-core"
-version = "2.2.1"
+version = "2.3.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "browserforge" },
@@ -1832,9 +1832,9 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/79/50147e7b007743dcb3f21edd8f651421ac56edd8b37638bf3f6ad26bc02c/n24q02m_web_core-2.2.1.tar.gz", hash = "sha256:5db321a1928a708f063869f9ac4d4d0c0b66186056897234721843c1dcdd248e", size = 230971, upload-time = "2026-06-09T02:53:35.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/f9/8b6658a07414c2ec5716cd2e3a8ee1f96e72b066162107fa9ae75ed9911d/n24q02m_web_core-2.3.0b1.tar.gz", hash = "sha256:e0f6736f6b09e2e08992e22488b80c21221abe3e2a6f75bd36686782fdf31167", size = 245769, upload-time = "2026-06-19T07:03:41.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/72/5bf251ef3925190ae9e2940423cfc01bc1e9f5ecc2bff83d88a956864c7e/n24q02m_web_core-2.2.1-py3-none-any.whl", hash = "sha256:0182ec9d06504e8bc974903166d1d435c2cd222f614641ad563e7a53382d1ef4", size = 60577, upload-time = "2026-06-09T02:53:34.206Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4f/9bf9d9fb71ba7a02d90b0c24347f708ecc8dc6304e3b128b2174fa7986ce/n24q02m_web_core-2.3.0b1-py3-none-any.whl", hash = "sha256:b675060a90198552126743bf3cbfb93d725b541912cf8d1a120adee08fc64ae4", size = 67209, upload-time = "2026-06-19T07:03:40.767Z" },
 ]
 
 [[package]]
@@ -3521,8 +3521,8 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b12,<2" },
-    { name = "n24q02m-web-core", specifier = ">=2.2.1,<2.3" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b13,<2" },
+    { name = "n24q02m-web-core", specifier = ">=2.3.0b1,<3" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },


### PR DESCRIPTION
WS-3 search chain (brave/exa + runtime fallback + DISABLE_LOCAL_SEARCH + relay widget), WS-2 browser backend chain (CF/browserless + DISABLE_LOCAL_BROWSER), WS-4 key-gated CapSolver tier, WS-5 DISABLE_LOCAL_EMBED/_RERANK via mcp_core.chains. Bumps web-core 2.3.0b1 + mcp-core 1.18.0b13.