### PR TITLE
[FIX] N+1 Query Fetching Adjacent Context

### DIFF
--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -260,13 +260,28 @@ def _build_results_cf(scored, fts_chunks, d1: D1Backend, limit: int):
             adj_keys.add((url, ver, idx - 1))
             adj_keys.add((url, ver, idx + 1))
     adj_map: dict[tuple[str, str, int], str] = {}
-    for url, ver, idx in adj_keys:
-        row = d1.fetchone(
-            "SELECT content FROM doc_chunks WHERE url = ? AND version_id = ? AND chunk_index = ?",
-            [url, ver, idx],
-        )
-        if row:
-            adj_map[(url, ver, idx)] = row["content"]
+    if adj_keys:
+        # Avoid N+1 by batching (url, version_id, chunk_index) lookups.
+        # Safe traditional SQLite parameter limit is 999.
+        unique_keys = sorted(adj_keys)
+        batch_size = 333  # 333 * 3 = 999 params
+
+        for i in range(0, len(unique_keys), batch_size):
+            batch = unique_keys[i : i + batch_size]
+            placeholders = ",".join(["(?,?,?)"] * len(batch))
+            params = [val for key in batch for val in key]
+
+            # Security: Placeholders are constructed from static tokens (?,?,?)
+            # and strictly separated from the query structure.
+            sql = (
+                "SELECT url, version_id, chunk_index, content "
+                "FROM doc_chunks "
+                f"WHERE (url, version_id, chunk_index) IN ({placeholders})"
+            )
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+            rows = d1.fetchall(sql, params)
+            for r in rows:
+                adj_map[(r["url"], r["version_id"], r["chunk_index"])] = r["content"]
 
     results: list[dict] = []
     for cid, score in scored:

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -125,3 +125,39 @@ def test_cf_search_matches_sqlite_golden(cf_corpus, cf_golden_topk):
         assert overlap >= 2, (
             f"top-3 rank parity failed for {q!r}: {cf_top[:3]} vs {golden[:3]}"
         )
+
+
+def test_search_fetches_adjacent_context():
+    db = _backend()
+    db.upsert_library("alpha", docs_url="https://a")
+    lib = db.get_library("alpha")
+    db.upsert_version(lib["id"], "1.0")
+    ver = db.get_best_version(lib["id"], "1.0")
+    chunks = []
+    for p in range(3):
+        for i in range(3):
+            chunks.append(
+                {
+                    "id": f"c_{p}_{i}",
+                    "url": f"https://a/p{p}",
+                    "title": f"Page {p}",
+                    "chunk_index": i,
+                    "content": f"page {p} chunk {i}",
+                    "heading_path": "API",
+                }
+            )
+    db.add_chunks(ver["id"], lib["id"], chunks, embeddings=None)
+
+    # Search for "chunk 1", should return "page 0 chunk 1", "page 1 chunk 1", "page 2 chunk 1"
+    # They should all have context_before (chunk 0) and context_after (chunk 2)
+    results = db.search("chunk 1", limit=10)
+
+    found_pages = set()
+    for r in results:
+        for p in range(3):
+            if r["content"] == f"page {p} chunk 1":
+                assert r["context_before"] == f"page {p} chunk 0"
+                assert r["context_after"] == f"page {p} chunk 2"
+                found_pages.add(p)
+
+    assert found_pages == {0, 1, 2}


### PR DESCRIPTION
### Issue
Fetching adjacent chunk context (before/after) in `src/wet_mcp/db_cf.py` was implemented using an N+1 query pattern, where each adjacent chunk was fetched in a separate `fetchone` call. This introduces significant network overhead, especially in the Cloudflare D1 environment.

### Fix
Refactored `_build_results_cf` to collect all required adjacent chunk keys and fetch them in batches using a single SQL query with the `WHERE (url, version_id, chunk_index) IN (...)` pattern.
- Used a batch size of 333 (total 999 parameters) to stay within SQLite's safe parameter limit.
- Maintained existing functionality and ensured proper security with bound parameters.
- Added a regression test `test_search_fetches_adjacent_context` in `tests/test_db_cf.py`.

### Verification
- Ran `uv run ruff check --fix .` and `uv run ruff format .`.
- Ran `uv run pytest tests/test_db_cf.py` (Passed).
- Ran full test suite `uv run pytest -n0` (Passed).

---
*PR created automatically by Jules for task [1189478156862003830](https://jules.google.com/task/1189478156862003830) started by @n24q02m*