### PR TITLE
[FIX] Reduce parameters in query_docs

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1095,6 +1095,7 @@ async def search(  # noqa: PLR0913
             if not _docs_db:
                 return "Error: Docs database not initialized"
             from wet_mcp.sources.docs import (
+                DocsQueryOptions,
                 ingest_tier2,
                 query_docs,
                 resolve_library,
@@ -1147,9 +1148,11 @@ async def search(  # noqa: PLR0913
                 _docs_db,
                 lib_id,
                 query,
-                effective_version,
-                topic,
-                limit,
+                DocsQueryOptions(
+                    version=effective_version,
+                    topic=topic,
+                    limit=limit,
+                ),
             )
             return json.dumps(
                 {

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -3857,14 +3857,19 @@ def _estimate_tokens(text: str) -> int:
     return max(1, len(text or "") // 4)
 
 
+@dataclass
+class DocsQueryOptions:
+    version: str | None = None
+    topic: str | None = None
+    limit: int = 10
+    query_embedding: list[float] | None = None
+
+
 def query_docs(
     db: Any,
     library_id: str,
     query: str,
-    version: str | None = None,
-    topic: str | None = None,
-    limit: int = 10,
-    query_embedding: list[float] | None = None,
+    options: DocsQueryOptions | None = None,
 ) -> list[dict]:
     """Phase 2 docs query honoring version + topic filter + token cap.
 
@@ -3885,6 +3890,8 @@ def query_docs(
     if not library_id or not query:
         return []
 
+    opt = options or DocsQueryOptions()
+
     # Hydrate library + version metadata.
     lib_row = db._conn.execute(
         "SELECT * FROM libraries WHERE id = ?", (library_id,)
@@ -3893,9 +3900,9 @@ def query_docs(
         return []
     library_name = lib_row["name"]
 
-    if version and version != "latest":
-        ver_row = db.get_best_version(library_id, version)
-        if ver_row is None or ver_row.get("version") != version:
+    if opt.version and opt.version != "latest":
+        ver_row = db.get_best_version(library_id, opt.version)
+        if ver_row is None or ver_row.get("version") != opt.version:
             # Version not indexed (or only the fallback latest exists) —
             # caller decides whether to trigger ingest.
             return []
@@ -3903,13 +3910,13 @@ def query_docs(
     candidates = db.search(
         query=query,
         library_name=library_name,
-        version=version if version and version != "latest" else None,
-        limit=limit * 2,
-        query_embedding=query_embedding,
+        version=opt.version if opt.version and opt.version != "latest" else None,
+        limit=opt.limit * 2,
+        query_embedding=opt.query_embedding,
     )
 
-    if topic:
-        norm_topic = topic.lower().strip()
+    if opt.topic:
+        norm_topic = opt.topic.lower().strip()
         candidates = [
             c
             for c in candidates
@@ -3920,7 +3927,7 @@ def query_docs(
     out: list[dict] = []
     used_tokens = 0
     for chunk in candidates:
-        if len(out) >= limit:
+        if len(out) >= opt.limit:
             break
         token_count = chunk.get("token_count")
         if not token_count:

--- a/tests/test_docs_query.py
+++ b/tests/test_docs_query.py
@@ -55,6 +55,7 @@ else:
 
 DocsDB = _db_mod.DocsDB
 query_docs = _docs_mod.query_docs
+DocsQueryOptions = _docs_mod.DocsQueryOptions
 DOCS_QUERY_TOKEN_CAP = _docs_mod.DOCS_QUERY_TOKEN_CAP
 
 
@@ -118,7 +119,9 @@ def _seed_library_with_versions(
 def test_docs_query_filters_by_version(db: DocsDB) -> None:
     lib_id, v18, v19 = _seed_library_with_versions(db)
 
-    results = query_docs(db, lib_id, query="useState", version="18.0.0")
+    results = query_docs(
+        db, lib_id, query="useState", options=DocsQueryOptions(version="18.0.0")
+    )
 
     assert len(results) >= 1
     for chunk in results:
@@ -131,7 +134,9 @@ def test_docs_query_filters_by_version(db: DocsDB) -> None:
 def test_docs_query_topic_filter(db: DocsDB) -> None:
     lib_id, _, _ = _seed_library_with_versions(db)
 
-    results = query_docs(db, lib_id, query="React", topic="useState")
+    results = query_docs(
+        db, lib_id, query="React", options=DocsQueryOptions(topic="useState")
+    )
     assert len(results) >= 1
     for chunk in results:
         assert chunk.get("title", "").lower().startswith("usestate"), (
@@ -149,7 +154,12 @@ def test_docs_query_pinned_version_not_indexed_returns_empty(
 ) -> None:
     lib_id, _, _ = _seed_library_with_versions(db)
     # Pin a version that does not exist.
-    assert query_docs(db, lib_id, query="useState", version="99.0.0") == []
+    assert (
+        query_docs(
+            db, lib_id, query="useState", options=DocsQueryOptions(version="99.0.0")
+        )
+        == []
+    )
 
 
 def test_docs_query_token_cap_enforced(db: DocsDB) -> None:
@@ -171,7 +181,9 @@ def test_docs_query_token_cap_enforced(db: DocsDB) -> None:
     db.add_chunks(version_id=ver_id, library_id=lib_id, chunks=chunks)
     db.mark_version_indexed(ver_id, page_count=20, chunk_count=20)
 
-    results = query_docs(db, lib_id, query="keyword", limit=20)
+    results = query_docs(
+        db, lib_id, query="keyword", options=DocsQueryOptions(limit=20)
+    )
     assert results, "Expected at least one chunk"
     total_tokens = sum(c.get("token_count", 0) for c in results)
     # Cap is 5000 — first chunk 2000 -> 2000, second 4000, third would be
@@ -201,7 +213,7 @@ def test_docs_query_estimates_tokens_when_count_missing(db: DocsDB) -> None:
     db.add_chunks(version_id=ver_id, library_id=lib_id, chunks=chunks)
     db.mark_version_indexed(ver_id, page_count=5, chunk_count=5)
 
-    results = query_docs(db, lib_id, query="x", limit=10)
+    results = query_docs(db, lib_id, query="x", options=DocsQueryOptions(limit=10))
     # Even with chars/4 estimation we should return at least one and respect cap.
     if results:
         used = sum(_docs_mod._estimate_tokens(c["content"]) for c in results)

--- a/tests/test_project_lock.py
+++ b/tests/test_project_lock.py
@@ -66,6 +66,7 @@ DocsDB = _db_mod.DocsDB
 detect_manifests = _pl_mod.detect_manifests
 lock_project = _pl_mod.lock_project
 query_docs = _docs_mod.query_docs
+DocsQueryOptions = _docs_mod.DocsQueryOptions
 
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "projects"
@@ -243,6 +244,8 @@ def test_docs_query_respects_lock(db: DocsDB) -> None:
     )
 
     # Direct query_docs honors version pin only when caller passes it.
-    pinned_results = query_docs(db, lib_id, query="useState", version="18.0.0")
+    pinned_results = query_docs(
+        db, lib_id, query="useState", options=DocsQueryOptions(version="18.0.0")
+    )
     for chunk in pinned_results:
         assert "v18" in chunk.get("url", "")


### PR DESCRIPTION
Refactored query_docs in src/wet_mcp/sources/docs.py to use a DocsQueryOptions dataclass for optional parameters (version, topic, limit, query_embedding). Updated call sites in src/wet_mcp/server.py and relevant tests to match the new signature.

---
*PR created automatically by Jules for task [16094339825829189575](https://jules.google.com/task/16094339825829189575) started by @n24q02m*