### PR TITLE
fix: force real litellm to win unclecode-litellm file collision to restore catalog/LLM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,17 @@ RUN sed -i '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml && \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
+# crawl4ai pulls `unclecode-litellm` (a hard fork that ships files under the same
+# top-level `litellm/` package as real `litellm`). The two distributions collide
+# on `litellm/constants.py`; install order decides which wins, and when the fork's
+# older constants.py (no REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD) lands last the
+# real litellm 1.89.x redis_cache.py fails to import -> mcp_core.llm.catalog dies.
+# Reinstall real litellm LAST so its files are authoritative, then a build-time
+# smoke test fails the build loud rather than ever shipping a broken litellm.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --reinstall-package litellm "litellm==$(uv pip show litellm | awk '/^Version:/ {print $2}')" \
+    && uv run python -c "import litellm; from litellm.constants import REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD; from mcp_core.llm.catalog import list_models; n=len(list_models(modes=('chat',), configured_only=False, limit=5000)); assert n > 100, f'catalog too small: {n}'; print(f'litellm import OK, catalog chat models={n}')"
+
 # Install SearXNG from GitHub (zip archive + no-build-isolation for speed)
 # Then patch version_frozen.py (zip has no .git for version detection)
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
## Problem

`wet-mcp:3.3.0-beta.20` shipped a broken litellm: `import litellm` inside the image raised `ImportError: cannot import name 'REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD' from 'litellm.constants'`, so `mcp_core.llm.catalog.list_models` raised and the relay model-chain data-catalog rendered empty.

## Root cause (verified)

Not a version skew — both wet and imagine lock litellm `1.89.3` + mcp-core `1.18.0b19`. wet additionally depends on `crawl4ai 0.9.0` (via web-core), which hard-depends on **`unclecode-litellm 1.81.13`**, a fork that ships files under the same top-level `litellm/` package as real litellm. The two distributions **collide on `litellm/constants.py`**; install order is non-deterministic:

- b19: real litellm's constants.py won (67446 bytes) -> import OK, catalog=2215.
- b20: the fork's older constants.py won (54484 bytes, no `REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD`) -> real litellm's `redis_cache.py` import fails.

imagine has no crawl4ai -> no unclecode-litellm -> no collision -> always works.

A fresh `--no-cache` build reproduced the broken 54484-byte state at post-sync, confirming the install-order collision.

## Fix

In the builder, reinstall real litellm **last** so its files are authoritative, then a build-time smoke test asserts `import litellm` + the constant + `catalog chat models > 100`, failing the build loud instead of ever shipping a broken litellm again.

## Verification

Built builder target locally: `litellm import OK, catalog chat models=2215`. The exact STEP-3 command (`import litellm; list_models(modes=('chat',)...)`) prints `2215` inside the fixed image.