### PR TITLE
fix: treat reachable SearXNG (401/403) as healthy + stop test_server spawning real SearXNG

### DIFF
--- a/src/wet_mcp/sources/searxng.py
+++ b/src/wet_mcp/sources/searxng.py
@@ -39,9 +39,14 @@ def _searxng_auth() -> tuple[str, str] | None:
 
 
 async def _check_health(searxng_url: str) -> bool:
-    """Quick health check before issuing a search request.
+    """Whether the SearXNG instance is REACHABLE (not whether /healthz is 200).
 
-    Returns True if SearXNG is responsive, False otherwise.
+    Any HTTP response means the instance is up: 200 = ready, and 401/403 = up but
+    auth-gated / reverse-proxy-blocked (an external SearXNG behind Caddy/CF basic
+    auth answers /healthz with 401/403 even though /search works — the search call
+    itself carries the auth). Only a 5xx or a connection/timeout error means it is
+    actually down and worth an auto-restart. Returning True on 401/403 stops the
+    pointless restart→spawn of a local SearXNG when an external one is configured.
     """
     try:
         auth = _searxng_auth()
@@ -55,7 +60,7 @@ async def _check_health(searxng_url: str) -> bool:
                 },
                 **extra,
             )
-            return response.status_code == 200
+            return response.status_code < 500
     except Exception:
         return False
 

--- a/tests/test_searxng_auth.py
+++ b/tests/test_searxng_auth.py
@@ -70,3 +70,38 @@ async def test_check_health_applies_auth(monkeypatch):
         ok = await sx._check_health("http://sx")
     assert ok is True
     assert client.get.call_args.kwargs.get("auth") == ("u", "p")
+
+
+def _mock_health_client(status=None, exc=None):
+    resp = MagicMock(status_code=status)
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=exc) if exc else AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+async def test_check_health_reachable_on_2xx_4xx(monkeypatch):
+    """A reachable instance (200 ready, or 401/403/404 up-but-gated) is healthy —
+    an external SearXNG behind Caddy/CF auth answers /healthz 401/403 yet works, so
+    treating it as unhealthy would trigger a pointless local-SearXNG restart/spawn."""
+    _set_auth(monkeypatch, "", "")
+    for code in (200, 401, 403, 404, 499):
+        with patch("httpx.AsyncClient", return_value=_mock_health_client(status=code)):
+            assert await sx._check_health("http://sx") is True, (
+                f"{code} should be reachable"
+            )
+
+
+async def test_check_health_down_on_5xx_or_conn_error(monkeypatch):
+    """5xx (server error) or a connection/timeout error means actually down."""
+    import httpx
+
+    _set_auth(monkeypatch, "", "")
+    with patch("httpx.AsyncClient", return_value=_mock_health_client(status=503)):
+        assert await sx._check_health("http://sx") is False
+    with patch(
+        "httpx.AsyncClient",
+        return_value=_mock_health_client(exc=httpx.ConnectError("refused")),
+    ):
+        assert await sx._check_health("http://sx") is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,6 +13,22 @@ from wet_mcp.server import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_real_searxng_spawn():
+    """The search action's chain path reaches ``_ensure_searxng_healthy`` ->
+    ``ensure_searxng()`` — a real SearXNG subprocess spawn that hangs a Windows CI
+    runner blocking on the child's stdout. Stub the health-check so no test_server
+    test ever starts a real SearXNG; tests asserting on these targets re-patch
+    them and their patch overrides this default (same pattern as the conftest
+    backend/crawler stubs)."""
+    with patch(
+        "wet_mcp.sources.searxng._ensure_searxng_healthy",
+        new_callable=AsyncMock,
+        side_effect=lambda url: url,
+    ):
+        yield
+
+
 def test_maybe_register_custom_embed_no_optin_noop(monkeypatch):
     """No registration when LOCAL_EMBEDDING_MODEL is unset (default local)."""
     import qwen3_embed
@@ -404,7 +420,7 @@ async def test_search_applies_reranking():
             return_value="http://localhost:41592",
         ),
         patch(
-            "wet_mcp.server.searxng_search",
+            "wet_mcp.sources.searxng.search",
             new_callable=AsyncMock,
             return_value=mock_results,
         ),
@@ -652,7 +668,7 @@ async def test_search_enrich_flag():
             return_value="http://localhost:8080",
         ),
         patch(
-            "wet_mcp.server.searxng_search",
+            "wet_mcp.sources.searxng.search",
             new_callable=AsyncMock,
             return_value=mock_results,
         ),


### PR DESCRIPTION
## What

Two SearXNG-health fixes surfaced by the searxng-auth work:

1. **`_check_health` now means "reachable", not "/healthz is 200".** An external SearXNG behind a reverse-proxy auth/WAF gate (Caddy basic-auth, Cloudflare) answers `/healthz` with `401`/`403` even though `/search` works. The old `== 200` check returned `False` for it, triggering a pointless `_ensure_searxng_healthy` → `ensure_searxng()` local-SearXNG restart/spawn. Now: any response `< 500` = reachable (200 ready, 401/403/404 up-but-gated); only `5xx` or a connection/timeout error = down.

2. **`test_server.py` no longer spawns a real SearXNG.** The search action's chain path (`run_search_chain` → `SearxngBackend` → `wet_mcp.sources.searxng.search` → `_ensure_searxng_healthy` → `ensure_searxng()`) was reached by two tests that mocked the stale `wet_mcp.server.searxng_search` reference (no longer on the path since the search action moved to `run_search_chain`). They now mock `wet_mcp.sources.searxng.search` (the real target), and an autouse fixture stubs `_ensure_searxng_healthy` so no `test_server` test can spawn a real SearXNG subprocess — which was hanging the Windows CI runner (`subprocess _readerthread` block) into a 30s timeout.

## Tests

- `test_searxng_auth.py`: `_check_health` reachable on 200/401/403/404/499, down on 5xx + ConnectError.
- `test_server.py`: stale mock targets corrected + autouse no-spawn fixture.
- Full suite green (pre-commit).