### PR TITLE
fix: keep wet container on standard-1 (basic 4GB disk too small for crawl4ai image)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,7 +14,7 @@
       // image first: `docker pull ghcr.io/n24q02m/wet-mcp:beta && docker tag ... wet-mcp:beta
       // && wrangler containers push wet-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/wet-mcp:beta",
-      "instance_type": "basic",
+      "instance_type": "standard-1",
       "max_instances": 10
     }
   ],


### PR DESCRIPTION
## Problem

PR #1406 set the wet CF container to `instance_type=basic`. The live redeploy FAILED with `ImagePullRequestedDiskSizeToSmall`: the `basic` instance type ships a 4GB disk, too small to unpack the heavy wet image (crawl4ai + deps). The deploy was rolled back to `standard-1` (8GB disk), so wet's main has carried an un-deployable `instance_type=basic` while the live worker ran the old config (standard-1 / old worker / max=3) with no cost savings applied.

## Fix

Revert ONLY `instance_type` `basic` -> `standard-1` so the heavy image fits the 8GB disk. Everything else from #1406 stays:

- `worker.ts` `sleepAfter = '5m'` (kept) -- this is the big idle-cost lever (~12x idle reduction) and works at any instance size.
- `wrangler.jsonc` `max_instances: 10` (kept).

Net effect: the idle-cost win lands on `standard-1` without the disk/OOM risk.

## Follow-up (not in this PR)

Slimming the wet Docker image (multi-stage build, drop build-only deps) below the 4GB `basic` disk would later allow moving to `basic` for an additional ~4x memory cut.