### PR TITLE
feat: rotate search-provider API keys on rate-limit (CSV multi-key)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,10 @@ dependencies = [
     # shipped in 1.18.0b4) + PerPluginStore token sub-key (1.18.0b5) +
     # CfKvBackend.ready() E.1 readiness probe (1.18.0b6) + the mcp_core.chains
     # capability provider-chain primitive (resolve_backend / run_with_fallback,
-    # 1.18.0b13) used by the search chain + disable-local toggles. Beta pin until 1.18.0 stable.
-    "n24q02m-mcp-core[llm]>=1.18.0b13,<2",
+    # 1.18.0b13) used by the search chain + disable-local toggles + the
+    # mcp_core.llm.key_rotation primitive (split_keys / rotate_keys, 1.18.0b14)
+    # for search-backend multi-key rotation. Beta pin until 1.18.0 stable.
+    "n24q02m-mcp-core[llm]>=1.18.0b14,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.4",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -35,6 +35,7 @@ def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
         "type": "password",
         "placeholder": ph,
         "helpUrl": url,
+        "helpText": "Multiple keys: comma-separate for automatic rotation on rate-limit.",
         "derived": True,
         "required": False,
     }

--- a/src/wet_mcp/sources/search_backends.py
+++ b/src/wet_mcp/sources/search_backends.py
@@ -1,17 +1,25 @@
 """Pluggable web-search backends. Default SearXNG (local), Tavily (cloud) for CF
 where SearXNG cannot run. All return the same JSON string {results, total, query}
 | {error} that server.py's search action already expects from searxng.search().
+
+Each cloud backend takes a LIST of API keys (CSV in the env): a single key keeps
+exactly today's behaviour, while multiple keys rotate automatically on a
+key-specific failure (HTTP 429 rate-limit / 401-403 auth) via the shared
+``mcp_core.llm.key_rotation`` primitive. An empty result from a working key is
+legitimate and never triggers rotation — only the PROVIDER chain advances on empty.
 """
 
 from __future__ import annotations
 
 import json
 import os
+from collections.abc import Awaitable, Callable
 from typing import Protocol
 
 import httpx
 from loguru import logger
 from mcp_core.chains import run_with_fallback
+from mcp_core.llm.key_rotation import rotate_keys, split_keys
 
 from wet_mcp.config import settings
 
@@ -27,6 +35,42 @@ class SearchBackend(Protocol):
         exclude_domains: list[str] | None = None,
         categories: str = "general",
     ) -> str: ...
+
+
+class _SearchHTTPError(Exception):
+    """A non-2xx response from a search provider, carrying ``status_code`` so
+    ``mcp_core.llm.key_rotation`` classifies 429/401/403 as a rotatable
+    (key-specific) failure and advances to the next key. The message is the safe
+    ``"<Provider> HTTP <code>"`` form — it never carries the request body/key."""
+
+    def __init__(self, provider: str, status_code: int) -> None:
+        self.status_code = status_code
+        super().__init__(f"{provider} HTTP {status_code}")
+
+
+async def _search_with_rotation(
+    keys: list[str],
+    attempt: Callable[[str], Awaitable[str]],
+    provider: str,
+) -> str:
+    """Rotate ``keys`` for one search provider, advancing only on a key-specific
+    failure (429/401/403). Returns the tool-contract error envelope when keys are
+    exhausted or a non-rotatable error occurs — type name only, never the
+    exception text (an httpx error may carry the request body, i.e. the key)."""
+    if not keys:
+        return json.dumps({"error": f"{provider} search backend has no API key"})
+    try:
+        return await rotate_keys(keys, attempt, label=provider.lower())
+    except _SearchHTTPError as exc:
+        return json.dumps(
+            {"error": str(exc)}
+        )  # "<Provider> HTTP <code>" — safe, no key
+    except (
+        httpx.HTTPError
+    ) as exc:  # transport — type name only (never echo, may carry the key)
+        return json.dumps({"error": f"{provider} request failed: {type(exc).__name__}"})
+    except Exception as exc:  # tool contract: error string, never raise; type name only
+        return json.dumps({"error": f"{provider} search failed: {type(exc).__name__}"})
 
 
 class SearxngBackend:
