### PR TITLE
fix: rightsize CF container to fit $10 budget

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -209,7 +209,7 @@ function extractUserId(request: Request): string {
 // + EXPOSE 8080).
 export class WetContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '1h'
+  sleepAfter = '5m'
   // The container reaches cloud model/search APIs (Jina, Vertex, Tavily) over the
   // public internet; kv/d1/vectorize.internal stay intercepted (see outboundByHost).
   enableInternet = true

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,8 +14,8 @@
       // image first: `docker pull ghcr.io/n24q02m/wet-mcp:beta && docker tag ... wet-mcp:beta
       // && wrangler containers push wet-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/wet-mcp:beta",
-      "instance_type": "standard-1",
-      "max_instances": 100
+      "instance_type": "basic",
+      "max_instances": 10
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
## Why

Container memory (GiB-second) is ~95% of the Cloudflare bill for this server, currently **189% over the $10 budget**. Cloud-mode wet-mcp is stateless: embed/rerank/LLM run via cloud providers (Jina / Vertex / xAI), credentials live in KV + D1, and no local ONNX model is loaded into the container. It therefore needs well under 1 GiB of memory.

## Changes (config-only)

| File | Field | Before | After |
|---|---|---|---|
| `wrangler.jsonc` | `instance_type` | `standard-1` (4 GiB) | `basic` (1 GiB) |
| `wrangler.jsonc` | `max_instances` | `100` | `10` |
| `src/worker.ts` | `WetContainer.sleepAfter` | `1h` | `5m` |

`sleepAfter` drops to 5m because there is no in-RAM auth window to preserve — credentials are persisted in KV/D1, so idle containers can sleep aggressively and stop accruing GiB-second charges.

No application logic changed (`defaultPort`, outbound handlers, env forwarding all untouched).

## Verification

- `wrangler deploy --dry-run`: exits 0, no config/schema parse error; `basic` + `max_instances: 10` accepted, container entry recognized.
- `bun run test:worker` (vitest): 9/9 pass.
- docs-sync CLAUDE.md <-> AGENTS.md guard: pass.
- Pre-existing `tsc` errors in `tests/worker.test.ts` are unrelated to this change (identical on clean `origin/main`); CI does not run `tsc`.