### PR TITLE
fix: make LLM gate + embed/rerank backend sub-aware in multi-user

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -384,6 +384,10 @@ class Settings(BaseSettings):
         "jina_ai/jina-reranker-v3",
         "cohere/rerank-v3.5",
     )
+    _DEFAULT_LLM_CHAIN = (
+        "gemini/gemini-3-flash-preview",
+        "openai/gpt-5.4-mini-2026-03-17",
+    )
 
     def _key_available(self, env_var: str) -> bool:
         """Whether a provider key is set (env or GOOGLE->GEMINI alias)."""
@@ -395,6 +399,44 @@ class Settings(BaseSettings):
             if canonical == env_var and os.getenv(alias):
                 return True
         return False
+
+    def _key_available_in(self, env_var: str, creds: dict[str, str]) -> bool:
+        """Whether a provider key is present in an explicit ``creds`` dict.
+
+        Multi-user analogue of :meth:`_key_available`: instead of reading
+        ``os.environ`` (which never holds per-sub keys, and whose mutation
+        would bleed one user's key into another's concurrent request), it
+        consults the request-scoped per-sub credential bucket. The GOOGLE ->
+        GEMINI alias is honored the same way.
+        """
+        if creds.get(env_var):
+            return True
+        aliases = getattr(self, "_ENV_ALIASES", {})
+        for alias, canonical in aliases.items():
+            if canonical == env_var and creds.get(alias):
+                return True
+        return False
+
+    def _chain_for_creds(
+        self,
+        explicit: str,
+        default: tuple[str, ...],
+        creds: dict[str, str],
+    ) -> list[str]:
+        """Resolve a model chain from an explicit ``<TASK>_MODELS`` value or
+        the curated default, key-gated against an explicit ``creds`` dict.
+
+        Mirrors :meth:`_chain` for the per-sub (HTTP multi-user) path: an
+        explicit chain submitted by the user is used verbatim; otherwise the
+        curated default is filtered to models whose provider key is in the
+        sub's bucket (none -> empty -> local ONNX). No ``os.environ`` reads,
+        so a second sub never inherits the first sub's chain.
+        """
+        if explicit:
+            return [m.strip() for m in explicit.split(",") if m.strip()]
+        return [
+            m for m in default if self._key_available_in(key_env_for_model(m), creds)
+        ]
 
     def _chain(self, primary: str, legacy: str, default: tuple[str, ...]) -> list[str]:
         if primary:
@@ -435,10 +477,38 @@ class Settings(BaseSettings):
         # verbatim; an empty env falls to the curated default filtered to models
         # whose provider key is configured (none -> [] -> LLM feature off, never
         # a keyless cloud model that 401s at call time).
