### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SQL injection risk in PRAGMA table_info

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The `token_store.py` module constructed file paths by directly concatenating user-controlled inputs (`provider`, `sub`) via `pathlib.Path` without validation. This allowed path traversal (e.g., using `../` or absolute paths) to read or write arbitrary files on the system with the application's permissions.
 **Learning:** Even when using higher-level path abstractions like `pathlib`, string concatenation or `/` division with unvalidated user input is unsafe because the underlying OS resolution still respects traversal sequences.
 **Prevention:** Always explicitly validate path components for dangerous characters (like `/`, `\`, and `..`) using an explicit string validation helper before passing them to file I/O operations or path constructors.
+## 2026-06-19 - Parameterized SQL for PRAGMA Functions
+**Vulnerability:** Found `f"PRAGMA table_info({table})"` which injects an unparameterized variable into the SQL statement. While `table` here is currently controlled by the application through migrations or tests, this pattern is a classic vector for SQL Injection. SQLite doesn't support parameterized input for raw PRAGMA statements.
+**Learning:** SQLite has equivalent table-valued functions (e.g. `pragma_table_info(?)`) which *do* support parameter binding.
+**Prevention:** Avoid dynamic SQL via f-strings where possible. Use parameterized equivalents like `SELECT name FROM pragma_table_info(?)` instead of `f"PRAGMA table_info({table})"`.

--- a/src/wet_mcp/alembic/versions/docs_002_libraries.py
+++ b/src/wet_mcp/alembic/versions/docs_002_libraries.py
@@ -44,14 +44,18 @@ logger = logging.getLogger("alembic.runtime.migration")
 
 def _existing_columns(table: str) -> set[str]:
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
-    return {row[1] for row in rows}
+    rows = bind.exec_driver_sql(
+        "SELECT name FROM pragma_table_info(?)", (table,)
+    ).fetchall()
+    return {row[0] for row in rows}
 
 
 def _existing_indexes(table: str) -> set[str]:
     bind = op.get_bind()
-    rows = bind.exec_driver_sql(f"PRAGMA index_list({table})").fetchall()
-    return {row[1] for row in rows}
+    rows = bind.exec_driver_sql(
+        "SELECT name FROM pragma_index_list(?)", (table,)
+    ).fetchall()
+    return {row[0] for row in rows}
 
 
 def _add_column_if_missing(table: str, name: str, ddl: str) -> None:

--- a/src/wet_mcp/alembic/versions/docs_004_chunk_summaries.py
+++ b/src/wet_mcp/alembic/versions/docs_004_chunk_summaries.py
@@ -32,9 +32,9 @@ def upgrade() -> None:
     # migration on an already-upgraded DB is a no-op. PRAGMA table_info
     # returns rows shaped as (cid, name, type, notnull, dflt_value, pk).
     existing_cols = {
-        row[1]
+        row[0]
         for row in op.get_bind()
-        .exec_driver_sql("PRAGMA table_info(doc_chunks)")
+        .exec_driver_sql("SELECT name FROM pragma_table_info('doc_chunks')")
         .fetchall()
     }
     if "summary" not in existing_cols:

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -644,7 +644,9 @@ class DocsDB:
         # presence once per call so we don't crash on older schemas.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info('libraries')"
+            ).fetchall()
         }
         pkg_json = (
             json.dumps(package_managers, ensure_ascii=False)
@@ -767,7 +769,9 @@ class DocsDB:
         """
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(libraries)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info('libraries')"
+            ).fetchall()
         }
         sets: list[str] = []
         params: list = []
@@ -900,7 +904,9 @@ class DocsDB:
         # Detect optional columns once so we can branch on a single INSERT.
         existing_cols = {
             r["name"]
-            for r in self._conn.execute("PRAGMA table_info(doc_chunks)").fetchall()
+            for r in self._conn.execute(
+                "SELECT name FROM pragma_table_info('doc_chunks')"
+            ).fetchall()
         }
         phase2_cols = [
             c

--- a/tests/test_alembic_offline.py
+++ b/tests/test_alembic_offline.py
@@ -102,7 +102,7 @@ def test_run_migrations_offline_full_chain_fails_gracefully(tmp_path: Path) -> N
     """Verify that offline migration for the full chain fails due to live DB inspection.
 
     This test documents a known limitation: some migration scripts (like docs_002)
-    use live database inspection (PRAGMA table_info) which fails in offline mode
+    use live database inspection (pragma_table_info) which fails in offline mode
     because 'op.get_bind()' returns a 'MockConnection' that doesn't support 'exec_driver_sql'.
 
     Even though it fails in the migration script, it still exercises the

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -219,7 +219,9 @@ class TestLibraryMigration:
         # Second call triggers OperationalError because column exists
         db._create_libraries_table()
         # Check if column exists
-        info = db._conn.execute("PRAGMA table_info(libraries)").fetchall()
+        info = db._conn.execute(
+            "SELECT name FROM pragma_table_info('libraries')"
+        ).fetchall()
         cols = [c["name"] for c in info]
         assert "discovery_version" in cols
 
@@ -685,7 +687,7 @@ class TestMarkLibraryIndexed:
     def test_mark_library_indexed_legacy_db(self, db):
         """No-op if columns are missing (lines 600-601)."""
         # We can't easily mock sqlite3.Connection.execute as it's read-only.
-        # Instead, mock the return value of fetchall for PRAGMA table_info.
+        # Instead, mock the return value of fetchall for pragma_table_info.
 
         mock_results = [{"name": "id"}, {"name": "name"}]
 
@@ -702,10 +704,10 @@ class TestMarkLibraryIndexed:
             db.mark_library_indexed("legacy1", total_versions=10)
 
             # Verify it did NOT call execute with UPDATE
-            # The first call should be PRAGMA table_info
+            # The first call should be pragma_table_info
             # If it didn't return early, there would be a second call with UPDATE
             assert mock_conn.execute.call_count == 1
-            assert "PRAGMA table_info" in mock_conn.execute.call_args[0][0]
+            assert "pragma_table_info" in mock_conn.execute.call_args[0][0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -40,10 +40,12 @@ def _make_alembic_cfg(db_path: Path) -> Config:
 def _table_columns(db_path: Path, table: str) -> set[str]:
     conn = sqlite3.connect(str(db_path))
     try:
-        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        rows = conn.execute(
+            "SELECT name FROM pragma_table_info(?)", (table,)
+        ).fetchall()
     finally:
         conn.close()
-    return {r[1] for r in rows}
+    return {r[0] for r in rows}
 
 
 def _table_exists(db_path: Path, table: str) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -3460,7 +3460,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b15"
+version = "3.3.0b16"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix SQL injection risk in PRAGMA table_info

🚨 Severity: HIGH
💡 Vulnerability: SQL injection risk due to string formatting (f-strings) for dynamic table names in raw PRAGMA calls (e.g., `f"PRAGMA table_info({table})"`). Even though these are mostly used in migrations, it violates safe coding practices. SQLite does not support bound parameters in raw PRAGMA statements.
🎯 Impact: If user input ever reaches this code path, it could allow an attacker to inject arbitrary SQL statements, potentially leading to unauthorized data disclosure, modification, or data loss.
🔧 Fix: Replaced raw PRAGMA commands with their parameterized, table-valued function equivalents (`pragma_table_info(?)` and `pragma_index_list(?)`), which safely support variable binding. Adjusted index extractions since we only `SELECT name`.
✅ Verification: Ran full `uv run pytest` suite, `ruff check`, and `ruff format`. All passed successfully.

---
*PR created automatically by Jules for task [7966469335488376781](https://jules.google.com/task/7966469335488376781) started by @n24q02m*