### PR TITLE
fix: prefer self-hosted browserless over CF Browser Rendering in CF deploy

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,7 +36,7 @@
     "DISABLE_LOCAL_SEARCH": "true",
     "DISABLE_LOCAL_BROWSER": "true",
     "DISABLE_LOCAL_EMBED": "true",
-    "BROWSER_BACKENDS": "cf-browser-rendering,browserless",
+    "BROWSER_BACKENDS": "browserless,cf-browser-rendering",
     "CF_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
     "PUBLIC_URL": "https://wet.n24q02m.com",
     "MCP_STORAGE_BACKEND": "cf-kv",


### PR DESCRIPTION
Flip `BROWSER_BACKENDS` order to `browserless,cf-browser-rendering` so the self-hosted browserless (browserless.n24q02m.com) is the primary headless render backend and CF Browser Rendering is the fallback.

Verified live after redeploy (image b-fb27101): wet `search` returns real results via self-hosted SearXNG; browserless renders JS (quote-divs populated that a static fetch lacks). Routes JS-render through self-host (lower CF paid browser-rendering usage), CF tier kept as safety net.