### PR TITLE
fix: pin CF container max_instances to 3

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,7 +15,7 @@
       // && wrangler containers push wet-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/wet-mcp:beta",
       "instance_type": "standard-1",
-      "max_instances": 10
+      "max_instances": 3
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
The live CF app already runs `max_instances=3` (PATCHed directly), but the committed `wrangler.jsonc` still said `max_instances: 10` — a future `wrangler deploy` would regress the live setting back to 10.

This pins the committed config to match live (3), eliminating the drift. Only that one number changed; `instance_type`, `image`, and everything else are untouched.