### PR TITLE
fix: canary Gate-A/B settle-retry (avoid false-fail on slow container startup)

### DIFF
--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -259,6 +259,22 @@ def _gate_kid_stable(public_url: str, *, tries: int = 10, delay: int = 6) -> boo
     return ok
 
 
+def _retry_gate(fn, public_url: str, *, tries: int = 10, delay: int = 6) -> bool:
+    """Poll a boolean gate until it passes or the settle window is exhausted.
+
+    STATE=ready means the Durable Object is provisioned, NOT that the in-container
+    app is already serving. A heavy Python container (cryptg/telethon/uvicorn)
+    needs ~10-15s after ready before /authorize fronts /login, so a single
+    check-once gate false-fails and triggers an unnecessary rollback. Mirror the
+    settle-window approach _gate_kid_stable already uses."""
+    for i in range(tries):
+        if fn(public_url):
+            return True
+        if i < tries - 1:
+            time.sleep(delay)
+    return False
+
+
 def _canary(public_url: str, *, dry: bool) -> bool:
     if dry:
         print(
@@ -268,8 +284,8 @@ def _canary(public_url: str, *, dry: bool) -> bool:
         return True
     print(f"Canary gate against {public_url} (credential-free):")
     results = [
-        _gate_a(public_url),
-        _gate_b(public_url),
+        _retry_gate(_gate_a, public_url),
+        _retry_gate(_gate_b, public_url),
         _gate_kid_stable(public_url),
     ]
     return all(results)


### PR DESCRIPTION
Gate-A/B canary checked once immediately after DO STATE=ready, but heavy Python containers need ~10-15s more to serve /login → false-fail → unnecessary rollback (telegram/imagine). Image proven good (fronts /login locally w/ MCP_RELAY_PASSWORD). Wrap Gate-A/B in the settle-window retry _gate_kid_stable already uses. No change on genuinely-broken deploys.