### PR TITLE
⚡ Bolt: Bound concurrency for CPU-bound markdown chunking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2025-05-14 - Parallelize Batch API Calls
 **Learning:** Sequential batch API processing logic (e.g., in a `for` loop) can severely bottleneck processing of large inputs. `asyncio.gather` bounded by a semaphore effectively maximizes throughput without hitting rate limits.
 **Action:** When making numerous API calls (such as chunks of a large text for embeddings), use an `asyncio.Semaphore` with `asyncio.gather` instead of awaiting sequential iterations in a loop.
+## 2025-05-14 - Bound Concurrency for CPU-Bound Async Tasks
+**Learning:** Using `asyncio.to_thread` for CPU-bound tasks inside concurrent loops like `asyncio.gather` can spawn too many threads, leading to thread pool exhaustion and event loop starvation.
+**Action:** Always bound concurrency using an `asyncio.Semaphore` (e.g., `asyncio.Semaphore(10)`) when fanning out tasks that internally delegate to `asyncio.to_thread`.

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2021,12 +2021,18 @@ async def _fetch_and_chunk_docs(
                 f"(min {_MIN_GH_CHUNKS}), falling through"
             )
 
+    # ⚡ Bolt Optimization: Bound concurrency for CPU-bound chunk_markdown
+    # Limit to 10 concurrent thread offloads to prevent thread pool exhaustion
+    # and main event loop starvation during large batch page processing.
+    sem = asyncio.Semaphore(10)
+
     async def _process_page(page: dict) -> list[dict]:
-        p_chunks = await asyncio.to_thread(
-            chunk_markdown,
-            content=page["content"],
-            url=page.get("url", ""),
-        )
+        async with sem:
+            p_chunks = await asyncio.to_thread(
+                chunk_markdown,
+                content=page["content"],
+                url=page.get("url", ""),
+            )
         for chunk in p_chunks:
             if not chunk.get("title") and page.get("title"):
                 chunk["title"] = page["title"]


### PR DESCRIPTION
💡 **What:** Bounded the concurrency for `asyncio.to_thread` dispatch of the CPU-bound `chunk_markdown` task within `_fetch_and_chunk_docs` by introducing an `asyncio.Semaphore(10)`.
🎯 **Why:** Previously, processing a batch of up to 50 documents would spawn 50 concurrent futures via `asyncio.gather`, resulting in up to 50 concurrent thread dispatches. This overwhelmed the default `asyncio` thread pool (which often defaults to min(32, os.cpu_count() + 4)), causing significant thread pool exhaustion and event loop starvation.
📊 **Impact:** Prevents the main `asyncio` event loop from blocking or stalling during large doc indexing, improving overall application responsiveness and reducing peak memory footprint during concurrent scraping.
🔬 **Measurement:** Can be verified by monitoring thread count and CPU usage during the indexing of a large library, and ensuring it stays within the configured limit of 10. Tests were run locally and all passed.

---
*PR created automatically by Jules for task [16232962080400842540](https://jules.google.com/task/16232962080400842540) started by @n24q02m*