@@ -60,8 +104,37 @@ class SearxngBackend:
 class TavilyBackend:
     _URL = "https://api.tavily.com/search"
 
-    def __init__(self, api_key: str) -> None:
-        self.api_key = api_key
+    def __init__(self, keys: list[str]) -> None:
+        self.keys = keys
+
+    async def _search_one(self, key, query, max_results) -> str:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                self._URL,
+                json={
+                    "api_key": key,
+                    "query": query,
+                    "max_results": max_results,
+                    "search_depth": "basic",
+                },
+            )
+            if resp.status_code != 200:
+                raise _SearchHTTPError("Tavily", resp.status_code)
+            results = resp.json().get("results", [])
+            mapped = [
+                {
+                    "url": r.get("url", ""),
+                    "title": r.get("title", ""),
+                    "snippet": r.get("content", r.get("title", "")),
+                    "source": "tavily",
+                }
+                for r in results
+            ]
+            return json.dumps(
+                {"results": mapped, "total": len(mapped), "query": query},
+                ensure_ascii=False,
+                indent=2,
+            )
 
     async def search(
         self,
@@ -73,38 +146,11 @@ class TavilyBackend:
         exclude_domains=None,
         categories="general",
     ) -> str:
-        try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                resp = await client.post(
-                    self._URL,
-                    json={
-                        "api_key": self.api_key,
-                        "query": query,
-                        "max_results": max_results,
-                        "search_depth": "basic",
-                    },
-                )
-                if resp.status_code != 200:
-                    return json.dumps({"error": f"Tavily HTTP {resp.status_code}"})
-                results = resp.json().get("results", [])
-                mapped = [
-                    {
-                        "url": r.get("url", ""),
-                        "title": r.get("title", ""),
-                        "snippet": r.get("content", r.get("title", "")),
-                        "source": "tavily",
-                    }
-                    for r in results
-                ]
-                return json.dumps(
-                    {"results": mapped, "total": len(mapped), "query": query},
-                    ensure_ascii=False,
-                    indent=2,
-                )
-        except httpx.HTTPError as e:  # network/transport — never echo the message (may carry the request body/key)
-            return json.dumps({"error": f"Tavily request failed: {type(e).__name__}"})
-        except Exception as e:  # tool contract: error string, never raise; type name only (no key leak)
-            return json.dumps({"error": f"Tavily search failed: {type(e).__name__}"})
+        return await _search_with_rotation(
+            self.keys,
+            lambda key: self._search_one(key, query, max_results),
+            "Tavily",
+        )
 
 
 class BraveBackend:
@@ -116,19 +162,10 @@ class BraveBackend:
 
     _URL = "https://api.search.brave.com/res/v1/web/search"
 
-    def __init__(self, api_key: str) -> None:
-        self.api_key = api_key
+    def __init__(self, keys: list[str]) -> None:
+        self.keys = keys
 
