### PR TITLE
[FIX] N+1 Overhead in Execute Script Loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-05-14 - Bound Concurrency for CPU-Bound Async Tasks
 **Learning:** Using `asyncio.to_thread` for CPU-bound tasks inside concurrent loops like `asyncio.gather` can spawn too many threads, leading to thread pool exhaustion and event loop starvation.
 **Action:** Always bound concurrency using an `asyncio.Semaphore` (e.g., `asyncio.Semaphore(10)`) when fanning out tasks that internally delegate to `asyncio.to_thread`.
+## 2026-06-29 - D1 Batch Execution Optimization
+**Learning:** Executing multiple SQL statements iteratively in Cloudflare D1 via separate HTTP roundtrips introduces significant N+1 overhead. D1's native `batch()` API allows combining multiple statements into a single request, which is much more efficient for migrations and bulk updates.
+**Action:** Use the `/batch` endpoint (backed by `env.D1.batch()`) for `executescript` and `executemany` (non-INSERT) in the D1 backend to minimize network roundtrips.

--- a/src/wet_mcp/backends/d1.py
+++ b/src/wet_mcp/backends/d1.py
@@ -61,6 +61,17 @@ class D1Backend:
             raise RuntimeError(f"D1Backend query failed: HTTP {status}")
         return json.loads(data.decode()).get("results", [])
 
+    def batch(self, queries: list[dict[str, Any]]) -> list[list[dict]]:
+        if not queries:
+            return []
+        body = json.dumps(queries).encode()
+        status, data = self._http.request(
+            "POST", f"{self.base_url}/batch", body, self._headers()
+        )
+        if status != 200:
+            raise RuntimeError(f"D1Backend batch failed: HTTP {status}")
+        return json.loads(data.decode()).get("results", [])
+
     def fetchall(self, sql: str, params: list[Any]) -> list[dict]:
         return self.execute(sql, params)
 
@@ -83,14 +94,14 @@ class D1Backend:
                 flat = [v for row in batch for v in row]
                 self.execute(batched_sql, flat)
             else:
-                for row in batch:
-                    self.execute(sql, row)
+                self.batch([{"sql": sql, "params": row} for row in batch])
 
     def executescript(self, sql: str) -> None:
-        # Migrations: split on ';' and run each non-empty statement.
-        for stmt in (s.strip() for s in sql.split(";")):
-            if stmt:
-                self.execute(stmt, [])
+        # Migrations: split on ';' and run in batches.
+        stmts = [s.strip() for s in sql.split(";") if s.strip()]
+        for i in range(0, len(stmts), self.max_rows_per_insert):
+            batch = stmts[i : i + self.max_rows_per_insert]
+            self.batch([{"sql": stmt, "params": []} for stmt in batch])
 
 
 def d1_backend_from_env() -> D1Backend:

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,7 +24,7 @@ export interface Env {
     put(k: string, v: string | ArrayBuffer): Promise<void>
     delete(k: string): Promise<void>
   }
-  D1: { prepare(sql: string): { bind(...p: unknown[]): { all(): Promise<{ results: unknown[] }> } } }
+  D1: { prepare(sql: string): { bind(...p: unknown[]): { all(): Promise<{ results: unknown[] }> } }; batch(statements: unknown[]): Promise<{ results: unknown[] }[]> }
   VECTORIZE: {
     upsert(v: unknown[]): Promise<{ mutationId: string }>
     query(vector: number[], opts: { topK: number; filter?: unknown }): Promise<{ matches: unknown[] }>
@@ -134,10 +134,18 @@ const kvOutbound: OutboundHandler<Env> = async (request, env) => {
 
 const d1Outbound: OutboundHandler<Env> = async (request, env) => {
   const url = new URL(request.url)
-  if (url.pathname === '/query' && request.method === 'POST') {
-    const { sql, params } = (await request.json()) as { sql: string; params: unknown[] }
-    const { results } = await env.D1.prepare(sql).bind(...(params ?? [])).all()
-    return Response.json({ results })
+  if (request.method === 'POST') {
+    if (url.pathname === '/query') {
+      const { sql, params } = (await request.json()) as { sql: string; params: unknown[] }
+      const { results } = await env.D1.prepare(sql).bind(...(params ?? [])).all()
+      return Response.json({ results })
+    }
+    if (url.pathname === '/batch') {
+      const queries = (await request.json()) as { sql: string; params: unknown[] }[]
+      const stmts = queries.map((q) => env.D1.prepare(q.sql).bind(...(q.params ?? [])))
+      const batchResults = await env.D1.batch(stmts)
+      return Response.json({ results: batchResults })
+    }
   }
   return new Response('not found', { status: 404 })
 }

--- a/tests/conftest_cf.py
+++ b/tests/conftest_cf.py
@@ -50,13 +50,25 @@ class FakeD1Http:
         self.conn.executescript(ddl_sql)
 
     def request(self, method, url, data=None, headers=None):
-        assert method == "POST" and url.endswith("/query")
-        payload = json.loads(data.decode())
-        sql, params = payload["sql"], payload.get("params", [])
-        cur = self.conn.execute(sql, params)
-        rows = [dict(r) for r in cur.fetchall()] if cur.description else []
-        self.conn.commit()
-        return (200, json.dumps({"results": rows}).encode())
+        assert method == "POST"
+        if url.endswith("/query"):
+            payload = json.loads(data.decode())
+            sql, params = payload["sql"], payload.get("params", [])
+            cur = self.conn.execute(sql, params)
+            rows = [dict(r) for r in cur.fetchall()] if cur.description else []
+            self.conn.commit()
+            return (200, json.dumps({"results": rows}).encode())
+        if url.endswith("/batch"):
+            queries = json.loads(data.decode())
+            batch_results = []
+            for q in queries:
+                sql, params = q["sql"], q.get("params", [])
+                cur = self.conn.execute(sql, params)
+                rows = [dict(r) for r in cur.fetchall()] if cur.description else []
+                batch_results.append({"results": rows})
+            self.conn.commit()
+            return (200, json.dumps({"results": batch_results}).encode())
+        raise AssertionError(f"unexpected url {url}")
 
 
 class FakeVectorizeHttp:


### PR DESCRIPTION
- Implemented a new `/batch` endpoint in `src/worker.ts` using D1's native `batch()` API.
- Added `batch()` method to `D1Backend` in `src/wet_mcp/backends/d1.py`.
- Refactored `executescript()` and `executemany()` to use `batch()` to reduce network roundtrips.
- Updated `tests/conftest_cf.py` to support the new endpoint in test mocks.
- Verified with unit tests and ensured no regressions in existing CF backend tests.

---
*PR created automatically by Jules for task [5271316548274966335](https://jules.google.com/task/5271316548274966335) started by @n24q02m*