### PR TITLE
fix: SearXNG URL field on relay + skip GDrive device-code on Cloudflare

### DIFF
--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -390,6 +390,16 @@ def poll_until_readable(sub: str | None, retries: int = 8, delay: float = 0.5) -
     return False
 
 
+def _sync_redundant_on_cf() -> bool:
+    """Whether Google Drive docs-sync is redundant on this deployment.
+
+    On Cloudflare the docs DB is D1 + Vectorize (durable across container
+    recreate), so the GDrive delta-sync is redundant. Skip the device-code flow
+    there so the relay never offers a non-functional Google Drive setup.
+    """
+    return os.environ.get("DOCS_DB_BACKEND", "").strip().lower() == "cf-d1"
+
+
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
     """Save credentials from OAuth form to ``config.json`` and apply to environment.
 
@@ -434,7 +444,11 @@ def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | 
         try:
             from wet_mcp.config import settings as s
 
-            if s.google_drive_client_id and s.google_drive_client_secret:
+            if (
+                s.google_drive_client_id
+                and s.google_drive_client_secret
+                and not _sync_redundant_on_cf()
+            ):
                 import httpx
 
                 response = httpx.post(
@@ -506,7 +520,11 @@ def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | 
     try:
         from wet_mcp.config import settings as s
 
-        if s.google_drive_client_id and s.google_drive_client_secret:
+        if (
+            s.google_drive_client_id
+            and s.google_drive_client_secret
+            and not _sync_redundant_on_cf()
+        ):
             import httpx
 
             response = httpx.post(

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -86,6 +86,7 @@ RELAY_SCHEMA: dict[str, Any] = {
             "task": "search",
             "suggestedModels": _SEARCH_BACKENDS,
             "providerKeys": {
+                "searxng": "SEARXNG_URL",
                 "tavily": "TAVILY_API_KEY",
                 "brave": "BRAVE_API_KEY",
                 "exa": "EXA_API_KEY",
@@ -138,6 +139,23 @@ RELAY_SCHEMA: dict[str, Any] = {
         _key_field(
             "EXA_API_KEY", "Exa API Key", "exa_...", "https://dashboard.exa.ai/api-keys"
         ),
+        {
+            # SearXNG is a named backend (not a model-prefix provider): selecting
+            # it in the search chain derives this field via providerKeys so the
+            # user can point at an external instance. Blank -> auto-started local
+            # SearXNG. Optional basic-auth via env SEARXNG_AUTH_USER/PASS.
+            "key": "SEARXNG_URL",
+            "label": "SearXNG URL (external instance)",
+            "type": "url",
+            "placeholder": "https://searxng.example.com",
+            "helpText": (
+                "Point at an external SearXNG. Leave blank to use the local "
+                "auto-started instance. Basic-auth (if any): set env "
+                "SEARXNG_AUTH_USER / SEARXNG_AUTH_PASS."
+            ),
+            "derived": True,
+            "required": False,
+        },
         {
             "key": "GITHUB_TOKEN",
             "label": "GitHub Personal Access Token",

--- a/tests/test_relay_searxng_and_cf_gdrive.py
+++ b/tests/test_relay_searxng_and_cf_gdrive.py
@@ -1,0 +1,67 @@
+"""F10: SearXNG relay URL cred field. F9: skip GDrive device-code on Cloudflare.
+
+F10 -- selecting SearXNG in the relay search chain used to surface no credential
+field, so an external SearXNG instance could not be configured via the form.
+F9 -- on Cloudflare the docs DB is D1 + Vectorize (durable), so the Google Drive
+delta-sync is redundant; the relay must not trigger the GDrive device-code flow
+there (it offered a non-functional setup).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from wet_mcp.relay_schema import RELAY_SCHEMA
+
+
+def _field(key: str) -> dict | None:
+    return next((f for f in RELAY_SCHEMA["fields"] if f.get("key") == key), None)
+
+
+def test_searxng_surfaces_url_cred_field():
+    """Selecting SearXNG must surface a derived SEARXNG_URL field."""
+    search = _field("SEARCH_BACKENDS")
+    assert search is not None
+    assert search["providerKeys"].get("searxng") == "SEARXNG_URL"
+
+    url_field = _field("SEARXNG_URL")
+    assert url_field is not None
+    assert url_field.get("derived") is True
+    assert url_field.get("type") == "url"
+
+
+def test_sync_redundant_on_cf(monkeypatch):
+    from wet_mcp.credential_state import _sync_redundant_on_cf
+
+    monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
+    assert _sync_redundant_on_cf() is False
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    assert _sync_redundant_on_cf() is True
+    monkeypatch.setenv("DOCS_DB_BACKEND", "sqlite")
+    assert _sync_redundant_on_cf() is False
+
+
+def test_gdrive_device_code_skipped_on_cf(monkeypatch, tmp_path):
+    """On CF (DOCS_DB_BACKEND=cf-d1) the GDrive device-code flow is not triggered."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.setenv("PUBLIC_URL", "https://wet.example.com")
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    monkeypatch.delenv("MCP_STORAGE_BACKEND", raising=False)  # creds -> LocalFs (tmp)
+
+    from wet_mcp import credential_state
+    from wet_mcp.config import settings
+
+    # Pretend GDrive client creds exist so only the CF gate would stop the flow.
+    monkeypatch.setattr(settings, "google_drive_client_id", "cid", raising=False)
+    monkeypatch.setattr(
+        settings, "google_drive_client_secret", "csecret", raising=False
+    )
+
+    with patch("httpx.post") as mock_post:
+        result = credential_state.save_credentials(
+            {"JINA_AI_API_KEY": "k"}, {"sub": "user_a"}
+        )
+
+    assert mock_post.call_count == 0  # no device/code request on CF
+    assert result is None  # no device-code next_step returned to the form


### PR DESCRIPTION
Two relay/setup fixes reported during the pre-stabilization audit.

## SearXNG has no credential field on the relay
SearXNG is a named search backend (not a model-prefix provider), so selecting it surfaced no field and an external instance could not be configured via the form. Map `searxng -> SEARXNG_URL` in the search-chain `providerKeys` and add a derived `SEARXNG_URL` url field (blank = local auto-SearXNG; optional basic-auth via env `SEARXNG_AUTH_USER`/`SEARXNG_AUTH_PASS`).

## GDrive offered on Cloudflare where sync is redundant
On CF the docs DB is D1 + Vectorize (durable), so the Google Drive delta-sync is redundant. Gate the GDrive device-code trigger (both multi-user and single-user save paths) behind `DOCS_DB_BACKEND != cf-d1` so the relay no longer offers a non-functional Google Drive setup on CF.

## Tests
Full suite: 1940 passed, 33 skipped. New: searxng URL field present, `_sync_redundant_on_cf` truth table, GDrive device-code not triggered on CF.