### PR TITLE
[SECURITY] Raw SQL Execution using f-strings in Migrations

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -435,20 +435,34 @@ class DocsDB:
         # Idempotent column adds for legacy DBs that pre-date Alembic.
         # Each ALTER is wrapped in a try/except so re-running on a fresh
         # head-shape table does not raise.
-        for col_ddl in (
-            "discovery_version INTEGER DEFAULT 0",
-            "canonical_name TEXT",
-            "homepage TEXT",
-            "github_url TEXT",
-            "package_managers TEXT",
-            "tier INTEGER NOT NULL DEFAULT 2",
-            "last_indexed_at REAL",
-            "total_versions INTEGER NOT NULL DEFAULT 0",
+        for sql, col_name in (
+            (
+                "ALTER TABLE libraries ADD COLUMN discovery_version INTEGER DEFAULT 0",
+                "discovery_version",
+            ),
+            ("ALTER TABLE libraries ADD COLUMN canonical_name TEXT", "canonical_name"),
+            ("ALTER TABLE libraries ADD COLUMN homepage TEXT", "homepage"),
+            ("ALTER TABLE libraries ADD COLUMN github_url TEXT", "github_url"),
+            (
+                "ALTER TABLE libraries ADD COLUMN package_managers TEXT",
+                "package_managers",
+            ),
+            (
+                "ALTER TABLE libraries ADD COLUMN tier INTEGER NOT NULL DEFAULT 2",
+                "tier",
+            ),
+            (
+                "ALTER TABLE libraries ADD COLUMN last_indexed_at REAL",
+                "last_indexed_at",
+            ),
+            (
+                "ALTER TABLE libraries ADD COLUMN total_versions INTEGER NOT NULL DEFAULT 0",
+                "total_versions",
+            ),
         ):
             try:
-                self._conn.execute(f"ALTER TABLE libraries ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
-                col_name = col_ddl.split()[0]
                 logger.debug(f"Migrated libraries table: added {col_name}")
             except sqlite3.OperationalError:
                 pass  # Column already exists
@@ -472,9 +486,12 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in ("release_date REAL", "source_url TEXT"):
+        for sql in (
+            "ALTER TABLE versions ADD COLUMN release_date REAL",
+            "ALTER TABLE versions ADD COLUMN source_url TEXT",
+        ):
             try:
-                self._conn.execute(f"ALTER TABLE versions ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass
@@ -501,14 +518,14 @@ class DocsDB:
             )
         """)
         # Idempotent column adds for legacy DBs.
-        for col_ddl in (
-            "section TEXT",
-            "topic TEXT",
-            "content_hash TEXT",
-            "token_count INTEGER",
+        for sql in (
+            "ALTER TABLE doc_chunks ADD COLUMN section TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN topic TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN content_hash TEXT",
+            "ALTER TABLE doc_chunks ADD COLUMN token_count INTEGER",
         ):
             try:
-                self._conn.execute(f"ALTER TABLE doc_chunks ADD COLUMN {col_ddl}")
+                self._conn.execute(sql)
                 self._conn.commit()
             except sqlite3.OperationalError:
                 pass


### PR DESCRIPTION
Replaced dynamic SQL generation using f-strings in `ALTER TABLE` migration statements with hardcoded literal SQL strings in `src/wet_mcp/db.py`.

This addresses a security hygiene issue flagged by SAST tools, ensuring that database schema modifications use static strings even in contexts where the input is currently hardcoded.

Fixed in:
- `_create_libraries_table`
- `_create_versions_table`
- `_create_doc_chunks_table`

No functional changes or regressions introduced. Verified with existing migration tests.

---
*PR created automatically by Jules for task [8343245797605870611](https://jules.google.com/task/8343245797605870611) started by @n24q02m*