-    async def search(
-        self,
-        query: str,
-        max_results: int = 10,
-        time_range=None,
-        language=None,
-        include_domains=None,
-        exclude_domains=None,
-        categories="general",
-    ) -> str:
+    async def _search_one(self, key, query, max_results, time_range, language) -> str:
         params: dict[str, str | int] = {
             "q": query,
             "count": min(max(max_results, 1), 20),
@@ -142,35 +179,42 @@ class BraveBackend:
                 params["freshness"] = freshness
         if language:
             params["search_lang"] = language
-        headers = {"X-Subscription-Token": self.api_key, "Accept": "application/json"}
-        try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                resp = await client.get(self._URL, params=params, headers=headers)
-                if resp.status_code != 200:
-                    return json.dumps({"error": f"Brave HTTP {resp.status_code}"})
-                results = resp.json().get("web", {}).get("results", [])
-                mapped = [
-                    {
-                        "url": r.get("url", ""),
-                        "title": r.get("title", ""),
-                        "snippet": r.get("description", r.get("title", "")),
-                        "source": "brave",
-                    }
-                    for r in results
-                ]
-                return json.dumps(
-                    {"results": mapped, "total": len(mapped), "query": query},
-                    ensure_ascii=False,
-                    indent=2,
-                )
-        except (
-            httpx.HTTPError
-        ) as e:  # transport — type name only (never echo, may carry the token)
-            return json.dumps({"error": f"Brave request failed: {type(e).__name__}"})
-        except (
-            Exception
-        ) as e:  # tool contract: error string, never raise; type name only
-            return json.dumps({"error": f"Brave search failed: {type(e).__name__}"})
+        headers = {"X-Subscription-Token": key, "Accept": "application/json"}
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(self._URL, params=params, headers=headers)
+            if resp.status_code != 200:
+                raise _SearchHTTPError("Brave", resp.status_code)
+            results = resp.json().get("web", {}).get("results", [])
+            mapped = [
+                {
+                    "url": r.get("url", ""),
+                    "title": r.get("title", ""),
+                    "snippet": r.get("description", r.get("title", "")),
+                    "source": "brave",
+                }
+                for r in results
+            ]
+            return json.dumps(
+                {"results": mapped, "total": len(mapped), "query": query},
+                ensure_ascii=False,
+                indent=2,
+            )
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 10,
+        time_range=None,
+        language=None,
+        include_domains=None,
+        exclude_domains=None,
+        categories="general",
+    ) -> str:
+        return await _search_with_rotation(
+            self.keys,
+            lambda key: self._search_one(key, query, max_results, time_range, language),
+            "Brave",
+        )
 
 
 class ExaBackend:
@@ -183,8 +227,41 @@ class ExaBackend:
 
     _URL = "https://api.exa.ai/search"
 
-    def __init__(self, api_key: str) -> None:
-        self.api_key = api_key
+    def __init__(self, keys: list[str]) -> None:
+        self.keys = keys
+
+    async def _search_one(
+        self, key, query, max_results, include_domains, exclude_domains
+    ) -> str:
+        body: dict[str, object] = {
+            "query": query,
+            "numResults": min(max(max_results, 1), 100),
+            "contents": {"text": {"maxCharacters": 300}},
+        }
+        if include_domains:
+            body["includeDomains"] = include_domains
+        if exclude_domains:
+            body["excludeDomains"] = exclude_domains
+        headers = {"x-api-key": key, "Content-Type": "application/json"}
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(self._URL, json=body, headers=headers)
+            if resp.status_code != 200:
+                raise _SearchHTTPError("Exa", resp.status_code)
+            results = resp.json().get("results", [])
+            mapped = [
+                {
+                    "url": r.get("url", ""),
+                    "title": r.get("title", ""),
+                    "snippet": (r.get("text") or r.get("title", ""))[:300],
+                    "source": "exa",
+                }
+                for r in results
+            ]
+            return json.dumps(
+                {"results": mapped, "total": len(mapped), "query": query},
+                ensure_ascii=False,
+                indent=2,
+            )
 
     async def search(
         self,
@@ -196,44 +273,13 @@ class ExaBackend:
         exclude_domains=None,
         categories="general",
     ) -> str:
