### PR TITLE
fix: read SEARXNG_AUTH_USER/PASS and apply basic-auth to external SearXNG

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # wet consumes web-core's SSRF surface (is_safe_url / safe_httpx_client) AND, since 2.3.0,
     # the remote render backends (CFBrowserRenderingClient / BrowserlessClient /
     # RemoteRenderStrategy) for the browser provider chain + the under-rendered escalation fix.
-    "n24q02m-web-core>=2.3.0b1,<3",
+    "n24q02m-web-core>=2.3.0b2,<3",
     # MCP Server
     "mcp[cli]",
     # HTTP Client

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -80,6 +80,11 @@ class Settings(BaseSettings):
     # SearXNG
     searxng_url: str = "http://localhost:41592"
     searxng_timeout: int = 30
+    # Optional HTTP basic-auth for an external SearXNG behind a reverse-proxy
+    # auth gate (e.g. Caddy basic-auth). Both must be set to take effect; the
+    # auto-local SearXNG needs neither. Avoids embedding credentials in SEARXNG_URL.
+    searxng_auth_user: str = ""  # env SEARXNG_AUTH_USER
+    searxng_auth_pass: str = ""  # env SEARXNG_AUTH_PASS
 
     # Pluggable web search backend selector. "searxng" (default, local) or
     # "tavily" (cloud adapter for CF where embedded SearXNG cannot run).

--- a/src/wet_mcp/sources/searxng.py
+++ b/src/wet_mcp/sources/searxng.py
@@ -23,8 +23,19 @@ from web_core.search.client import (  # noqa: F401
     _build_filtered_query,
 )
 
+from wet_mcp.config import settings
+
 # Default health check timeout
 _HEALTH_CHECK_TIMEOUT = 5.0
+
+
+def _searxng_auth() -> tuple[str, str] | None:
+    """HTTP basic-auth ``(user, pass)`` for an external authenticated SearXNG
+    (e.g. behind Caddy basic-auth), or ``None`` when not both configured — the
+    auto-local SearXNG needs none. Avoids embedding credentials in SEARXNG_URL."""
+    user = settings.searxng_auth_user
+    pwd = settings.searxng_auth_pass
+    return (user, pwd) if user and pwd else None
 
 
 async def _check_health(searxng_url: str) -> bool:
@@ -33,6 +44,8 @@ async def _check_health(searxng_url: str) -> bool:
     Returns True if SearXNG is responsive, False otherwise.
     """
     try:
+        auth = _searxng_auth()
+        extra = {"auth": auth} if auth else {}
         async with httpx.AsyncClient(timeout=_HEALTH_CHECK_TIMEOUT) as client:
             response = await client.get(
                 f"{searxng_url}/healthz",
@@ -40,6 +53,7 @@ async def _check_health(searxng_url: str) -> bool:
                     "X-Real-IP": "127.0.0.1",
                     "X-Forwarded-For": "127.0.0.1",
                 },
+                **extra,
             )
             return response.status_code == 200
     except Exception:
@@ -118,6 +132,7 @@ async def search(
             language=language,
             include_domains=include_domains,
             exclude_domains=exclude_domains,
+            auth=_searxng_auth(),
         )
 
         output = {

--- a/tests/test_searxng.py
+++ b/tests/test_searxng.py
@@ -264,6 +264,7 @@ async def test_search_passes_params_to_web_core(mock_wc_search):
         language="vi",
         include_domains=["docs.python.org"],
         exclude_domains=["pinterest.com"],
+        auth=None,
     )
 
 

--- a/tests/test_searxng_auth.py
+++ b/tests/test_searxng_auth.py
@@ -1,0 +1,72 @@
+"""wet reads SEARXNG_AUTH_USER/PASS and applies HTTP basic-auth to the external
+SearXNG (search + health check), instead of requiring credentials embedded in
+SEARXNG_URL."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import wet_mcp.sources.searxng as sx
+from wet_mcp.config import settings
+
+
+def _set_auth(monkeypatch, user, pwd):
+    monkeypatch.setattr(settings, "searxng_auth_user", user, raising=False)
+    monkeypatch.setattr(settings, "searxng_auth_pass", pwd, raising=False)
+
+
+def test_searxng_auth_tuple_when_both_set(monkeypatch):
+    _set_auth(monkeypatch, "u", "p")
+    assert sx._searxng_auth() == ("u", "p")
+
+
+def test_searxng_auth_none_when_partial_or_empty(monkeypatch):
+    _set_auth(monkeypatch, "u", "")
+    assert sx._searxng_auth() is None
+    _set_auth(monkeypatch, "", "p")
+    assert sx._searxng_auth() is None
+    _set_auth(monkeypatch, "", "")
+    assert sx._searxng_auth() is None
+
+
+async def test_search_forwards_auth_to_web_core(monkeypatch):
+    _set_auth(monkeypatch, "u", "p")
+    captured = {}
+
+    async def fake_wc_search(url, query, **kw):
+        captured.update(kw)
+        return []
+
+    monkeypatch.setattr(
+        sx, "_ensure_searxng_healthy", AsyncMock(return_value="http://sx")
+    )
+    monkeypatch.setattr(sx, "_wc_search", fake_wc_search)
+    await sx.search("http://sx", "q")
+    assert captured.get("auth") == ("u", "p")
+
+
+async def test_search_auth_none_when_unset(monkeypatch):
+    _set_auth(monkeypatch, "", "")
+    captured = {}
+
+    async def fake_wc_search(url, query, **kw):
+        captured.update(kw)
+        return []
+
+    monkeypatch.setattr(
+        sx, "_ensure_searxng_healthy", AsyncMock(return_value="http://sx")
+    )
+    monkeypatch.setattr(sx, "_wc_search", fake_wc_search)
+    await sx.search("http://sx", "q")
+    assert captured.get("auth") is None
+
+
+async def test_check_health_applies_auth(monkeypatch):
+    _set_auth(monkeypatch, "u", "p")
+    resp = MagicMock(status_code=200)
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    with patch("httpx.AsyncClient", return_value=client):
+        ok = await sx._check_health("http://sx")
+    assert ok is True
+    assert client.get.call_args.kwargs.get("auth") == ("u", "p")

