### PR TITLE
[TEST] Missing test for rerank_chain_for_creds in src/wet_mcp/config.py

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -661,3 +661,44 @@ def test_wet_google_alias_satisfies_gemini(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "x")
     # GOOGLE_API_KEY alias satisfies GEMINI_API_KEY for the gemini default.
     assert "gemini/gemini-embedding-001" in Settings().embedding_chain()
+
+
+# -----------------------------------------------------------------------
+# Per-sub chain resolution (chain_for_creds)
+# -----------------------------------------------------------------------
+
+
+def test_embedding_chain_for_creds():
+    s = Settings()
+    # Explicit
+    assert s.embedding_chain_for_creds({"EMBEDDING_MODELS": "a,b"}) == ["a", "b"]
+    # Default filtered
+    creds = {"GEMINI_API_KEY": "x"}
+    assert s.embedding_chain_for_creds(creds) == ["gemini/gemini-embedding-001"]
+    # Default filtered - none
+    assert s.embedding_chain_for_creds({}) == []
+
+
+def test_rerank_chain_for_creds():
+    # Disabled
+    assert Settings(rerank_enabled=False).rerank_chain_for_creds({}) == []
+
+    s = Settings(rerank_enabled=True)
+    # Explicit
+    assert s.rerank_chain_for_creds({"RERANK_MODELS": "c,d"}) == ["c", "d"]
+    # Default filtered
+    creds = {"COHERE_API_KEY": "y"}
+    assert s.rerank_chain_for_creds(creds) == ["cohere/rerank-v3.5"]
+    # Default filtered - none
+    assert s.rerank_chain_for_creds({}) == []
+
+
+def test_llm_chain_for_creds():
+    s = Settings()
+    # Explicit
+    assert s.llm_chain_for_creds({"LLM_MODELS": "e,f"}) == ["e", "f"]
+    # Default filtered
+    creds = {"GEMINI_API_KEY": "z"}
+    assert s.llm_chain_for_creds(creds) == ["gemini/gemini-3-flash-preview"]
+    # Default filtered - none
+    assert s.llm_chain_for_creds({}) == []


### PR DESCRIPTION
Added comprehensive test coverage for `embedding_chain_for_creds`, `rerank_chain_for_creds`, and `llm_chain_for_creds` in `tests/test_config.py`.

These tests verify:
- Explicit model chain overrides via the `creds` dict.
- Default chain filtering based on keys present in `creds`.
- The `rerank_enabled` gate for reranking chains.
- Fallback to empty lists when no keys are available.

Verified with `uv run pytest tests/test_config.py` (64/64 passed) and the full test suite (1999/1999 passed).

---
*PR created automatically by Jules for task [4224356312469193364](https://jules.google.com/task/4224356312469193364) started by @n24q02m*