-        body: dict[str, object] = {
-            "query": query,
-            "numResults": min(max(max_results, 1), 100),
-            "contents": {"text": {"maxCharacters": 300}},
-        }
-        if include_domains:
-            body["includeDomains"] = include_domains
-        if exclude_domains:
-            body["excludeDomains"] = exclude_domains
-        headers = {"x-api-key": self.api_key, "Content-Type": "application/json"}
-        try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                resp = await client.post(self._URL, json=body, headers=headers)
-                if resp.status_code != 200:
-                    return json.dumps({"error": f"Exa HTTP {resp.status_code}"})
-                results = resp.json().get("results", [])
-                mapped = [
-                    {
-                        "url": r.get("url", ""),
-                        "title": r.get("title", ""),
-                        "snippet": (r.get("text") or r.get("title", ""))[:300],
-                        "source": "exa",
-                    }
-                    for r in results
-                ]
-                return json.dumps(
-                    {"results": mapped, "total": len(mapped), "query": query},
-                    ensure_ascii=False,
-                    indent=2,
-                )
-        except (
-            httpx.HTTPError
-        ) as e:  # transport — type name only (never echo, may carry the key)
-            return json.dumps({"error": f"Exa request failed: {type(e).__name__}"})
-        except (
-            Exception
-        ) as e:  # tool contract: error string, never raise; type name only
-            return json.dumps({"error": f"Exa search failed: {type(e).__name__}"})
+        return await _search_with_rotation(
+            self.keys,
+            lambda key: self._search_one(
+                key, query, max_results, include_domains, exclude_domains
+            ),
+            "Exa",
+        )
 
 
 def _make_backend(name: str, searxng_url: str | None = None) -> SearchBackend:
@@ -241,25 +287,26 @@ def _make_backend(name: str, searxng_url: str | None = None) -> SearchBackend:
 
     ``searxng_url`` overrides ``settings.searxng_url`` for the SearXNG backend
     (the live auto-started URL, which may use a dynamic port) without mutating
