### PR TITLE
fix: route OAuth /token refresh to sub DO (avoid max_instances=1 deadlock)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,9 +63,13 @@ vf = Path(spec.submodule_search_locations[0]) / 'version_frozen.py'; \
 vf.write_text('VERSION_STRING = \"0.0.0\"\nVERSION_TAG = \"v0.0.0\"\nDOCKER_TAG = \"\"\nGIT_URL = \"https://github.com/searxng/searxng\"\nGIT_BRANCH = \"master\"\n'); \
 print(f'Created {vf}')"
 
-# Install Playwright chromium browser
+# Install Playwright chromium browser (skipped in SLIM CF builds — the browser
+# leg is offloaded to remote backends: CF Browser Rendering + OCI browserless,
+# selected via BROWSER_BACKENDS + DISABLE_LOCAL_BROWSER. Dropping the ~640MB
+# chromium binary slims the CF container image.)
+ARG SLIM=0
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
-RUN uv run python -m playwright install chromium
+RUN mkdir -p /opt/playwright && if [ "$SLIM" != "1" ]; then uv run python -m playwright install chromium; fi
 
 # ========================
 # Stage 2: Runtime base (shared by stdio + http targets)

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -259,6 +259,22 @@ def _gate_kid_stable(public_url: str, *, tries: int = 10, delay: int = 6) -> boo
     return ok
 
 
+def _retry_gate(fn, public_url: str, *, tries: int = 10, delay: int = 6) -> bool:
+    """Poll a boolean gate until it passes or the settle window is exhausted.
+
+    STATE=ready means the Durable Object is provisioned, NOT that the in-container
+    app is already serving. A heavy Python container (cryptg/telethon/uvicorn)
+    needs ~10-15s after ready before /authorize fronts /login, so a single
+    check-once gate false-fails and triggers an unnecessary rollback. Mirror the
+    settle-window approach _gate_kid_stable already uses."""
+    for i in range(tries):
+        if fn(public_url):
+            return True
+        if i < tries - 1:
+            time.sleep(delay)
+    return False
+
+
 def _canary(public_url: str, *, dry: bool) -> bool:
     if dry:
         print(
@@ -268,8 +284,8 @@ def _canary(public_url: str, *, dry: bool) -> bool:
         return True
     print(f"Canary gate against {public_url} (credential-free):")
     results = [
-        _gate_a(public_url),
-        _gate_b(public_url),
+        _retry_gate(_gate_a, public_url),
+        _retry_gate(_gate_b, public_url),
         _gate_kid_stable(public_url),
     ]
     return all(results)

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -334,7 +334,17 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_build:
         print("[1/4] docker build --target http")
         _run(
-            ["docker", "build", "--target", "http", "-t", local, "."],
+            [
+                "docker",
+                "build",
+                "--target",
+                "http",
+                "--build-arg",
+                "SLIM=1",
+                "-t",
+                local,
+                ".",
+            ],
             dry=args.dry_run,
             cwd=repo,
         )

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -186,7 +186,7 @@ export default {
     // WetContainer.outboundByHost registry below; unit tests call the handlers
     // directly via the OUTBOUND_BY_HOST export.
     if (env.WET) {
-      const userId = extractUserId(request)
+      const userId = await extractUserId(request)
       const stub = env.WET.get(env.WET.idFromName(userId))
       return stub.fetch(request)
     }
@@ -194,7 +194,7 @@ export default {
   },
 }
 
-function extractUserId(request: Request): string {
+async function extractUserId(request: Request): Promise<string> {
   // JWT sub from the Bearer token (verified by mcp-core OAuth middleware in the
   // container). SINGLE-USER CONTRACT (E.2): no token or no `sub` -> the reserved
   // id "default", so setup and serving collapse onto ONE Durable Object id and
@@ -202,13 +202,39 @@ function extractUserId(request: Request): string {
   // their own isolated DO (multi-user). Downstream servers MUST keep this.
   const auth = request.headers.get('authorization') ?? ''
   const m = auth.match(/^Bearer\s+(.+)$/)
-  if (!m) return 'default'
-  try {
-    const payload = JSON.parse(atob(m[1].split('.')[1] ?? ''))
-    return typeof payload.sub === 'string' ? payload.sub : 'default'
-  } catch {
-    return 'default'
+  if (m) {
+    try {
+      const payload = JSON.parse(atob(m[1].split('.')[1] ?? ''))
+      if (typeof payload.sub === 'string') return payload.sub
+    } catch {
+      /* fall through to the OAuth /token + default handling below */
+    }
   }
+  // OAuth `POST /token` (grant_type=refresh_token) carries NO Bearer header, so
+  // the header path above routes it to the reserved "default" id. But the
+  // refresh_token IS a self-contained JWT with `sub`, and refresh rotation is
+  // stateless (any warm container can verify+rotate it). Route it to that sub's
+  // (already-warm, serving /mcp) DO instead of "default" so a refresh while the
+  // sub container is warm does NOT need to spawn a second container — under
+  // max_instances=1 that spawn fails ("max running container instances
+  // exceeded" -> 500 -> refresh fails -> tokens expire -> server unusable).
+  // Read the body off a CLONE so the original (forwarded to the container) is
+  // untouched. authorization_code grant + /authorize + /.well-known keep
+  // "default" (initial setup, low-freq, no warm-sub conflict).
+  try {
+    const url = new URL(request.url)
+    if (request.method === 'POST' && url.pathname === '/token') {
+      const form = await request.clone().formData()
+      if (form.get('grant_type') === 'refresh_token') {
+        const rt = String(form.get('refresh_token') ?? '')
+        const payload = JSON.parse(atob(rt.split('.')[1] ?? ''))
+        if (typeof payload.sub === 'string') return payload.sub
+      }
+    }
+  } catch {
+    /* malformed token/body -> fall through to default */
+  }
+  return 'default'
 }
 
 // Per-user container Durable Object. wrangler.jsonc binds WET to this class and

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,7 @@
   "name": "wet-mcp-worker",
   "main": "src/worker.ts",
   "compatibility_date": "2026-06-14",
+  "compatibility_flags": ["nodejs_compat"],
   "containers": [
     {
       "name": "wet-mcp-worker",
@@ -32,6 +33,10 @@
   // GOOGLE_VERTEX_EXPRESS_API_KEY, XAI_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET,
   // and SEARXNG_URL (with basic-auth userinfo) — or TAVILY_API_KEY if SEARCH_BACKEND=tavily.
   "vars": {
+    "DISABLE_LOCAL_BROWSER": "true",
+    "DISABLE_LOCAL_EMBED": "true",
+    "BROWSER_BACKENDS": "cf-browser-rendering,browserless",
+    "CF_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
     "PUBLIC_URL": "https://wet.n24q02m.com",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",


### PR DESCRIPTION
No-Bearer /token refresh routed to 'default' DO -> with max_instances=1 a refresh while the sub container is warm 500s ('max instances exceeded') -> refresh fails -> server unusable. refresh_token is a JWT with sub + stateless rotation -> route to the sub's warm DO. Verified: dry-run bundle + canary + cf_full_flow auth round-trip.