-        return self._chain(
-            self.llm_models,
-            "",
-            ("gemini/gemini-3-flash-preview", "openai/gpt-5.4-mini-2026-03-17"),
+        return self._chain(self.llm_models, "", self._DEFAULT_LLM_CHAIN)
+
+    # --- Per-sub (HTTP multi-user) chain resolution ---
+    #
+    # The single-user *_chain() methods above key-gate against ``os.environ``.
+    # In remote multi-user mode per-sub keys live in the request's PerPluginStore
+    # bucket (never in ``os.environ``), so these *_chain_for_creds variants
+    # resolve the chain from that explicit dict. An explicit ``<TASK>_MODELS``
+    # submitted by the user takes the chain field; otherwise the curated default
+    # is filtered to the providers the sub has a key for.
+
+    def embedding_chain_for_creds(self, creds: dict[str, str]) -> list[str]:
+        return self._chain_for_creds(
+            creds.get("EMBEDDING_MODELS", ""),
+            self._DEFAULT_EMBEDDING_CHAIN,
+            creds,
+        )
+
+    def rerank_chain_for_creds(self, creds: dict[str, str]) -> list[str]:
+        if not self.rerank_enabled:
+            return []
+        return self._chain_for_creds(
+            creds.get("RERANK_MODELS", ""),
+            self._DEFAULT_RERANK_CHAIN,
+            creds,
+        )
+
+    def llm_chain_for_creds(self, creds: dict[str, str]) -> list[str]:
+        return self._chain_for_creds(
+            creds.get("LLM_MODELS", ""),
+            self._DEFAULT_LLM_CHAIN,
+            creds,
         )
 
     # --- Embedding resolution ---

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -57,6 +57,7 @@ CLOUD_KEYS = [
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
     "COHERE_API_KEY",
+    "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
 ]
 
@@ -321,6 +322,51 @@ def credentials_for_current_request() -> dict[str, str]:
     if sub is None:
         return {k: v for k, v in os.environ.items() if k in CLOUD_KEYS and v}
     return read_for_sub(sub)
+
+
+# LLM-provider key env vars, in fallback-priority order. Used by the
+# sub-aware LLM availability gates (agent_orchestrator.detect_llm_provider /
+# llm._has_llm_provider). GOOGLE_API_KEY is the GEMINI alias; ANTHROPIC and
+# XAI round out the litellm-passthrough providers the relay form offers.
+LLM_PROVIDER_KEYS = (
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "XAI_API_KEY",
+)
+
+
+def detect_llm_provider_key() -> str | None:
+    """Return the first available LLM-provider key env name, or ``None``.
+
+    Sub-aware: in HTTP multi-user mode (``_current_sub`` set) it reads the
+    request's per-sub bucket via :func:`credentials_for_current_request` so
+    per-sub keys -- which never live in ``os.environ`` -- are seen. In stdio /
+    single-user mode it additionally consults ``os.environ`` directly so the
+    GEMINI alias ``GOOGLE_API_KEY`` (not a ``CLOUD_KEYS`` member) is still
+    honored. Order is the litellm fallback priority.
+
+    Centralises the availability check that ``agent_orchestrator`` and ``llm``
+    used to hand-maintain against an ``os.getenv`` tuple that (a) omitted
+    ANTHROPIC and (b) was blind to per-sub buckets.
+    """
+    sub = _current_sub.get()
+    creds = credentials_for_current_request()
+    for key in LLM_PROVIDER_KEYS:
+        if creds.get(key):
+            return key
+        # Single-user only: also honor env vars outside CLOUD_KEYS (the
+        # GOOGLE->GEMINI alias). Per-sub mode must NOT fall back to os.environ
+        # (that would read another process-global value, not this user's).
+        if sub is None and os.getenv(key):
+            return key
+    return None
+
+
+def has_llm_provider() -> bool:
+    """Whether any LLM provider key is available for the current request."""
+    return detect_llm_provider_key() is not None
 
 
 def api_key_for_model(model: str) -> str | None:

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -458,10 +458,60 @@ class Qwen3EmbedBackend:
 
 _backend: EmbeddingBackend | None = None
 
+# Shared local ONNX backend for the HTTP multi-user path. Local inference is
+# stateless and key-free, so a single instance is safely shared across subs
+# (no per-sub data flows through it). Lazily created so single-user / stdio
+# deployments that never hit the multi-user resolver don't download the model.
+_shared_local_backend: Qwen3EmbedBackend | None = None
+
 
 def get_backend() -> EmbeddingBackend | None:
-    """Get the current embedding backend singleton."""
+    """Get the current embedding backend singleton (startup-resolved)."""
     return _backend
+
+
+def _shared_local_embed_backend() -> Qwen3EmbedBackend:
+    """Return the process-shared local ONNX embedding backend (lazy)."""
+    global _shared_local_backend
+    if _shared_local_backend is None:
+        _shared_local_backend = Qwen3EmbedBackend()
+    return _shared_local_backend
+
+
+def resolve_embed_backend_for_request() -> EmbeddingBackend | None:
+    """Resolve the embedding backend for the CURRENT request.
+
+    * **Stdio / single-user HTTP** (``_current_sub`` is ``None``): return the
+      module-level startup singleton resolved once at lifespan start
+      (:func:`get_backend`). Behaviour is unchanged.
+
+    * **HTTP multi-user** (``_current_sub`` set): resolve PER REQUEST from the
+      sub's credential bucket. If the sub has a cloud embedding chain whose
+      provider key is present, build a fresh request-scoped
+      :class:`CloudEmbeddingBackend` carrying that sub's key explicitly (so the
+      key flows down the call, never into ``os.environ``). Otherwise fall back
+      to the process-shared local ONNX backend.
+
+    A per-sub request NEVER rebinds the module-level ``_backend`` singleton —
+    that would let one user's cloud model/key serve another concurrent user
+    (cross-sub contamination). The startup singleton is read-only here.
+    """
+    from wet_mcp.config import settings
+    from wet_mcp.credential_state import (
+        api_key_for_model,
+        credentials_for_current_request,
+        get_current_sub,
+    )
+
+    if get_current_sub() is None:
+        return get_backend()
+
+    creds = credentials_for_current_request()
+    chain = settings.embedding_chain_for_creds(creds)
+    if chain:
+        model = chain[0]
+        return CloudEmbeddingBackend(model, api_key=api_key_for_model(model))
+    return _shared_local_embed_backend()
 
 
 def init_backend(

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -46,13 +46,18 @@ def _strip_provider(model: str) -> str:
 
 
 def _has_llm_provider() -> bool:
-    """Check if any LLM provider API key is configured."""
-    return bool(
-        os.getenv("GEMINI_API_KEY")
-        or os.getenv("GOOGLE_API_KEY")
-        or os.getenv("OPENAI_API_KEY")
-        or os.getenv("XAI_API_KEY")
-    )
+    """Check if any LLM provider API key is configured.
+
+    Sub-aware (delegates to ``credential_state.has_llm_provider``): in HTTP
+    multi-user mode it reads the request's per-sub credential bucket (keys
+    that never live in ``os.environ``), and in stdio / single-user it reads
+    ``os.environ`` (incl. the GOOGLE->GEMINI alias). Now also recognises
+    ANTHROPIC_API_KEY — dispatch is litellm passthrough, which supports
+    anthropic/*, so the gate no longer drifts from the relay's offer.
+    """
+    from wet_mcp.credential_state import has_llm_provider
+
+    return has_llm_provider()
 
 
 def _detect_provider(model: str) -> str:

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -232,10 +232,59 @@ class Qwen3Reranker:
 
 _backend: RerankerBackend | None = None
 
+# Shared local ONNX reranker for the HTTP multi-user path. Local inference is
+# stateless and key-free, so one instance is safely shared across subs. Lazy
+# so single-user / stdio deployments never download the model unnecessarily.
+_shared_local_backend: Qwen3Reranker | None = None
+
 
 def get_reranker() -> RerankerBackend | None:
-    """Get the current reranker backend singleton."""
+    """Get the current reranker backend singleton (startup-resolved)."""
     return _backend
+
+
+def _shared_local_reranker() -> Qwen3Reranker:
+    """Return the process-shared local ONNX reranker backend (lazy)."""
+    global _shared_local_backend
+    if _shared_local_backend is None:
+        _shared_local_backend = Qwen3Reranker()
+    return _shared_local_backend
+
+
+def resolve_rerank_backend_for_request() -> RerankerBackend | None:
+    """Resolve the reranker backend for the CURRENT request.
+
+    * **Stdio / single-user HTTP** (``_current_sub`` is ``None``): return the
+      module-level startup singleton (:func:`get_reranker`). Unchanged.
+
+    * **HTTP multi-user** (``_current_sub`` set): resolve PER REQUEST from the
+      sub's credential bucket. If the sub has a cloud rerank chain whose
+      provider key is present, build a fresh request-scoped
+      :class:`CloudReranker` carrying that sub's key explicitly. Otherwise fall
+      back to the process-shared local ONNX reranker.
+
+    A per-sub request NEVER rebinds the module-level ``_backend`` singleton, so
+    one user's cloud reranker/key can't serve another concurrent user.
+    """
+    from wet_mcp.config import settings
+    from wet_mcp.credential_state import (
+        api_key_for_model,
+        credentials_for_current_request,
+        get_current_sub,
+    )
+
+    if get_current_sub() is None:
+        return get_reranker()
+
+    if not settings.rerank_enabled:
+        return None
+
+    creds = credentials_for_current_request()
+    chain = settings.rerank_chain_for_creds(creds)
+    if chain:
+        model = chain[0]
+        return CloudReranker(model=model, api_key=api_key_for_model(model))
+    return _shared_local_reranker()
 
 
 def init_reranker(

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -621,9 +621,9 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
         is_query: If True, use query_embed for instruction-aware asymmetric
             retrieval (Qwen3). Document embeddings stay raw.
     """
-    from wet_mcp.embedder import Qwen3EmbedBackend, get_backend
+    from wet_mcp.embedder import Qwen3EmbedBackend, resolve_embed_backend_for_request
 
-    backend = get_backend()
+    backend = resolve_embed_backend_for_request()
     if not backend:
         return None
     try:
@@ -637,9 +637,9 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
 
 async def _embed_batch(texts: list[str]) -> list[list[float]] | None:
     """Embed batch of texts if backend is available."""
-    from wet_mcp.embedder import get_backend
+    from wet_mcp.embedder import resolve_embed_backend_for_request
 
-    backend = get_backend()
+    backend = resolve_embed_backend_for_request()
     if not backend:
         return None
     try:
@@ -658,9 +658,9 @@ async def _rerank_results(
 
     Falls back to original results if reranking fails or is unavailable.
     """
-    from wet_mcp.reranker import get_reranker
+    from wet_mcp.reranker import resolve_rerank_backend_for_request
 
-    reranker = get_reranker()
+    reranker = resolve_rerank_backend_for_request()
     if not reranker or len(results) <= top_n:
         return results[:top_n]
 
@@ -2212,9 +2212,9 @@ async def _background_index_and_search(
         # Generate embeddings
         embeddings = None
         if all_chunks:
-            from wet_mcp.embedder import get_backend
+            from wet_mcp.embedder import resolve_embed_backend_for_request
 
-            if get_backend() is not None:
+            if resolve_embed_backend_for_request() is not None:
                 embed_texts_list = []
                 for c in all_chunks:
                     parts = []

--- a/src/wet_mcp/sources/agent_orchestrator.py
+++ b/src/wet_mcp/sources/agent_orchestrator.py
@@ -13,23 +13,18 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from typing import Any
 
 from loguru import logger
 
-# Order matches spec section 5.6 priority: Gemini > OpenAI > Anthropic > xAI.
-# wet currently does not ship an Anthropic SDK direct binding (it lives in
-# the LiteLLM-compatible layer that was dropped in Phase 1). The provider
-# is still listed so the env-detection error message stays accurate; if
-# only ANTHROPIC_API_KEY is set we fall through to "no provider" rather
-# than half-heartedly call a route we do not implement.
-_PROVIDER_KEYS = (
-    "GEMINI_API_KEY",
-    "GOOGLE_API_KEY",
-    "OPENAI_API_KEY",
-    "XAI_API_KEY",
-)
+from wet_mcp.credential_state import LLM_PROVIDER_KEYS
+
+# LLM-provider key env names, in spec-section-5.6 fallback priority. The
+# canonical list now lives in ``credential_state.LLM_PROVIDER_KEYS`` so the
+# availability gate is single-sourced (it previously omitted ANTHROPIC even
+# though dispatch is litellm passthrough, which supports anthropic/*).
+# Aliased here for the tests that key off ``ao._PROVIDER_KEYS``.
+_PROVIDER_KEYS = LLM_PROVIDER_KEYS
 
 _DEFAULT_MAX_URLS = 5
 _HARD_MAX_URLS = 20
@@ -43,13 +38,15 @@ _EXTRACT_CONCURRENCY = 3
 def detect_llm_provider() -> str | None:
     """Return the first configured provider key name, or ``None``.
 
-    Order is the spec-section-5.6 fallback chain. ``None`` means the
+    Sub-aware (delegates to ``credential_state.detect_llm_provider_key``): in
+    HTTP multi-user mode it reads the request's per-sub credential bucket so
+    keys that are never in ``os.environ`` are seen; in stdio / single-user it
+    reads ``os.environ`` (incl. the GOOGLE->GEMINI alias). ``None`` means the
     orchestrator should bail out with a structured error rather than try.
     """
-    for key in _PROVIDER_KEYS:
-        if os.getenv(key):
-            return key
-    return None
+    from wet_mcp.credential_state import detect_llm_provider_key
+
+    return detect_llm_provider_key()
 
 
 def _no_provider_error() -> str:

--- a/tests/test_multiuser_llm_gate_and_backend.py
+++ b/tests/test_multiuser_llm_gate_and_backend.py
@@ -1,0 +1,461 @@
+"""Multi-user LLM availability gates + per-request embed/rerank backend.
+
+Audit-confirmed bugs (single-user healthy; do not regress):
+
+1. Anthropic gate drift — the relay offers ANTHROPIC_API_KEY and suggests
+   ``anthropic/claude-*`` but the LLM availability gates excluded Anthropic,
+   so an Anthropic-only user could never run ``extract(action=agent)`` /
+   ``media(action=analyze)`` even though litellm passthrough supports it.
+
+2. Multi-user LLM gates read ``os.getenv`` — per-sub keys are never in
+   ``os.environ`` (they live in the per-sub PerPluginStore bucket), so the
+   gate must consult ``credentials_for_current_request()`` instead, or the
+   LLM features are permanently broken for every remote user.
+
+3. Embedding/rerank backend was a process-global singleton fixed at startup
+   from process env, so in multi-user a sub who submits a cloud embed/rerank
+   key still got LOCAL ONNX. The per-request resolver must build a per-sub
+   ``CloudEmbeddingBackend`` / ``CloudReranker`` (never rebinding the module
+   singleton), and a second sub must NOT see the first sub's key/chain.
+
+CRITICAL multi-user invariant: per-sub creds NEVER touch the process-global
+``os.environ``; they flow request-scoped via ``credentials_for_current_request``
+/ ``api_key_for_model`` bound to the per-request ``_current_sub`` contextvar.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wet_mcp.credential_state import (
+    CLOUD_KEYS,
+    set_current_sub,
+    store_for_sub,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """Each test: sub=None, no CLOUD_KEYS / *_MODELS chains in env, fresh store."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    set_current_sub(None)
+    for k in (*CLOUD_KEYS, "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    for k in ("EMBEDDING_MODELS", "RERANK_MODELS", "LLM_MODELS"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+    set_current_sub(None)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: Anthropic gate drift (single-user)
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicGateDriftSingleUser:
+    def test_detect_llm_provider_recognises_anthropic(self, monkeypatch):
+        from wet_mcp.sources import agent_orchestrator as ao
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+        assert ao.detect_llm_provider() == "ANTHROPIC_API_KEY"
+
+    def test_has_llm_provider_recognises_anthropic(self, monkeypatch):
+        from wet_mcp import llm
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+        assert llm._has_llm_provider() is True
+
+    async def test_run_agent_does_not_bail_with_anthropic_only(self, monkeypatch):
+        """An Anthropic-only single-user must clear the no-provider gate."""
+        from wet_mcp.sources import agent_orchestrator as ao
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+        # detect_llm_provider must be non-None so run_agent proceeds past the gate.
+        assert ao.detect_llm_provider() is not None
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: multi-user LLM gates must be sub-aware (not os.getenv)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiUserLlmGate:
+    def test_detect_llm_provider_reads_per_sub_bucket(self, monkeypatch):
+        from wet_mcp.sources import agent_orchestrator as ao
+
+        store_for_sub("user_a", {"GEMINI_API_KEY": "gem_a"})
+        # No keys in os.environ at all (cleared by fixture).
+        set_current_sub("user_a")
+        assert ao.detect_llm_provider() == "GEMINI_API_KEY"
+
+    def test_detect_llm_provider_per_sub_anthropic(self, monkeypatch):
+        from wet_mcp.sources import agent_orchestrator as ao
+
+        store_for_sub("user_a", {"ANTHROPIC_API_KEY": "sk-ant-a"})
+        set_current_sub("user_a")
+        assert ao.detect_llm_provider() == "ANTHROPIC_API_KEY"
+
+    def test_has_llm_provider_reads_per_sub_bucket(self, monkeypatch):
+        from wet_mcp import llm
+
+        store_for_sub("user_a", {"OPENAI_API_KEY": "oai_a"})
+        set_current_sub("user_a")
+        assert llm._has_llm_provider() is True
+
+    def test_gate_does_not_bleed_across_subs(self, monkeypatch):
+        """User B with no LLM key must NOT see user A's key via the gate."""
+        from wet_mcp import llm
+        from wet_mcp.sources import agent_orchestrator as ao
+
+        store_for_sub("user_a", {"GEMINI_API_KEY": "gem_a"})
+        store_for_sub("user_b", {"JINA_AI_API_KEY": "jina_b"})  # embed-only, no LLM
+
+        set_current_sub("user_a")
+        assert ao.detect_llm_provider() == "GEMINI_API_KEY"
+        assert llm._has_llm_provider() is True
+
+        set_current_sub("user_b")
+        # Jina is an embedding/rerank provider, not an LLM provider -> no LLM.
+        assert ao.detect_llm_provider() is None
+        assert llm._has_llm_provider() is False
+
+    def test_gate_false_when_sub_has_no_keys(self):
+        from wet_mcp import llm
+        from wet_mcp.sources import agent_orchestrator as ao
+
+        store_for_sub("empty_user", {})
+        set_current_sub("empty_user")
+        assert ao.detect_llm_provider() is None
+        assert llm._has_llm_provider() is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: per-request embed/rerank backend resolution (multi-user)
+# ---------------------------------------------------------------------------
+
+
+class TestPerRequestEmbedBackend:
+    def test_single_user_returns_startup_singleton(self, monkeypatch):
+        """sub=None -> the module-level startup singleton, unchanged."""
+        from wet_mcp import embedder
+        from wet_mcp.embedder import (
+            Qwen3EmbedBackend,
+            resolve_embed_backend_for_request,
+        )
+
+        sentinel = Qwen3EmbedBackend()
+        monkeypatch.setattr(embedder, "_backend", sentinel)
+        assert resolve_embed_backend_for_request() is sentinel
+
+    def test_multi_user_cloud_key_builds_cloud_backend(self, monkeypatch):
+        """sub with a cloud embed chain+key -> a per-request CloudEmbeddingBackend."""
+        from wet_mcp.embedder import (
+            CloudEmbeddingBackend,
+            resolve_embed_backend_for_request,
+        )
+
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+                "JINA_AI_API_KEY": "jina_a",
+            },
+        )
+        set_current_sub("user_a")
+        backend = resolve_embed_backend_for_request()
+        assert isinstance(backend, CloudEmbeddingBackend)
+        assert backend.model == "jina_ai/jina-embeddings-v5-text-small"
+
+    def test_multi_user_default_chain_with_key_builds_cloud(self, monkeypatch):
+        """No explicit chain but a provider key -> the key-gated default cloud model."""
+        from wet_mcp.embedder import (
+            CloudEmbeddingBackend,
+            resolve_embed_backend_for_request,
+        )
+
+        store_for_sub("user_a", {"JINA_AI_API_KEY": "jina_a"})
+        set_current_sub("user_a")
+        backend = resolve_embed_backend_for_request()
+        assert isinstance(backend, CloudEmbeddingBackend)
+        # jina is first in the default chain -> picked when its key is present.
+        assert "jina" in backend.model.lower()
+
+    def test_multi_user_no_cloud_key_uses_local(self, monkeypatch):
+        """sub with no embed provider key -> shared local ONNX (not cloud)."""
+        from wet_mcp.embedder import (
+            CloudEmbeddingBackend,
+            resolve_embed_backend_for_request,
+        )
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})  # no embed provider key
+        set_current_sub("user_a")
+        backend = resolve_embed_backend_for_request()
+        assert not isinstance(backend, CloudEmbeddingBackend)
+
+    def test_multi_user_does_not_rebind_singleton(self, monkeypatch):
+        """Resolving a per-sub cloud backend must NOT mutate the module singleton."""
+        from wet_mcp import embedder
+        from wet_mcp.embedder import (
+            Qwen3EmbedBackend,
+            resolve_embed_backend_for_request,
+        )
+
+        startup = Qwen3EmbedBackend()
+        monkeypatch.setattr(embedder, "_backend", startup)
+
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+                "JINA_AI_API_KEY": "jina_a",
+            },
+        )
+        set_current_sub("user_a")
+        resolve_embed_backend_for_request()
+        # Module singleton stays the startup local backend (no cross-sub contamination).
+        assert embedder.get_backend() is startup
+
+    def test_second_sub_does_not_see_first_sub_chain(self, monkeypatch):
+        """The headline isolation test: sub B must NOT inherit sub A's cloud chain."""
+        from wet_mcp.embedder import (
+            CloudEmbeddingBackend,
+            resolve_embed_backend_for_request,
+        )
+
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "gemini/gemini-embedding-001",
+                "GEMINI_API_KEY": "gem_a",
+            },
+        )
+        store_for_sub("user_b", {})  # nothing configured
+
+        set_current_sub("user_a")
+        a_backend = resolve_embed_backend_for_request()
+        assert isinstance(a_backend, CloudEmbeddingBackend)
+        assert a_backend.model == "gemini/gemini-embedding-001"
+
+        set_current_sub("user_b")
+        b_backend = resolve_embed_backend_for_request()
+        # User B has no cloud key/chain -> local ONNX, NOT A's gemini cloud model.
+        assert not isinstance(b_backend, CloudEmbeddingBackend)
+
+
+class TestPerRequestRerankBackend:
+    def test_single_user_returns_startup_singleton(self, monkeypatch):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import (
+            Qwen3Reranker,
+            resolve_rerank_backend_for_request,
+        )
+
+        sentinel = Qwen3Reranker()
+        monkeypatch.setattr(reranker, "_backend", sentinel)
+        assert resolve_rerank_backend_for_request() is sentinel
+
+    def test_multi_user_cloud_key_builds_cloud_reranker(self, monkeypatch):
+        from wet_mcp.reranker import (
+            CloudReranker,
+            resolve_rerank_backend_for_request,
+        )
+
+        store_for_sub(
+            "user_a",
+            {
+                "RERANK_MODELS": "cohere/rerank-v3.5",
+                "COHERE_API_KEY": "co_a",
+            },
+        )
+        set_current_sub("user_a")
+        backend = resolve_rerank_backend_for_request()
+        assert isinstance(backend, CloudReranker)
+        assert backend.model == "cohere/rerank-v3.5"
+
+    def test_multi_user_no_cloud_key_uses_local(self, monkeypatch):
+        from wet_mcp.reranker import (
+            CloudReranker,
+            resolve_rerank_backend_for_request,
+        )
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+        backend = resolve_rerank_backend_for_request()
+        assert not isinstance(backend, CloudReranker)
+
+    def test_second_sub_does_not_see_first_sub_rerank_key(self, monkeypatch):
+        from wet_mcp.reranker import (
+            CloudReranker,
+            resolve_rerank_backend_for_request,
+        )
+
+        store_for_sub(
+            "user_a",
+            {"RERANK_MODELS": "cohere/rerank-v3.5", "COHERE_API_KEY": "co_a"},
+        )
+        store_for_sub("user_b", {})
+
+        set_current_sub("user_a")
+        assert isinstance(resolve_rerank_backend_for_request(), CloudReranker)
+
+        set_current_sub("user_b")
+        assert not isinstance(resolve_rerank_backend_for_request(), CloudReranker)
+
+    def test_multi_user_does_not_rebind_singleton(self, monkeypatch):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import (
+            Qwen3Reranker,
+            resolve_rerank_backend_for_request,
+        )
+
+        startup = Qwen3Reranker()
+        monkeypatch.setattr(reranker, "_backend", startup)
+
+        store_for_sub(
+            "user_a",
+            {"RERANK_MODELS": "cohere/rerank-v3.5", "COHERE_API_KEY": "co_a"},
+        )
+        set_current_sub("user_a")
+        resolve_rerank_backend_for_request()
+        assert reranker.get_reranker() is startup
+
+
+class TestPerRequestBackendForwardsKey:
+    """The per-request cloud backend forwards the per-sub key to litellm."""
+
+    async def test_embed_backend_uses_per_sub_key(self, monkeypatch):
+        from wet_mcp.embedder import resolve_embed_backend_for_request
+
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+                "JINA_AI_API_KEY": "jina_a",
+            },
+        )
+
+        captured: dict = {}
+
+        async def fake_aembedding(**kwargs):
+            captured.update(kwargs)
+
+            class _R:
+                data = [{"index": 0, "embedding": [0.1, 0.2]}]
+
+            return _R()
+
+        monkeypatch.setattr("mcp_core.llm.aembedding", fake_aembedding)
+        set_current_sub("user_a")
+        backend = resolve_embed_backend_for_request()
+        await backend.embed_single("hello")
+        assert captured["api_key"] == "jina_a"
+
+    def test_rerank_backend_uses_per_sub_key(self, monkeypatch):
+        from wet_mcp.reranker import resolve_rerank_backend_for_request
+
+        store_for_sub(
+            "user_a",
+            {"RERANK_MODELS": "cohere/rerank-v3.5", "COHERE_API_KEY": "co_a"},
+        )
+
+        captured: dict = {}
+
+        def fake_rerank(**kwargs):
+            captured.update(kwargs)
+
+            class _R:
+                results = [{"index": 0, "relevance_score": 0.9}]
+
+            return _R()
+
+        monkeypatch.setattr("mcp_core.llm.rerank", fake_rerank)
+        set_current_sub("user_a")
+        backend = resolve_rerank_backend_for_request()
+        backend.rerank("q", ["doc"], top_n=1)
+        assert captured["api_key"] == "co_a"
+
+
+class TestLiveDispatchWiring:
+    """The server dispatch helpers resolve the backend PER REQUEST.
+
+    Guards against regressing the wiring back to the module-level singleton
+    (the original bug): ``_embed`` / ``_embed_batch`` / ``_rerank_results``
+    must consult the per-request resolver so a sub's cloud key actually takes
+    effect at call time.
+    """
+
+    async def test_embed_uses_per_sub_cloud_backend(self, monkeypatch):
+        from wet_mcp import server
+
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+                "JINA_AI_API_KEY": "jina_a",
+            },
+        )
+
+        captured: dict = {}
+
+        async def fake_aembedding(**kwargs):
+            captured.update(kwargs)
+
+            class _R:
+                data = [{"index": 0, "embedding": [0.1] * 768}]
+
+            return _R()
+
+        monkeypatch.setattr("mcp_core.llm.aembedding", fake_aembedding)
+        set_current_sub("user_a")
+        vec = await server._embed("hello")
+        assert vec is not None
+        # The live dispatch forwarded user_a's per-sub key (not os.environ).
+        assert captured["api_key"] == "jina_a"
+        assert captured["model"] == "jina_ai/jina-embeddings-v5-text-small"
+
+    async def test_rerank_results_uses_per_sub_cloud_backend(self, monkeypatch):
+        from wet_mcp import server
+
+        store_for_sub(
+            "user_a",
+            {"RERANK_MODELS": "cohere/rerank-v3.5", "COHERE_API_KEY": "co_a"},
+        )
+
+        captured: dict = {}
+
+        def fake_rerank(**kwargs):
+            captured.update(kwargs)
+
+            class _R:
+                results = [
+                    {"index": 1, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.1},
+                ]
+
+            return _R()
+
+        monkeypatch.setattr("mcp_core.llm.rerank", fake_rerank)
+        set_current_sub("user_a")
+        results = [{"content": "doc-a"}, {"content": "doc-b"}]
+        ranked = await server._rerank_results("q", results, top_n=1)
+        assert captured["api_key"] == "co_a"
+        # top result is index 1 (doc-b) per the fake scores.
+        assert ranked[0]["content"] == "doc-b"
+
+    async def test_single_user_embed_unchanged(self, monkeypatch):
+        """sub=None still uses the startup singleton (no behaviour change)."""
+        from wet_mcp import embedder, server
+
+        calls: list[str] = []
+
+        class _FakeBackend:
+            async def embed_single(self, text, dims=None):
+                calls.append(text)
+                return [0.5] * 4
+
+        monkeypatch.setattr(embedder, "_backend", _FakeBackend())
+        set_current_sub(None)
+        vec = await server._embed("hi")
+        assert vec == [0.5] * 4
+        assert calls == ["hi"]


