### PR TITLE
fix: key-gate the wet LLM default chain (no keyless cloud model)

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -146,7 +146,7 @@ class Settings(BaseSettings):
     # Media Analysis (Provider API keys)
     api_keys: SecretStr | None = None  # ENV_VAR:key,ENV_VAR:key (multiple providers)
 
-    llm_models: str = "gemini/gemini-3-flash-preview,openai/gpt-5.4-mini-2026-03-17"  # provider/model (fallback chain)
+    llm_models: str = ""  # provider/model fallback chain; empty -> key-gated default
     llm_temperature: float | None = None
 
     # Cache (web operations)
@@ -431,7 +431,15 @@ class Settings(BaseSettings):
         return c[0] if c else None
 
     def llm_chain(self) -> list[str]:
-        return [m.strip() for m in self.llm_models.split(",") if m.strip()]
+        # Key-gated like embedding/rerank: an explicit LLM_MODELS chain is used
+        # verbatim; an empty env falls to the curated default filtered to models
+        # whose provider key is configured (none -> [] -> LLM feature off, never
+        # a keyless cloud model that 401s at call time).
+        return self._chain(
+            self.llm_models,
+            "",
+            ("gemini/gemini-3-flash-preview", "openai/gpt-5.4-mini-2026-03-17"),
+        )
 
     # --- Embedding resolution ---
 

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -156,12 +156,14 @@ async def acompletion(
 
 
 def get_llm_config() -> dict:
-    """Build LLM configuration with fallback."""
-    models = [m.strip() for m in settings.llm_models.split(",") if m.strip()]
-    if not models:
-        models = ["gemini/gemini-3-flash-preview"]
+    """Build LLM configuration from the key-gated chain.
 
-    primary = models[0]
+    Uses ``settings.llm_chain()`` so an unconfigured default never emits a
+    keyless cloud model. When the chain is empty (no provider key configured)
+    ``model`` is ``None`` and callers degrade gracefully (LLM feature off).
+    """
+    models = settings.llm_chain()
+    primary = models[0] if models else None
     fallbacks = models[1:] if len(models) > 1 else None
 
     return {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -604,8 +604,16 @@ def test_wet_rerank_openai_only_is_local(monkeypatch):
 
 
 def test_wet_llm_chain_default(monkeypatch):
+    # Empty LLM_MODELS -> key-gated curated default: only models whose provider
+    # key is configured. With the Gemini key the chain head is the gemini
+    # default; with no key the chain is empty (LLM off, no keyless cloud model).
     monkeypatch.delenv("LLM_MODELS", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
     assert Settings().llm_chain()[0] == "gemini/gemini-3-flash-preview"
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    assert Settings().llm_chain() == []
 
 
 def test_wet_embedding_primary(monkeypatch):

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -1122,16 +1122,19 @@ class TestQwen3EmbedSingleQuery:
 class TestGetLlmConfigEmptyModels:
     """Cover line 33: empty models fallback."""
 
-    async def test_empty_models_fallback(self):
+    async def test_empty_models_fallback(self, monkeypatch):
         from wet_mcp.config import settings
         from wet_mcp.llm import get_llm_config
 
+        for k in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
         original = settings.llm_models
         settings.llm_models = ""
 
         try:
             config = get_llm_config()
-            assert config["model"] == "gemini/gemini-3-flash-preview"
+            # Empty chain + no provider key -> no model (LLM feature off).
+            assert config["model"] is None
         finally:
             settings.llm_models = original
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -67,10 +67,10 @@ def test_get_llm_config_fallbacks(mock_settings):
 
 
 def test_get_llm_config_empty_models(mock_settings):
-    """Test LLM config with empty or whitespace models string."""
+    """Whitespace-only models -> empty chain -> no model (LLM feature off)."""
     settings.llm_models = "   ,  "
     config = get_llm_config()
-    assert config["model"] == "gemini/gemini-3-flash-preview"
+    assert config["model"] is None
     assert config["fallbacks"] is None
 
 


### PR DESCRIPTION
## Problem
`llm_chain()` split `LLM_MODELS` verbatim and defaulted to a hardcoded `gemini+openai` pair, so with no provider key configured the default chain still emitted cloud models that 401 at call time -- unlike embedding/rerank which key-gate their default via `_chain()`.

## Fix
- `llm_chain()` routes through `_chain()`: an explicit `LLM_MODELS` is used verbatim; an empty env falls to the curated default filtered to models whose provider key is configured; none -> empty -> LLM feature off (no keyless cloud model).
- `get_llm_config()` consumes `llm_chain()` and returns `model=None` on an empty chain, so structured extraction degrades gracefully.

## Tests
Full suite: 1937 passed, 33 skipped. Default-chain tests updated to assert the key-gated behavior.