-    the global settings.
+    the global settings. Cloud backends read a CSV of keys (``split_keys``): a
+    single key is unchanged, multiple keys rotate on rate-limit/auth failure.
     """
     if name == "searxng":
         return SearxngBackend(searxng_url or settings.searxng_url)
     if name == "tavily":
-        key = os.getenv("TAVILY_API_KEY", settings.tavily_api_key)
-        if not key:
+        keys = split_keys(os.getenv("TAVILY_API_KEY", settings.tavily_api_key))
+        if not keys:
             raise ValueError("TAVILY_API_KEY required for the tavily search backend")
-        return TavilyBackend(key)
+        return TavilyBackend(keys)
     if name == "brave":
-        key = os.getenv("BRAVE_API_KEY", settings.brave_api_key)
-        if not key:
+        keys = split_keys(os.getenv("BRAVE_API_KEY", settings.brave_api_key))
+        if not keys:
             raise ValueError("BRAVE_API_KEY required for the brave search backend")
-        return BraveBackend(key)
+        return BraveBackend(keys)
     if name == "exa":
-        key = os.getenv("EXA_API_KEY", settings.exa_api_key)
-        if not key:
+        keys = split_keys(os.getenv("EXA_API_KEY", settings.exa_api_key))
+        if not keys:
             raise ValueError("EXA_API_KEY required for the exa search backend")
-        return ExaBackend(key)
+        return ExaBackend(keys)
     raise ValueError(f"Unknown search backend: {name}")
 
 

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -13,12 +13,13 @@ def test_mcp_core_pin_includes_token_subkey():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
-    # Storage backends shipped in 1.18.0b12; the token sub-key in 1.18.0b12;
-    # CfKvBackend.ready() readiness probe in 1.18.0b12. Compare the >= floor as a
-    # version (not a brittle substring) so legitimate bumps past b5 still pass.
+    # Storage backends + token sub-key + CfKvBackend.ready() shipped by 1.18.0b12;
+    # the mcp_core.llm.key_rotation primitive (split_keys / rotate_keys) used by the
+    # search-backend multi-key rotation shipped in 1.18.0b14. Compare the >= floor as
+    # a version (not a brittle substring) so legitimate bumps past b14 still pass.
     m = re.search(r">=\s*([0-9][0-9A-Za-z.\-]*)", core)
     assert m, f"no >= floor in pin: {core}"
-    assert Version(m.group(1)) >= Version("1.18.0b12"), f"floor too low: {core}"
+    assert Version(m.group(1)) >= Version("1.18.0b14"), f"floor too low: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/tests/test_search_backends.py
+++ b/tests/test_search_backends.py
@@ -27,7 +27,7 @@ async def test_tavily_maps_rest_response():
             }
         )
         post.return_value = resp
-        out = json.loads(await TavilyBackend("k").search("q", max_results=1))
+        out = json.loads(await TavilyBackend(["k"]).search("q", max_results=1))
         assert out["total"] == 1
         assert out["query"] == "q"
         assert out["results"][0]["url"] == "https://e/1"
@@ -39,7 +39,7 @@ async def test_tavily_http_error_returns_error_json():
         resp = unittest.mock.AsyncMock()
         resp.status_code = 401
         post.return_value = resp
-        out = json.loads(await TavilyBackend("bad").search("q"))
+        out = json.loads(await TavilyBackend(["bad"]).search("q"))
         assert "error" in out
 
 
@@ -81,7 +81,7 @@ async def test_tavily_error_never_leaks_api_key():
             "body={'api_key': 'tvly-SECRET-DEADBEEF'}"
         ),
     ):
-        out = await TavilyBackend(secret).search("q")
+        out = await TavilyBackend([secret]).search("q")
     assert secret not in out
     assert "error" in json.loads(out)
 
@@ -124,7 +124,7 @@ async def test_brave_maps_web_results():
             }
         )
         get.return_value = resp
-        out = json.loads(await BraveBackend("k").search("q", max_results=1))
+        out = json.loads(await BraveBackend(["k"]).search("q", max_results=1))
         assert out["total"] == 1
         assert out["results"][0]["url"] == "https://b/1"
         assert out["results"][0]["snippet"] == "d1"
@@ -136,7 +136,7 @@ async def test_brave_http_error_returns_error_json():
         resp = unittest.mock.AsyncMock()
         resp.status_code = 429
         get.return_value = resp
-        assert "error" in json.loads(await BraveBackend("k").search("q"))
+        assert "error" in json.loads(await BraveBackend(["k"]).search("q"))
 
 
 async def test_brave_error_never_leaks_key():
@@ -145,7 +145,7 @@ async def test_brave_error_never_leaks_key():
         "httpx.AsyncClient.get",
         side_effect=httpx.ConnectError(f"failed token={secret}"),
     ):
-        out = await BraveBackend(secret).search("q")
+        out = await BraveBackend([secret]).search("q")
     assert secret not in out
 
 
@@ -159,7 +159,7 @@ async def test_exa_maps_results_with_text_snippet():
             }
         )
         post.return_value = resp
-        out = json.loads(await ExaBackend("k").search("q", max_results=1))
+        out = json.loads(await ExaBackend(["k"]).search("q", max_results=1))
         assert out["results"][0]["source"] == "exa"
         assert len(out["results"][0]["snippet"]) == 300  # truncated
 

--- a/tests/test_search_backends_multikey.py
+++ b/tests/test_search_backends_multikey.py
@@ -1,0 +1,44 @@
+"""Multi-key rotation in the search backends: a CSV of keys for one provider
+rotates on a key-specific failure (429/401/403) and is byte-identical to today
+for a single key."""
+
+import json
+from unittest import mock
+
+from wet_mcp.sources.search_backends import TavilyBackend
+
+
+class _RL(Exception):
+    def __init__(self):
+        self.status_code = 429
+
+
+async def test_tavily_rotates_key_on_429():
+    used = []
+
+    async def fake_post(self, url, **kw):
+        key = kw["json"]["api_key"]
+        used.append(key)
+        if key == "bad":
+            raise _RL()
+        resp = mock.Mock(status_code=200)
+        resp.json = lambda: {
+            "results": [{"url": "https://e", "title": "t", "content": "c"}]
+        }
+        return resp
+
+    with mock.patch("httpx.AsyncClient.post", new=fake_post):
+        out = await TavilyBackend(["bad", "good"]).search("q", max_results=1)
+    assert "https://e" in out
+    assert used == ["bad", "good"]
+
+
+async def test_tavily_single_key_unchanged():
+    async def fake_post(self, url, **kw):
+        resp = mock.Mock(status_code=200)
+        resp.json = lambda: {"results": []}
+        return resp
+
+    with mock.patch("httpx.AsyncClient.post", new=fake_post):
+        out = await TavilyBackend(["solo"]).search("q")
+    assert "results" in json.loads(out)

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b13"
+version = "1.18.0b14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1806,9 +1806,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/de/63e21abb61c6463bf9ef5700b96f97c41755272154eac550cbf9eb0283f3/n24q02m_mcp_core-1.18.0b13.tar.gz", hash = "sha256:d8d56e7bbc89305e86ba3d5a61f3ae269063ec7f533a3b76e761dc36b7dc196b", size = 292494, upload-time = "2026-06-19T07:03:07.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/af/4ab96169a7446124cf1689bea50e1c6cc20cabbcf1889a4d6cc962b61411/n24q02m_mcp_core-1.18.0b14.tar.gz", hash = "sha256:846c194051c2cb640ecd61b787ab96e3857c5aba29d944845db5cddf9ff2b91b", size = 294342, upload-time = "2026-06-19T11:59:22.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/ac/97a7befbeb87e04a10c673468fff7cd02909914209cd2dee5571f000da25/n24q02m_mcp_core-1.18.0b13-py3-none-any.whl", hash = "sha256:7ca71aa27a01eb6e44e3144346c6fddaae980f092a106e440aa30cf22e5a8439", size = 161881, upload-time = "2026-06-19T07:03:06.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bc/7488455a8935cdc5e1de52d7b8aeebc6812f28e0f9a1f186383f78eb5a7a/n24q02m_mcp_core-1.18.0b14-py3-none-any.whl", hash = "sha256:29a283e8e820c55688404edecb3ff3fb94a5384db9b998da1c8733a00086a08c", size = 163276, upload-time = "2026-06-19T11:59:21.395Z" },
 ]
 
 [package.optional-dependencies]
@@ -3460,7 +3460,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b12"
+version = "3.3.0b14"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3521,7 +3521,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b13,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b14,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.3.0b1,<3" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
## What

Let each cloud **search** provider be configured with MULTIPLE comma-separated API keys that rotate automatically on a key-specific failure (HTTP 429 rate-limit / 401-403 auth), so a provider survives one key being throttled or revoked. The third (key) layer beneath the existing capability->provider chain.

## Changes

- `sources/search_backends.py`:
  - `TavilyBackend` / `BraveBackend` / `ExaBackend.__init__` now take `keys: list[str]` (was a single `api_key: str`).
  - Per-request body moves into `_search_one(key, ...)`, which now **raises** `_SearchHTTPError` (carrying `status_code`) on a non-2xx response so `mcp_core.llm.key_rotation` can classify 429/401/403 as rotatable.
  - A shared `_search_with_rotation(keys, attempt, provider)` wraps `rotate_keys`: advance only on a key-specific error, re-raise/return the tool-contract error envelope otherwise. Error envelopes keep the existing security posture — **type name only**, never the exception text (which may carry the request body / key).
  - `_make_backend` reads a CSV via `split_keys(os.getenv(...))`, keeps the per-backend "API key required" skip-guard.
- `relay_schema.py`: provider key fields note CSV multi-key support in `helpText` (no schema-type change; still a password string).
- Pin: `n24q02m-mcp-core[llm]>=1.18.0b14` (ships the `key_rotation` primitive) + `uv.lock`; pin-guard test floor bumped to b14.

## Backwards compatibility

A single key (no comma) is byte-identical to today: the env still resolves to one key, no extra HTTP. An empty result from a working key never rotates — only the PROVIDER chain advances on empty.

## Tests

- `tests/test_search_backends_multikey.py` (new) — Tavily rotates to the 2nd key on 429; single key unchanged.
- Existing `tests/test_search_backends.py` updated to construct backends with a key LIST.
- Full suite: 1924 passed, 33 skipped.