### PR TITLE
feat: forward capability-chain env vars into the CF container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ htmlcov/
 *.bak
 /*.patch
 /*.diff
+
+# CF deploy config with real resource IDs (never commit)
+wrangler.deploy.jsonc

--- a/docs/cf-deploy.md
+++ b/docs/cf-deploy.md
@@ -1,0 +1,121 @@
+# Cloudflare deploy runbook (MCP servers)
+
+Canonical, repeatable procedure to (re)deploy an MCP server's Cloudflare
+Worker + Container. Covers the 6 CF-migrated servers: `wet`, `mnemo`, `imagine`,
+`better-telegram`, `better-email`, `better-notion`. Companion to
+[`cf-template.md`](./cf-template.md) (the worker code template + footguns).
+
+> Real account/KV/D1/Vectorize IDs live ONLY in each repo's gitignored
+> `wrangler.deploy.jsonc`. This doc uses `<account-id>` / `<...-id>` placeholders.
+
+## Topology
+
+| Domain shape | What it is | Caddy? |
+|---|---|---|
+| `wet.n24q02m.com` (short) | **CF Worker** (migration target) | no |
+| `wet-mcp.n24q02m.com` (full repo name) | OCI legacy (CF Tunnel -> Caddy -> Docker), fallback | yes (`via: 1.1 Caddy` header) |
+
+Each server is a Worker + per-`sub` Container Durable Object. State is
+externalised so the container survives scale-to-zero / delete+recreate:
+
+| concern | backend | env |
+|---|---|---|
+| creds + OAuth tokens | KV (`PerPluginStore` cf-kv) | `MCP_STORAGE_BACKEND=cf-kv`, `MCP_KV_BASE_URL=http://kv.internal` |
+| memories / docs (mnemo, wet) | D1 | `DOCS_DB_BACKEND=cf-d1`, `MCP_D1_BASE_URL=http://d1.internal` |
+| embedding vectors (mnemo, wet) | Vectorize | `MCP_VECTORIZE_BASE_URL=http://vectorize.internal`, `MCP_VECTORIZE_IDX` |
+
+Two auth gates, both enforced (never disabled on shared infra):
+- **Gate A** — relay password (`MCP_RELAY_PASSWORD`, skret `/oci-vm-prod/prod`); `/authorize` -> `/login`.
+- **Gate B** — DCR + PKCE bearer (`/mcp` -> 401 without a token).
+
+## Prerequisites
+
+- **CF token** — skret `/n24q02m/dev` `CF_DEV_TOKEN` (account-scoped: workers
+  scripts/containers/KV ok; canNOT edit zone DNS/routes). Inject, never print:
+  ```bash
+  MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- bash -c \
+    'export CLOUDFLARE_API_TOKEN="$CF_DEV_TOKEN"; <cmd>'
+  ```
+- `docker`, and `bunx wrangler` (downloaded on demand; works in Python repos too).
+- **`wrangler.deploy.jsonc`** — gitignored copy of the committed placeholder
+  `wrangler.jsonc` with real IDs filled. If missing, reconstruct from
+  `wrangler.jsonc` + CF-queried IDs (`wrangler kv namespace list`,
+  `wrangler d1 list`, `wrangler vectorize list`). NO `routes` block (custom
+  domains are already attached); set `"workers_dev": false`. TS servers also
+  need `HOST=0.0.0.0` + `PORT=8080` (core-ts binds 127.0.0.1 by default, so the
+  container is otherwise unreachable).
+
+## Deploy (one command)
+
+```bash
+MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- bash -c \
+  'export CLOUDFLARE_API_TOKEN="$CF_DEV_TOKEN"; python scripts/deploy_cf.py'
+```
+
+`scripts/deploy_cf.py` runs: `docker build --target http` -> tag to
+`registry.cloudflare.com/<account-id>/<name>:<tag>` -> `wrangler containers push`
+-> `wrangler deploy --config wrangler.deploy.jsonc` -> **poll until rollout
+completes**. Flags: `--tag <tag>` (default `b-<short-sha>`), `--skip-build`,
+`--dry-run`. The CF container registry only pulls from
+`registry.cloudflare.com` (an external ghcr ref fails
+`IMAGE_REGISTRY_NOT_CONFIGURED`), hence the tag-then-push step.
+
+### Pinning mcp-core before a deploy
+
+The container bakes `n24q02m-mcp-core` via `uv sync --frozen` (Python) /
+`bun install` (TS), reading the **lockfile** — so a code fix in mcp-core only
+reaches the container after bumping the pin and rebuilding:
+
+```bash
+# Python (wet, mnemo, imagine)
+UV_NO_SOURCES=1 uv lock --upgrade-package n24q02m-mcp-core
+# TS (telegram, email, notion)
+bun update @n24q02m/mcp-core      # after setting ^<ver> in package.json
+```
+
+Pin to an ALREADY-PUBLISHED version (PSR generates it on mcp-core CD); never
+hand-pick a version string. A STABLE mcp-core release auto-files "bump" issues
+downstream; a BETA does not, so bump manually for betas.
+
+## Rollout wait (critical)
+
+`wrangler deploy` only registers the new image (application STATE ->
+`provisioning`). The running Durable Object instances keep serving the **OLD**
+image until recycled — slow for a heavy image (wet ~6GB). **Verify only after
+`wrangler containers list` shows STATE=`ready`**, and do NOT load-test during
+`provisioning` (sustained load pins old instances and delays the roll). A steady
+(non-decaying) failure rate that matches an already-fixed bug = old instances
+still serving, not a re-regression; confirm by grepping the fix inside the built
+image (`docker run --rm --entrypoint sh <img> -c 'grep ... $(find / -name <file>)'`).
+`deploy_cf.py` waits automatically.
+
+## Verify
+
+Protocol self-test (PRIMARY), not the CC harness:
+
+```bash
+MSYS_NO_PATHCONV=1 skret run -e prod --path=/oci-vm-prod/prod -- \
+  skret run -e prod --path=/<server>/prod -- \
+  uv run --no-project --with mcp --with httpx --with anyio \
+  python scripts/cf_full_flow.py --endpoint https://<server>.n24q02m.com
+```
+
+- `mnemo` harness is `scripts/cf_full_flow_mnemo.py`; `notion` is delegated
+  Notion OAuth (`bootstrap` -> user approves -> `exchange --landing "<url>"`).
+- Invalid-sub regression check (no-retry, counts `_`-subs that save): the generic
+  `~/.cf-verify/check.py` mints N subs and asserts `INVALID_SUB=0`.
+
+## Per-server map
+
+| Server | Worker / DO | Backends | Notable vars |
+|---|---|---|---|
+| wet | `wet-mcp-worker` / `WetContainer` | KV + D1 + Vectorize | `SEARCH_BACKEND`, `EMBEDDING/RERANK/LLM_MODELS` |
+| mnemo | `mnemo-mcp-worker` / `MnemoContainer` | KV + D1 + Vectorize | `EMBEDDING_DIMS=768`, model chains |
+| imagine | `imagine-mcp-worker` / `ImagineContainer` | KV | `IMAGINE_OUTPUT_MODE=base64` |
+| telegram | `better-telegram-mcp-worker` / `TelegramContainer` | KV | `HOST=0.0.0.0`, `PORT=8080` |
+| email | `better-email-mcp-worker` / `EmailContainer` | KV | `HOST=0.0.0.0`, `PORT=8080` |
+| notion | `better-notion-mcp-worker` / `NotionContainer` | KV | `HOST=0.0.0.0`, `PORT=8080`, delegated OAuth |
+
+Per-server secrets: `wrangler secret put` for `CREDENTIAL_SECRET`,
+`MCP_RELAY_PASSWORD`, `MCP_DCR_SERVER_SECRET`, plus provider/OAuth keys. These
+are NOT in `wrangler.deploy.jsonc` (only non-secret `vars` are).

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -1,0 +1,358 @@
+"""CF wet-mcp live OAuth full-flow self-test harness.
+
+Drives the deployed wet-mcp Cloudflare Worker (Worker + per-sub Container + KV +
+D1 + Vectorize) end-to-end against a public endpoint. wet is a LOCAL-FORM server
+(like mnemo/imagine/email, NOT delegated like notion): the /authorize gate is just
+the relay password, so the whole flow is fully autonomous -- no third-party consent.
+
+Flow (authorization_code + PKCE, DCR public client; ported verbatim from the
+mnemo/imagine/email CF harnesses):
+  1. DCR register   -- POST /register (RFC 7591) -> client_id
+  2. password-grant -- GET /authorize -> POST /login (Gate A relay password) -> form
+  3. save creds     -- POST /authorize?nonce=... {provider key} (retry-on-500 for the
+                       E.1 outbound-interception race). wet's _require_credentials()
+                       gates every tool on the per-sub vault holding >=1 provider key
+                       (JINA/GEMINI/OPENAI/COHERE); it does NOT read the server-side
+                       forwarded JINA from os.environ, so a real user must submit one.
+                       The harness submits whatever key skret /wet-mcp/prod injects.
+  4. token          -- POST /token (code + verifier) -> bearer JWT
+  5. tool call      -- config(status) + search(action="search"); assert the search
+                       path resolves real results (URLs) over the CF deployment.
+
+Secrets from env: Gate A login password MCP_RELAY_PASSWORD (or RELAY_PW) from skret
+/oci-vm-prod/prod (infra-shared); >=1 provider key (JINA_AI_API_KEY preferred) from
+skret /wet-mcp/prod -- compose both namespaces.
+
+Run modes:
+  (default)            full flow: config(status) + search, assert real results.
+  --save-only          configure one sub (submit provider key) + dump the token
+                       (recreate-gate setup half of the state-survives-recreate test).
+  --auth-only          replay the SAME token (same sub) and search again WITHOUT
+                       re-saving (recreate-gate verify: the sub vault survived KV).
+  --two-sub-isolation  two distinct subs; assert each authorizes to a distinct sub
+                       (the relay-login mints a fresh random sub per /authorize).
+
+Examples:
+  skret run -e prod --path=/oci-vm-prod/prod -- \
+    skret run -e prod --path=/wet-mcp/prod -- \
+      python scripts/cf_full_flow.py
+  ... -- python scripts/cf_full_flow.py --endpoint https://wet.n24q02m.com
+  ... -- python scripts/cf_full_flow.py --save-only
+  ... -- python scripts/cf_full_flow.py --auth-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json as _json
+import os
+import re
+import secrets
+import sys
+import time
+import urllib.parse
+from pathlib import Path
+
+DEFAULT_ENDPOINT = "https://wet.n24q02m.com"
+
+# A distinctive query so the search path is exercised against the live web backend.
+SEARCH_QUERY = "cloudflare workers durable objects"
+
+
+def _password() -> str:
+    pw = os.environ.get("RELAY_PW") or os.environ.get("MCP_RELAY_PASSWORD")
+    if not pw:
+        raise SystemExit(
+            "MCP_RELAY_PASSWORD (or RELAY_PW) is required for the password-grant "
+            "login gate. It lives in skret /oci-vm-prod/prod (infra-shared), NOT "
+            "/wet-mcp/prod -- compose both namespaces."
+        )
+    return pw
+
+
+def _creds() -> dict[str, str]:
+    """Per-sub credential form payload. wet's `_require_credentials()` gates every
+    tool on the per-sub vault holding at least one provider key (JINA / GEMINI /
+    OPENAI / COHERE) -- it does NOT read the server-side forwarded JINA from
+    os.environ. So a real user must submit a key; the harness submits whichever
+    provider key skret /wet-mcp/prod injects (JINA preferred)."""
+    creds: dict[str, str] = {}
+    for env_name in (
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "COHERE_API_KEY",
+        "XAI_API_KEY",
+    ):
+        v = os.environ.get(env_name)
+        if v:
+            creds[env_name] = v
+    if not creds:
+        raise SystemExit(
+            "No provider key in env (JINA_AI_API_KEY / GEMINI_API_KEY / "
+            "OPENAI_API_KEY / COHERE_API_KEY). skret /wet-mcp/prod injects them; "
+            "wet's per-sub gate requires at least one to authorize tool calls."
+        )
+    return creds
+
+
+class _SaveRetry(Exception):
+    pass
+
+
+def get_token(endpoint: str, creds: dict[str, str], *, save_retries: int = 8) -> str:
+    """Run the full OAuth flow, retrying on a transient 500 at the credential save
+    step (CF Containers outbound-interception race on cold-started instances; E.1).
+    Each retry restarts from DCR so the nonce is fresh. ``creds`` is the /authorize
+    form payload (EMPTY for wet: search/extract + embed are server-side)."""
+    import httpx  # lazy: keep --help importable without httpx installed
+
+    last: Exception | None = None
+    for attempt in range(save_retries):
+        try:
+            return _get_token_once(httpx, endpoint, creds)
+        except _SaveRetry as e:
+            last = e
+            print(
+                f"get_token: save 500 (interception race), retry {attempt + 1}/{save_retries}"
+            )
+            time.sleep(3)
+    raise RuntimeError(f"get_token failed after {save_retries} retries: {last}")
+
+
+def _get_token_once(httpx, endpoint: str, creds: dict[str, str]) -> str:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    ru = "http://localhost:9999/cb"
+    pw = _password()
+    with httpx.Client(timeout=120, follow_redirects=False) as c:
+        cid = c.post(
+            f"{endpoint}/register",
+            json={
+                "client_name": "cf-verify",
+                "redirect_uris": [ru],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+                "scope": "offline_access",
+            },
+        ).json()["client_id"]
+        az = c.get(
+            f"{endpoint}/authorize",
+            params={
+                "response_type": "code",
+                "client_id": cid,
+                "redirect_uri": ru,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": "st",
+                "scope": "offline_access",
+            },
+        )
+        nxt = urllib.parse.parse_qs(
+            urllib.parse.urlparse(az.headers["location"]).query
+        )["next"][0]
+        lg = c.post(f"{endpoint}/login", data={"next": nxt, "password": pw})
+        url = lg.headers["location"]
+        url = url if url.startswith("http") else endpoint + url
+        form_html = c.get(url).text
+        m = re.search(r"/authorize\?nonce=([A-Za-z0-9_\-]+)", form_html)
+        assert m, "nonce not found in form"
+        nonce = m.group(1)
+        sub = c.post(f"{endpoint}/authorize", params={"nonce": nonce}, json=creds)
+        if sub.status_code == 500 and "save credentials" in sub.text:
+            raise _SaveRetry(sub.text[:120])
+        assert sub.status_code == 200, (sub.status_code, sub.text[:300])
+        data = sub.json()
+        assert data.get("ok"), data
+        code = urllib.parse.parse_qs(urllib.parse.urlparse(data["redirect_url"]).query)[
+            "code"
+        ][0]
+        tok = c.post(
+            f"{endpoint}/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": ru,
+                "client_id": cid,
+                "code_verifier": verifier,
+            },
+        )
+        assert tok.status_code == 200, (tok.status_code, tok.text[:300])
+        return tok.json()["access_token"]
+
+
+def _sub_of(token: str) -> str:
+    payload = _json.loads(base64.urlsafe_b64decode(token.split(".")[1] + "=="))
+    return payload.get("sub", "?")
+
+
+async def _call(s, label, tool, args, *, retries=20, delay=8):
+    """Call a tool, retrying while the sub is still propagating (KV cross-colo
+    eventual consistency after the setup write; E.2). Returns the concatenated
+    text payload, or None on give-up."""
+    for i in range(retries):
+        try:
+            res = await s.call_tool(tool, args)
+            txt = "".join(getattr(b, "text", "") for b in res.content)
+            if "awaiting_setup" in txt or "Credentials not configured" in txt:
+                print(f"{label}: awaiting_setup (KV propagating) try {i + 1}/{retries}")
+                await asyncio.sleep(delay)
+                continue
+            print(f"{label} OK:", txt[:320].replace("\n", " "))
+            return txt
+        except Exception as e:
+            print(f"{label} ERR:", repr(e)[:300])
+            return None
+    print(f"{label}: gave up after {retries} tries")
+    return None
+
+
+def _assert_search_resolved(txt: str | None) -> None:
+    """A real search result is a JSON listing with at least one http(s) URL and no
+    hard error. A backend-misconfig (SearXNG vs Tavily) surfaces as an error string
+    here -- that is a genuine CF-deployment finding, not a test bug."""
+    assert txt is not None, "search returned no payload (gave up while not ready)"
+    low = txt.lower()
+    assert not low.startswith("error"), f"search returned an error: {txt[:300]}"
+    assert "http" in low, f"search did not return any URL result: {txt[:300]}"
+    print("ASSERT OK: search resolved real web results over the CF deployment.")
+
+
+async def _session(endpoint: str, token: str):
+    from mcp import ClientSession  # lazy: keep --help importable without mcp installed
+    from mcp.client.streamable_http import streamablehttp_client
+
+    return streamablehttp_client(
+        f"{endpoint}/mcp", headers={"Authorization": f"Bearer {token}"}
+    ), ClientSession
+
+
+async def _run_search(s) -> str | None:
+    return await _call(
+        s,
+        "SEARCH",
+        "search",
+        {"action": "search", "query": SEARCH_QUERY, "max_results": 3},
+    )
+
+
+def _token_file() -> Path:
+    return Path(__file__).with_name(".wet_cf_token")
+
+
+async def run_full(endpoint: str) -> None:
+    token = get_token(endpoint, _creds())
+    print("TOKEN OK len=", len(token), "sub=", _sub_of(token))
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        tools = await s.list_tools()
+        print("TOOLS:", [t.name for t in tools.tools])
+        await _call(s, "CONFIG_STATUS", "config", {"action": "status"})
+        txt = await _run_search(s)
+        _assert_search_resolved(txt)
+    print("FULL FLOW PASS.")
+
+
+async def run_save_only(endpoint: str) -> None:
+    token = get_token(endpoint, _creds())
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        await _call(s, "CONFIG_STATUS", "config", {"action": "status"})
+    # Dump the EXACT token so --auth-only replays the SAME JWT sub (relay-login mints
+    # a fresh random sub per /authorize).
+    _token_file().write_text(token)
+    print(
+        "SAVE-ONLY OK: sub configured=",
+        _sub_of(token),
+        "(token dumped for --auth-only)",
+    )
+
+
+async def run_auth_only(endpoint: str) -> None:
+    tok_path = _token_file()
+    if not tok_path.exists():
+        raise SystemExit("No dumped token -- run --save-only first.")
+    token = tok_path.read_text().strip()
+    print("AUTH-ONLY: replaying saved token for sub=", _sub_of(token))
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        txt = await _run_search(s)
+        _assert_search_resolved(txt)
+    print("AUTH-ONLY PASS: sub survived recreate (KV vault resolved, no re-save).")
+
+
+async def run_two_sub_isolation(endpoint: str) -> None:
+    token_a = get_token(endpoint, _creds())
+    sub_a = _sub_of(token_a)
+    token_b = get_token(endpoint, _creds())
+    sub_b = _sub_of(token_b)
+    print(f"sub A={sub_a}  sub B={sub_b}")
+    if sub_a == sub_b:
+        raise SystemExit(
+            f"ISOLATION INCONCLUSIVE: both flows share sub {sub_a} (cannot test bleed)."
+        )
+    transport, ClientSession = await _session(endpoint, token_b)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        txt = await _run_search(s)
+        _assert_search_resolved(txt)
+    print(
+        "TWO-SUB ISOLATION OK: distinct subs, sub B authorizes + searches independently."
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="CF wet-mcp live OAuth full-flow self-test harness.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--endpoint",
+        default=DEFAULT_ENDPOINT,
+        help=f"Deployed wet endpoint (default: {DEFAULT_ENDPOINT})",
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--save-only",
+        action="store_true",
+        help="Configure one sub (empty form) + dump the token, then exit (recreate setup).",
+    )
+    mode.add_argument(
+        "--auth-only",
+        action="store_true",
+        help="Replay the SAME token + search WITHOUT re-saving (recreate verify).",
+    )
+    mode.add_argument(
+        "--two-sub-isolation",
+        action="store_true",
+        help="Two distinct subs; assert sub B authorizes + searches independently.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.save_only:
+        asyncio.run(run_save_only(args.endpoint))
+    elif args.auth_only:
+        asyncio.run(run_auth_only(args.endpoint))
+    elif args.two_sub_isolation:
+        asyncio.run(run_two_sub_isolation(args.endpoint))
+    else:
+        asyncio.run(run_full(args.endpoint))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Build + push + deploy this MCP server's Cloudflare Worker+Container.
+
+Turns the manual CF redeploy recipe into one repeatable command. Reads the
+gitignored ``wrangler.deploy.jsonc`` (real account/KV/D1/Vectorize IDs) for the
+container image name + account, builds the ``http`` target, pushes to the CF
+managed registry, deploys, and waits for the container rollout to finish
+(STATE=ready) so you never verify against a half-rolled old image.
+
+Run from the repo root, with the CF dev token injected by skret:
+
+    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- \\
+        python scripts/deploy_cf.py            # tag defaults to b-<short-sha>
+    ... python scripts/deploy_cf.py --tag b10-abc1234   # explicit tag
+    ... python scripts/deploy_cf.py --skip-build         # reuse a built image
+    ... python scripts/deploy_cf.py --dry-run            # print the plan only
+
+Requires: CLOUDFLARE_API_TOKEN in env (skret /n24q02m/dev CF_DEV_TOKEN ->
+export CLOUDFLARE_API_TOKEN), docker, and ``bunx wrangler``. The CF container
+registry only pulls from registry.cloudflare.com/<account>/... (not ghcr), so the
+local image is tagged to that path before ``wrangler containers push``.
+
+Why the rollout wait: a heavy image (wet ~6GB) keeps serving OLD Durable Object
+instances for minutes after deploy (``containers list`` STATE=provisioning);
+verifying during that window shows stale behaviour. See docs/cf-deploy.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEPLOY_CONFIG = "wrangler.deploy.jsonc"
+
+
+def _strip_jsonc(text: str) -> str:
+    """Strip full-line // comments + trailing commas so json.loads accepts our
+    deploy.jsonc. Inline // after values is intentionally NOT stripped (would
+    corrupt https:// URLs); our deploy.jsonc keeps comments on their own lines."""
+    lines = [ln for ln in text.splitlines() if not re.match(r"\s*//", ln)]
+    body = "\n".join(lines)
+    body = re.sub(r",(\s*[}\]])", r"\1", body)  # trailing commas
+    return body
+
+
+def _load_deploy_config(repo: Path) -> dict:
+    path = repo / DEPLOY_CONFIG
+    if not path.exists():
+        sys.exit(
+            f"{DEPLOY_CONFIG} not found in {repo}. It is gitignored (real IDs); "
+            "reconstruct it from the committed wrangler.jsonc + CF resource IDs first."
+        )
+    return json.loads(_strip_jsonc(path.read_text(encoding="utf-8")))
+
+
+def _short_sha(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _run(cmd: list[str], *, dry: bool, cwd: Path | None = None) -> None:
+    print(f"  $ {' '.join(cmd)}")
+    if dry:
+        return
+    subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True)
+
+
+def _image_parts(cfg: dict) -> tuple[str, str, str]:
+    """Return (registry_base_without_tag, account_id, image_name) from the
+    deploy config's first container image ref
+    registry.cloudflare.com/<account>/<name>:<tag>."""
+    ref = cfg["containers"][0]["image"]
+    base = ref.rsplit(":", 1)[0]  # drop existing tag
+    m = re.match(r"registry\.cloudflare\.com/([0-9a-f]+)/(.+)$", base)
+    if not m:
+        sys.exit(
+            f"unexpected image ref (need registry.cloudflare.com/<acct>/<name>): {ref}"
+        )
+    return base, m.group(1), m.group(2)
+
+
+def _set_image_tag(repo: Path, full_ref: str) -> None:
+    """Rewrite the deploy.jsonc image line in place so `wrangler deploy` ships the
+    tag we just pushed (gitignored file, safe to edit)."""
+    path = repo / DEPLOY_CONFIG
+    text = path.read_text(encoding="utf-8")
+    new = re.sub(
+        r'("image":\s*")registry\.cloudflare\.com/[^"]+(")',
+        rf"\g<1>{full_ref}\g<2>",
+        text,
+        count=1,
+    )
+    path.write_text(new, encoding="utf-8")
+
+
+def _wait_ready(worker: str, *, dry: bool, timeout_s: int = 600) -> None:
+    """Poll `wrangler containers list` until the worker leaves provisioning."""
+    if dry:
+        print(f"  (dry-run) would poll containers list until {worker} STATE=ready")
+        return
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        out = subprocess.run(
+            ["bunx", "wrangler", "containers", "list"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        line = next((ln for ln in out.splitlines() if worker in ln), "")
+        print(f"  [rollout] {line.strip() or '(no row yet)'}")
+        if line and "provisioning" not in line.lower():
+            print(f"  rollout complete: {worker} is no longer provisioning.")
+            return
+        time.sleep(25)
+    print(f"  WARNING: {worker} still provisioning after {timeout_s}s — verify later.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Deploy this MCP server's CF Worker+Container."
+    )
+    p.add_argument("--tag", default="", help="image tag (default: b-<short-sha>)")
+    p.add_argument(
+        "--skip-build", action="store_true", help="reuse an already-built local image"
+    )
+    p.add_argument("--dry-run", action="store_true", help="print the plan, run nothing")
+    args = p.parse_args(argv)
+
+    repo = Path(__file__).resolve().parent.parent
+    cfg = _load_deploy_config(repo)
+    worker = cfg["name"]
+    base, account, name = _image_parts(cfg)
+    tag = args.tag or f"b-{_short_sha(repo)}"
+    local = f"{name}:{tag}"
+    full = f"{base}:{tag}"
+
+    print(f"Deploy {worker}: image {local} -> {full}")
+    if not args.skip_build:
+        print("[1/4] docker build --target http")
+        _run(
+            ["docker", "build", "--target", "http", "-t", local, "."],
+            dry=args.dry_run,
+            cwd=repo,
+        )
+    print("[2/4] docker tag -> CF registry")
+    _run(["docker", "tag", local, full], dry=args.dry_run)
+    print("[3/4] wrangler containers push")
+    _run(["bunx", "wrangler", "containers", "push", full], dry=args.dry_run, cwd=repo)
+    print(f"[4/4] wrangler deploy --config {DEPLOY_CONFIG}")
+    if not args.dry_run:
+        _set_image_tag(repo, full)
+    _run(
+        ["bunx", "wrangler", "deploy", "--config", DEPLOY_CONFIG],
+        dry=args.dry_run,
+        cwd=repo,
+    )
+
+    print("Waiting for container rollout (avoid verifying a half-rolled old image)...")
+    _wait_ready(worker, dry=args.dry_run)
+    print(
+        f"DONE: {worker} deployed at tag {tag}. Verify with scripts/cf_full_flow*.py."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -26,6 +26,17 @@ class DocsDBCfBackend:
         self._vec = vectorize
         self._embedding_dims = embedding_dims
 
+    def stats(self) -> dict:
+        """Return database statistics. Mirrors wet_mcp.db.DocsDB.stats over D1 so
+        config(action="status") is polymorphic across the SQLite and CF backends."""
+        lib_row = self._d1.fetchone("SELECT COUNT(*) AS n FROM libraries", [])
+        chunk_row = self._d1.fetchone("SELECT COUNT(*) AS n FROM doc_chunks", [])
+        return {
+            "libraries": (lib_row or {}).get("n", 0),
+            "chunks": (chunk_row or {}).get("n", 0),
+            "vec_enabled": self._vec is not None,
+        }
+
     # --- relational CRUD (parameterized D1) ---
 
     def upsert_library(self, name: str, docs_url: str | None = None, **extra) -> str:

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,6 +53,20 @@ export interface Env {
   // search secrets — exactly one set depending on SEARCH_BACKEND
   SEARXNG_URL?: string
   TAVILY_API_KEY?: string
+  // Capability provider chains (search/browser) + per-task disable-local toggles.
+  SEARCH_BACKENDS?: string
+  BRAVE_API_KEY?: string
+  EXA_API_KEY?: string
+  BROWSER_BACKENDS?: string
+  CF_ACCOUNT_ID?: string
+  CF_BROWSER_RENDERING_TOKEN?: string
+  BROWSERLESS_URL?: string
+  BROWSERLESS_TOKEN?: string
+  CAPSOLVER_API_KEY?: string
+  DISABLE_LOCAL_EMBED?: string
+  DISABLE_LOCAL_RERANK?: string
+  DISABLE_LOCAL_SEARCH?: string
+  DISABLE_LOCAL_BROWSER?: string
 }
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the container
@@ -66,6 +80,12 @@ const CONTAINER_ENV_KEYS = [
   'PUBLIC_URL', 'CREDENTIAL_SECRET', 'JINA_AI_API_KEY',
   'GOOGLE_VERTEX_EXPRESS_API_KEY', 'XAI_API_KEY',
   'MCP_RELAY_PASSWORD', 'MCP_DCR_SERVER_SECRET',
+  // capability provider chains + disable-local toggles (WS-2/3/4/5)
+  'SEARCH_BACKENDS', 'BRAVE_API_KEY', 'EXA_API_KEY',
+  'BROWSER_BACKENDS', 'CF_ACCOUNT_ID', 'CF_BROWSER_RENDERING_TOKEN',
+  'BROWSERLESS_URL', 'BROWSERLESS_TOKEN', 'CAPSOLVER_API_KEY',
+  'DISABLE_LOCAL_EMBED', 'DISABLE_LOCAL_RERANK',
+  'DISABLE_LOCAL_SEARCH', 'DISABLE_LOCAL_BROWSER',
 ] as const
 
 function pickContainerEnv(env: Env): Record<string, string> {

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -43,6 +43,37 @@ def test_add_chunks_then_fts_search():
     assert results[0]["url"] == "https://a/p1"
 
 
+def test_stats_reports_counts():
+    # config(action="status") calls _docs_db.stats(); the CF backend must expose it
+    # (regression: wet CF config(status) crashed with "'DocsDBCfBackend' object has no
+    # attribute 'stats'", 2026-06-17).
+    db = _backend()
+    assert db.stats() == {"libraries": 0, "chunks": 0, "vec_enabled": True}
+    db.upsert_library("alpha", docs_url="https://a")
+    lib = db.get_library("alpha")
+    db.upsert_version(lib["id"], "1.0")
+    ver = db.get_best_version(lib["id"], "1.0")
+    db.add_chunks(
+        ver["id"],
+        lib["id"],
+        [
+            {
+                "id": "c1",
+                "url": "https://a/p1",
+                "title": "API",
+                "chunk_index": 0,
+                "content": "hello world",
+                "heading_path": "API",
+            },
+        ],
+        embeddings=None,
+    )
+    s = db.stats()
+    assert s["libraries"] == 1
+    assert s["chunks"] == 1
+    assert s["vec_enabled"] is True
+
+
 def test_hybrid_search_applies_rrf_and_url_diversity():
     db = _backend()
     db.upsert_library("alpha", docs_url="https://a")

--- a/uv.lock
+++ b/uv.lock
@@ -1813,7 +1813,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b6"
+version = "1.18.0b10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1828,9 +1828,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/8f/9ce65d1341ff74e1962556b3ede6041eeac676b8b061ddd7af69360559af/n24q02m_mcp_core-1.18.0b6.tar.gz", hash = "sha256:633cdb9a023aa31c20dee513e56bd2d4715ea98aee3912b4c7d52446e2b3c693", size = 275601, upload-time = "2026-06-15T13:04:15.295Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/70/043942c59667fce1b53f269f5df16cf9fb12bde1a4bbb81f52c51baac10e/n24q02m_mcp_core-1.18.0b10.tar.gz", hash = "sha256:62a7f759ddade906eb9603a67e6155b87dee79163bb7c732db0698b395214f88", size = 282027, upload-time = "2026-06-17T08:19:56.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/65/9a7e9510c944961e5c32d58bbf53ee7d96dd1db2219e8e9db25b4da49506/n24q02m_mcp_core-1.18.0b6-py3-none-any.whl", hash = "sha256:739fcdbac3cc4ab07fb21401f87143f50edf12d88f5a072d77bc5415e8da8d64", size = 151539, upload-time = "2026-06-15T13:04:16.536Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c4/fd1626e9ab0afe60ae9880b8f5a855ad14ef1785a2598d8010b55cbee62c/n24q02m_mcp_core-1.18.0b10-py3-none-any.whl", hash = "sha256:44ea32698b985384181676ee4c3e2f2d58abae8dfc94b47eaaeee371d978b1f0", size = 156789, upload-time = "2026-06-17T08:19:54.678Z" },
 ]
 
 [package.optional-dependencies]
@@ -3495,7 +3495,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b10"
+version = "3.3.0b11"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
worker.ts CONTAINER_ENV_KEYS now forwards SEARCH_BACKENDS/BROWSER_BACKENDS + provider keys + DISABLE_LOCAL_* toggles + browserless/CF-rendering/capsolver creds into the container, so the WS-2/3/4/5 config actually reaches the Python config on CF instead of being dropped.