### PR TITLE
⚡ Bolt: Optimize doc cleaning pipeline to prevent redundant string allocations

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 import zlib
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urljoin, urlparse
@@ -2023,7 +2024,7 @@ _MKDOCS_UI_RE = re.compile(
 _NAV_BLOCK_MIN_LINES = 8
 
 
-def _strip_nav_blocks(lines: list[str]) -> list[str]:
+def _strip_nav_blocks(lines: Sequence[str]) -> list[str]:
     """Remove navigation sidebar blocks from crawled content.
 
     Detects blocks of 8+ consecutive lines that look like site navigation
@@ -2054,7 +2055,7 @@ def _strip_nav_blocks(lines: list[str]) -> list[str]:
     return result
 
 
-def _strip_nav_heading_blocks(lines: list[str]) -> list[str]:
+def _strip_nav_heading_blocks(lines: Sequence[str]) -> list[str]:
     """Remove navigation-like blocks of consecutive headings.
 
     Navigation sidebars from rendered HTML sometimes produce long sequences
@@ -2077,7 +2078,7 @@ def _strip_nav_heading_blocks(lines: list[str]) -> list[str]:
             headings[i] = (len(m.group(1)), m.group(2))
 
     if len(headings) < 5:
-        return lines
+        return list(lines)
 
     # Find runs of same-level headings with minimal content between them
     nav_lines: set[int] = set()
@@ -2109,7 +2110,7 @@ def _strip_nav_heading_blocks(lines: list[str]) -> list[str]:
             i += 1
 
     if not nav_lines:
-        return lines
+        return list(lines)
 
     return [line for i, line in enumerate(lines) if i not in nav_lines]
 

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -2023,7 +2023,7 @@ _MKDOCS_UI_RE = re.compile(
 _NAV_BLOCK_MIN_LINES = 8
 
 
-def _strip_nav_blocks(content: str) -> str:
+def _strip_nav_blocks(lines: list[str]) -> list[str]:
     """Remove navigation sidebar blocks from crawled content.
 
     Detects blocks of 8+ consecutive lines that look like site navigation
@@ -2031,7 +2031,6 @@ def _strip_nav_blocks(content: str) -> str:
     This targets MkDocs Material sidebars, Sphinx toctrees, and similar
     navigation structures that leak into crawled markdown.
     """
-    lines = content.splitlines()
     result: list[str] = []
     nav_block: list[str] = []
 
@@ -2052,10 +2051,10 @@ def _strip_nav_blocks(content: str) -> str:
     if len(nav_block) < _NAV_BLOCK_MIN_LINES:
         result.extend(nav_block)
 
-    return "\n".join(result)
+    return result
 
 
-def _strip_nav_heading_blocks(content: str) -> str:
+def _strip_nav_heading_blocks(lines: list[str]) -> list[str]:
     """Remove navigation-like blocks of consecutive headings.
 
     Navigation sidebars from rendered HTML sometimes produce long sequences
@@ -2070,8 +2069,6 @@ def _strip_nav_heading_blocks(content: str) -> str:
     When 5+ consecutive headings at the same level have <= 50 chars of text
     between them, they are stripped as navigation artifacts.
     """
-    lines = content.splitlines()
-
     # Build heading map: line_index -> (level, text)
     headings: dict[int, tuple[int, str]] = {}
     for i, line in enumerate(lines):
@@ -2080,7 +2077,7 @@ def _strip_nav_heading_blocks(content: str) -> str:
             headings[i] = (len(m.group(1)), m.group(2))
 
     if len(headings) < 5:
-        return content
+        return lines
 
     # Find runs of same-level headings with minimal content between them
     nav_lines: set[int] = set()
@@ -2112,9 +2109,9 @@ def _strip_nav_heading_blocks(content: str) -> str:
             i += 1
 
     if not nav_lines:
-        return content
+        return lines
 
-    return "\n".join(line for i, line in enumerate(lines) if i not in nav_lines)
+    return [line for i, line in enumerate(lines) if i not in nav_lines]
 
 
 # Patterns that indicate a page was blocked by bot protection (Cloudflare,
@@ -2187,14 +2184,18 @@ def _clean_doc_content(content: str) -> str:
     # Remove TOC anchor links (- [Title](#section))
     content = _TOC_LINK_RE.sub("", content)
 
+    # ⚡ Bolt Optimization: optimize text processing by passing a `list[str]`
+    # through multiple helper functions instead of repeatedly splitting and
+    # re-joining strings via `splitlines()` and `\n.join()`.
+    lines = content.splitlines()
+
     # Remove navigation sidebar blocks (MkDocs Material, Sphinx, etc.)
-    content = _strip_nav_blocks(content)
+    lines = _strip_nav_blocks(lines)
 
     # Remove navigation heading blocks (## Topic A / ## Topic B / ...)
-    content = _strip_nav_heading_blocks(content)
+    lines = _strip_nav_heading_blocks(lines)
 
     # Filter noise lines
-    lines = content.splitlines()
     cleaned = []
     for line in lines:
         stripped = line.strip()

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -1408,17 +1408,19 @@ class TestStripNavBlocks:
         """Removes blocks of 8+ consecutive nav link lines."""
         nav_lines = [f"- [Page {i}](https://example.com/page{i})" for i in range(10)]
         content = "# Title\n\nIntro text.\n\n" + "\n".join(nav_lines) + "\n\nContent."
-        result = _strip_nav_blocks(content)
-        assert "Page 5" not in result
-        assert "Intro text." in result
-        assert "Content." in result
+        result = _strip_nav_blocks(content.splitlines())
+        result_str = "\n".join(result)
+        assert "Page 5" not in result_str
+        assert "Intro text." in result_str
+        assert "Content." in result_str
 
     def test_keeps_short_link_list(self):
         """Keeps blocks of fewer than 8 nav link lines."""
         nav_lines = [f"- [Page {i}](https://example.com/page{i})" for i in range(3)]
         content = "# Title\n\n" + "\n".join(nav_lines) + "\n\nContent."
-        result = _strip_nav_blocks(content)
-        assert "Page 1" in result
+        result = _strip_nav_blocks(content.splitlines())
+        result_str = "\n".join(result)
+        assert "Page 1" in result_str
 
 
 # ---------------------------------------------------------------------------
@@ -1431,9 +1433,10 @@ class TestStripNavHeadingBlocks:
         """Removes 5+ consecutive same-level headings with no content."""
         headings = "\n".join([f"## Topic {i}" for i in range(7)])
         content = "# Title\n\nIntro.\n\n" + headings + "\n\nContent."
-        result = _strip_nav_heading_blocks(content)
-        assert "Topic 3" not in result
-        assert "Intro." in result
+        result = _strip_nav_heading_blocks(content.splitlines())
+        result_str = "\n".join(result)
+        assert "Topic 3" not in result_str
+        assert "Intro." in result_str
 
     def test_keeps_headings_with_content(self):
         """Keeps headings that have substantial content between them."""
@@ -1442,14 +1445,15 @@ class TestStripNavHeadingBlocks:
             lines.append(f"## Section {i}")
             lines.append("x" * 100)  # Substantial content
         content = "\n".join(lines)
-        result = _strip_nav_heading_blocks(content)
-        assert "Section 3" in result
+        result = _strip_nav_heading_blocks(content.splitlines())
+        result_str = "\n".join(result)
+        assert "Section 3" in result_str
 
     def test_fewer_than_5_headings_unchanged(self):
         """Content with fewer than 5 headings is returned unchanged."""
         content = "## A\nText\n## B\nText\n## C\nText"
-        result = _strip_nav_heading_blocks(content)
-        assert result == content
+        result = _strip_nav_heading_blocks(content.splitlines())
+        assert result == content.splitlines()
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -3425,7 +3425,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0b21"
+version = "3.3.0b22"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
**💡 What:** I updated the `_clean_doc_content` function and its two helper functions, `_strip_nav_blocks` and `_strip_nav_heading_blocks`, to operate on a `list[str]` instead of a single string.
**🎯 Why:** The previous implementation repeatedly split the content into lines and joined it back together using `.splitlines()` and `\n.join()`. This caused redundant memory allocation and string concatenation, which hurts performance, especially with large crawled documents.
**📊 Impact:** Reduced string allocations and time complexity associated with line manipulations. The text is split into lines exactly once, filtered, and then processed.
**🔬 Measurement:** Test coverage maintains functional parity, and benchmark tools / profilers should show fewer `str.join` calls and lower memory pressure during Tier 2 docs ingestion.

---
*PR created automatically by Jules for task [5640058979776014321](https://jules.google.com/task/5640058979776014321) started by @n24q02m*