--- a/tests/test_searxng_unit.py
+++ b/tests/test_searxng_unit.py
@@ -162,6 +162,7 @@ async def test_search_passes_all_params(mock_wc_search):
         language="vi",
         include_domains=["docs.python.org"],
         exclude_domains=["pinterest.com"],
+        auth=None,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1818,7 +1818,7 @@ llm = [
 
 [[package]]
 name = "n24q02m-web-core"
-version = "2.3.0b1"
+version = "2.3.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "browserforge" },
@@ -1832,9 +1832,9 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/f9/8b6658a07414c2ec5716cd2e3a8ee1f96e72b066162107fa9ae75ed9911d/n24q02m_web_core-2.3.0b1.tar.gz", hash = "sha256:e0f6736f6b09e2e08992e22488b80c21221abe3e2a6f75bd36686782fdf31167", size = 245769, upload-time = "2026-06-19T07:03:41.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/5c/a2a6137ae9995474db1f903cba03b8e3cbd9eee4ea2a86478cdf76911208/n24q02m_web_core-2.3.0b2.tar.gz", hash = "sha256:273befba0369ac1ed7cfb5dcb7eadaf025322cf9fda0c156a8b1c096866760ef", size = 246139, upload-time = "2026-06-19T13:17:53.936Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/4f/9bf9d9fb71ba7a02d90b0c24347f708ecc8dc6304e3b128b2174fa7986ce/n24q02m_web_core-2.3.0b1-py3-none-any.whl", hash = "sha256:b675060a90198552126743bf3cbfb93d725b541912cf8d1a120adee08fc64ae4", size = 67209, upload-time = "2026-06-19T07:03:40.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6b/7d12b7c7f61c597d0e867bae3021105b39a1fe19b977767e86b90fcba490/n24q02m_web_core-2.3.0b2-py3-none-any.whl", hash = "sha256:9e0c3f94ed00d5b21623bb914447994cae83861ba44a4ea5672ec3aa59f740a4", size = 67431, upload-time = "2026-06-19T13:17:52.796Z" },
 ]
 
 [[package]]
@@ -3460,7 +3460,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b14"
+version = "3.3.0b15"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3522,7 +3522,7 @@ requires-dist = [
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
     { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b14,<2" },
-    { name = "n24q02m-web-core", specifier = ">=2.3.0b1,<3" },
+    { name = "n24q02m-web-core", specifier = ">=2.3.0b2,<3" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },


### PR DESCRIPTION
## What

wet now reads `SEARXNG_AUTH_USER` / `SEARXNG_AUTH_PASS` and applies HTTP Basic auth to an external SearXNG (search + health check), instead of requiring the credentials embedded in `SEARXNG_URL`. Root-cause fix for the searxng-auth workaround (URL-embedded userinfo) noted in the 2026-06-19 CF/OCI deploy.

## Changes

- `config.py`: new `searxng_auth_user` / `searxng_auth_pass` settings (env `SEARXNG_AUTH_USER` / `SEARXNG_AUTH_PASS`, both default `""`).
- `sources/searxng.py`: `_searxng_auth()` returns `(user, pass)` only when both are set (the auto-local SearXNG needs none); applied to `_check_health` and forwarded as `auth=` to `web_core.search.search`.
- Pin: `n24q02m-web-core>=2.3.0b2` (ships the `auth` param) + `uv.lock`.

## Backwards compatibility

Both unset (default) → `_searxng_auth()` is `None` → no auth header, byte-identical to today (local SearXNG, and the URL-embedded-auth workaround still works). The two existing exact-call tests were updated for the new `auth=None` kwarg.

## Tests

- `tests/test_searxng_auth.py` (new, 5): helper truth table + search forwards auth + health-check applies auth.
- Full suite: 1929 passed, 33 skipped.