### PR DESCRIPTION
## Summary

Fixes three audit-confirmed multi-user bugs in wet-mcp. Single-user (sub is None / `PUBLIC_URL` unset) behaviour is unchanged; these only affected the remote multi-user (per-JWT-sub) deployment.

### 1. Anthropic gate drift
The relay form offers `ANTHROPIC_API_KEY` and suggests `anthropic/claude-*`, but the LLM availability gates (`agent_orchestrator.detect_llm_provider`, `llm._has_llm_provider`) checked a hand-maintained provider-key tuple of gemini/google/openai/xai only. Since dispatch is litellm passthrough (which supports `anthropic/*`), an Anthropic-only user could never run `extract(action="agent")` even though the actual call would have worked. The gates are now single-sourced on `credential_state.LLM_PROVIDER_KEYS` and recognise Anthropic (also added to `CLOUD_KEYS` so credential-state detection counts it as configured).

### 2. Multi-user LLM gates read `os.getenv`
In multi-user mode per-sub keys live in the per-sub `PerPluginStore` bucket and are **never** copied to `os.environ` (that would bleed one user's key into a concurrent request of another). The gates read `os.getenv` directly, so `extract(action="agent")` and `analyze_media` were permanently broken for every remote user. The gates now resolve availability via `credentials_for_current_request()` — the per-sub bucket when `_current_sub` is set, `os.environ` (incl. the GOOGLE→GEMINI alias) otherwise.

### 3. Embedding/rerank backend was a startup process-global singleton
`server._init_embedding_backend` / `_init_reranker_backend` resolved the backend once at startup from process env. In multi-user, a sub who submitted a cloud embed/rerank key still got LOCAL ONNX (their selection ignored). New `resolve_embed_backend_for_request` / `resolve_rerank_backend_for_request`:
- single-user (`_current_sub` is None) → the startup singleton (unchanged);
- multi-user → build a fresh per-request `CloudEmbeddingBackend` / `CloudReranker` from the current sub's chain + key (forwarded explicitly via `api_key_for_model`, never `os.environ`) when a provider key is present; empty chain → process-shared local ONNX.

The module-level singleton is **never rebound** from a per-sub request, so one user's cloud model/key can't serve another concurrent sub. The dispatch helpers (`_embed`, `_embed_batch`, `_rerank_results`, and the background-index embed check) are wired to the per-request resolver.

## Security invariant (multi-user isolation)
Per-sub credentials stay request-scoped via the `_current_sub` contextvar and `api_key_for_model`; they never touch the process-global `os.environ`. `tests/test_multiuser_llm_gate_and_backend.py` includes explicit tests that **a second sub does NOT see the first sub's key/chain** (gate, embed backend, and rerank backend), plus single-user no-regression tests.

## Tests
- New: `tests/test_multiuser_llm_gate_and_backend.py` (24 tests) covering all three bugs + live-dispatch wiring + cross-sub isolation.
- Full suite: **1964 passed, 33 skipped, 0 failed**.
- `ruff check` + `ruff format --check` clean; `ty check` shows only 2 pre-existing diagnostics (confirmed present on `origin/main`, unrelated to this change).

## Note for reviewer
Per the multi-user isolation review gate, this PR is intentionally **not merged** — the lead reviews multi-user-isolation diffs before merge.
