### PR TITLE
fix: resolve per-sub api_key in dispatch instead of mutating os.environ

### DIFF
--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -323,6 +323,31 @@ def credentials_for_current_request() -> dict[str, str]:
     return read_for_sub(sub)
 
 
+def api_key_for_model(model: str) -> str | None:
+    """Resolve the provider API key for ``model`` from the CURRENT request.
+
+    HTTP multi-user (``_current_sub`` set): return the ``<PROVIDER>_API_KEY``
+    from THAT subject's per-sub bucket so the cloud dispatch (embedder /
+    reranker / llm) passes it EXPLICITLY per call — instead of leaking it
+    into the process-global ``os.environ``, which bled one ``sub``'s keys
+    into another's request (``os.environ`` is shared mutable state, not
+    contextvar-isolated).
+
+    Single-user / stdio (no sub): return ``None`` so litellm's own provider
+    env fallback applies unchanged — the single-user dispatch contract is
+    untouched (this is the documented "empty api_key -> None -> env" path).
+    """
+    sub = _current_sub.get()
+    if sub is None:
+        return None
+    from mcp_core.llm.providers import key_env_for_model
+
+    key_env = key_env_for_model(model)
+    if not key_env:
+        return None
+    return read_for_sub(sub).get(key_env) or None
+
+
 def _await_backend_ready() -> None:
     """E.1: when the active backend is CF KV, poll its readiness probe before the
     first credential write so the PUT never races outbound-interception. No-op for

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -228,17 +228,24 @@ class CloudEmbeddingBackend:
         # Lazy import: litellm costs ~1-2s on first import.
         from mcp_core.llm import aembedding
 
+        from wet_mcp.credential_state import api_key_for_model
+
         kwargs: dict = {}
         if dimensions:
             kwargs["dimensions"] = dimensions
         if self._provider == "cohere":
             kwargs["input_type"] = "search_document"
 
+        litellm_model = self._litellm_model()
+        # Resolve the provider key from the request-scoped per-sub bucket
+        # (HTTP multi-user) or the process env (single-user); explicit
+        # api_key (init-time override) wins. Avoids relying on os.environ,
+        # which bled keys across concurrent users.
         response = await aembedding(
-            model=self._litellm_model(),
+            model=litellm_model,
             input=texts,
             api_base=self.api_base or os.getenv("EMBEDDING_API_BASE") or None,
-            api_key=self.api_key or None,
+            api_key=self.api_key or api_key_for_model(litellm_model),
             **kwargs,
         )
 

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -115,10 +115,15 @@ async def acompletion(
     if response_format is not None:
         call_kwargs["response_format"] = response_format
 
+    from wet_mcp.credential_state import api_key_for_model
+
     resolved_api_base = api_base or os.getenv("LLM_API_BASE") or None
-    # Normalise empty string to None: mcp_core.llm forwards a non-None
-    # api_key to litellm, which suppresses provider env-var fallback (401).
-    resolved_api_key = api_key or None
+    # Resolve the provider key from the request-scoped per-sub bucket (HTTP
+    # multi-user) or the process env (single-user); an explicit api_key wins.
+    # Resolved per model so a fallback to a different provider gets its own
+    # key. Avoids relying on os.environ (cross-user bleed). Empty string ->
+    # None so litellm's own provider env fallback still applies single-user.
+    resolved_api_key = api_key or api_key_for_model(model) or None
 
     try:
         return await core_acompletion(
@@ -137,7 +142,7 @@ async def acompletion(
                         model=fb_model,
                         messages=messages,
                         api_base=resolved_api_base,
-                        api_key=resolved_api_key,
+                        api_key=api_key or api_key_for_model(fb_model) or None,
                         **call_kwargs,
                     )
                 except Exception:

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -81,13 +81,19 @@ class CloudReranker:
         # Lazy import: litellm costs ~1-2s on first import.
         from mcp_core.llm import rerank as core_rerank
 
+        from wet_mcp.credential_state import api_key_for_model
+
+        litellm_model = self._litellm_model()
+        # Resolve the provider key from the request-scoped per-sub bucket
+        # (HTTP multi-user) or the process env (single-user); explicit
+        # api_key wins. Avoids os.environ cross-user bleed.
         response = core_rerank(
-            model=self._litellm_model(),
+            model=litellm_model,
             query=query,
             documents=documents,
             top_n=top_n,
             api_base=os.getenv("RERANK_API_BASE") or None,
-            api_key=self.api_key or None,
+            api_key=self.api_key or api_key_for_model(litellm_model),
         )
 
         # litellm RerankResponse.results defaults to None and rerank items

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -111,11 +111,12 @@ def _require_credentials() -> str | None:
     * **HTTP multi-user request** (``_current_sub`` set via auth_scope) —
       look up the per-sub PerPluginStore bucket. If empty, return
       AWAITING_SETUP error so the user opens the relay form. If non-empty,
-      apply to ``os.environ`` for the duration of the asyncio task so the
-      existing provider-init code (settings.setup_providers, JINA/Gemini
-      client builders, …) picks the right user's keys, and allow the call.
-      Per-asyncio-task contextvar isolation guarantees concurrent users
-      see only their own values.
+      allow the call. The credentials stay request-scoped: the cloud
+      dispatch (embedder / reranker / llm) resolves the right provider key
+      per call via :func:`credential_state.api_key_for_model`. We do NOT
+      copy them into the process-global ``os.environ`` — that bled one
+      ``sub``'s keys into another's request (``os.environ`` is shared
+      mutable state, not contextvar-isolated).
 
     * **Stdio / single-user HTTP / no JWT** — ``_current_sub`` is ``None``;
       fall back to the legacy ``CredentialState`` machine driven by env
@@ -147,17 +148,10 @@ def _require_credentials() -> str | None:
                     ),
                 }
             )
-        # Apply per-sub creds to env for the request. Python contextvar +
-        # asyncio task isolation ensures concurrent requests for different
-        # subs do not race on os.environ at the per-call boundary used by
-        # downstream provider builders. (We never reset because each
-        # request overwrites with its own sub's values; missing keys for
-        # this sub fall through to whatever the previous request set,
-        # which is acceptable per spec §4.2 since `_require_credentials`
-        # already verified at least one key is present.)
-        for key, value in creds.items():
-            if value:
-                os.environ[key] = value
+        # Credentials verified for this sub. They stay request-scoped:
+        # the cloud dispatch resolves the per-sub key per call via
+        # credential_state.api_key_for_model. Do NOT write them into
+        # os.environ (process-global -> cross-sub bleed).
         return None
 
     state = get_state()

--- a/tests/test_per_sub_credential_isolation.py
+++ b/tests/test_per_sub_credential_isolation.py
@@ -1,0 +1,180 @@
+"""F1: per-sub credential isolation — no cross-user ``os.environ`` bleed.
+
+Regression guard for the multi-user HTTP path where ``_require_credentials``
+used to copy a request's per-sub credentials into the process-global
+``os.environ`` (and never reset), so a later request for a different ``sub``
+read whatever the previous request left behind (cross-user key bleed /
+billing + data-isolation breach). The fix resolves each provider key per
+call from the request-scoped per-sub bucket via ``api_key_for_model`` and
+stops mutating ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def test_require_credentials_does_not_bleed_keys_to_os_environ(monkeypatch, tmp_path):
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.server import _require_credentials
+
+    store_for_sub("user_a", {"JINA_AI_API_KEY": "key_a"})
+    store_for_sub("user_b", {"GEMINI_API_KEY": "key_b"})
+
+    try:
+        set_current_sub("user_a")
+        assert _require_credentials() is None  # configured -> tool call allowed
+        # user_a's key must NOT land in the process-global environment.
+        assert os.environ.get("JINA_AI_API_KEY") is None
+
+        set_current_sub("user_b")
+        assert _require_credentials() is None
+        # user_b must not inherit user_a's key from the previous request,
+        # and must not leak its own key into the global env either.
+        assert os.environ.get("JINA_AI_API_KEY") is None
+        assert os.environ.get("GEMINI_API_KEY") is None
+    finally:
+        set_current_sub(None)
+
+
+def test_api_key_for_model_resolves_per_sub(monkeypatch, tmp_path):
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    from wet_mcp.credential_state import (
+        api_key_for_model,
+        set_current_sub,
+        store_for_sub,
+    )
+
+    store_for_sub("user_a", {"JINA_AI_API_KEY": "key_a"})
+    store_for_sub("user_b", {"GEMINI_API_KEY": "key_b"})
+
+    try:
+        set_current_sub("user_a")
+        assert api_key_for_model("jina_ai/jina-embeddings-v5") == "key_a"
+        # user_a has no Gemini key -> None (not a bled value from elsewhere).
+        assert api_key_for_model("gemini/gemini-3-flash-preview") is None
+
+        set_current_sub("user_b")
+        assert api_key_for_model("gemini/gemini-3-flash-preview") == "key_b"
+        # no bleed of user_a's Jina key into user_b's request.
+        assert api_key_for_model("jina_ai/jina-embeddings-v5") is None
+    finally:
+        set_current_sub(None)
+
+
+def test_api_key_for_model_returns_none_for_single_user(monkeypatch, tmp_path):
+    """Single-user / stdio (no sub): None so litellm's own env fallback applies.
+
+    The single-user dispatch contract is intentionally unchanged — the cloud
+    backends still pass ``api_key=None`` and litellm reads the provider env
+    var itself. ``api_key_for_model`` only resolves an explicit key for the
+    HTTP multi-user (``sub`` set) path, which is where the bleed lived.
+    """
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "k1")
+
+    from wet_mcp.credential_state import api_key_for_model, set_current_sub
+
+    set_current_sub(None)
+    assert api_key_for_model("openai/gpt-4o-mini") is None
+    assert api_key_for_model("jina_ai/x") is None
+
+
+async def test_embedder_forwards_per_sub_api_key(monkeypatch, tmp_path):
+    """CloudEmbeddingBackend forwards the request's per-sub key to litellm."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.embedder import CloudEmbeddingBackend
+
+    store_for_sub("user_a", {"JINA_AI_API_KEY": "key_a"})
+
+    captured: dict = {}
+
+    async def fake_aembedding(**kwargs):
+        captured.update(kwargs)
+
+        class _R:
+            data = [{"index": 0, "embedding": [0.1, 0.2, 0.3]}]
+
+        return _R()
+
+    monkeypatch.setattr("mcp_core.llm.aembedding", fake_aembedding)
+    backend = CloudEmbeddingBackend("jina_ai/jina-embeddings-v5", api_key=None)
+    try:
+        set_current_sub("user_a")
+        await backend.embed_single("hello")
+        assert captured["api_key"] == "key_a"
+    finally:
+        set_current_sub(None)
+
+
+def test_reranker_forwards_per_sub_api_key(monkeypatch, tmp_path):
+    """CloudReranker forwards the request's per-sub key to litellm."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.reranker import CloudReranker
+
+    store_for_sub("user_a", {"JINA_AI_API_KEY": "key_a"})
+
+    captured: dict = {}
+
+    def fake_rerank(**kwargs):
+        captured.update(kwargs)
+
+        class _R:
+            results = [{"index": 0, "relevance_score": 0.9}]
+
+        return _R()
+
+    monkeypatch.setattr("mcp_core.llm.rerank", fake_rerank)
+    backend = CloudReranker(model="jina_ai/jina-reranker-v3", api_key=None)
+    try:
+        set_current_sub("user_a")
+        backend.rerank("q", ["doc"], top_n=1)
+        assert captured["api_key"] == "key_a"
+    finally:
+        set_current_sub(None)
+
+
+async def test_llm_acompletion_forwards_per_sub_api_key(monkeypatch, tmp_path):
+    """llm.acompletion forwards the request's per-sub key to litellm."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.llm import acompletion
+
+    store_for_sub("user_a", {"GEMINI_API_KEY": "key_a"})
+
+    captured: dict = {}
+
+    async def fake_core_acompletion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_core_acompletion)
+    try:
+        set_current_sub("user_a")
+        await acompletion(
+            model="gemini/gemini-3-flash-preview",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert captured["api_key"] == "key_a"
+    finally:
+        set_current_sub(None)


### PR DESCRIPTION
## Problem

In HTTP multi-user mode, `_require_credentials()` copied the request's per-sub credential bucket into the process-global `os.environ` and never reset it. `os.environ` is shared mutable process state (not contextvar-scoped, contrary to the in-code comment), so a later request for a different JWT `sub` read whatever keys the previous request left behind — a cross-user API-key bleed (one tenant's request could dispatch with another tenant's provider key: billing + data-isolation breach).

## Fix

- New `credential_state.api_key_for_model(model)` resolves the provider key for the current request from THAT subject's per-sub bucket (keyed via `mcp_core.llm.providers.key_env_for_model`). Returns `None` on the single-user/stdio path so litellm's own provider env fallback is unchanged.
- Cloud dispatch (`embedder.CloudEmbeddingBackend`, `reranker.CloudReranker`, `llm.acompletion`) now passes the resolved key explicitly per call.
- `_require_credentials()` no longer writes `os.environ`.

Single-user / stdio behavior is intentionally unchanged.

## Tests

- New `tests/test_per_sub_credential_isolation.py`: no cross-sub env bleed, per-sub key resolution, single-user returns None, dispatch-forwarding for embedder/reranker/llm.
- Full suite: 1937 passed, 33 skipped.