### PR TITLE
fix: document browserless render backend and BROWSER_BACKENDS config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ mise run dev       # uv run wet-mcp
 - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
+- Browser render backends (headless leg of `extract`): `BROWSER_BACKENDS` (CSV escalation chain: `native` | `browserless` | `cf-browser-rendering`; empty = `native`), `BROWSERLESS_URL`/`BROWSERLESS_TOKEN` (self-host browserless), `CF_BROWSER_RENDERING_TOKEN`/`CF_ACCOUNT_ID` (Cloudflare Browser Rendering), `CAPSOLVER_API_KEY` (optional key-gated captcha tier)
+- Disable-local toggles (skip heavy in-process fallbacks per capability): `DISABLE_LOCAL_BROWSER`, `DISABLE_LOCAL_SEARCH`, `DISABLE_LOCAL_EMBED`, `DISABLE_LOCAL_RERANK`
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`
 - HTTP auth (live self-host): credentials are configured via the OAuth-AS browser form at `<PUBLIC_URL>/authorize`; `GET /mcp` without a Bearer token returns 401 + `www-authenticate` pointing at `/.well-known/oauth-protected-resource`. The browser form is gated by `MCP_RELAY_PASSWORD` (single shared password, gate only — empty disables it; not per-user). Multi-user remote mode also requires `CREDENTIAL_SECRET` (per-sub vault key) + `MCP_DCR_SERVER_SECRET` (proof of intentional multi-user deploy).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ mise run dev       # uv run wet-mcp
 - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
+- Browser render backends (headless leg of `extract`): `BROWSER_BACKENDS` (CSV escalation chain: `native` | `browserless` | `cf-browser-rendering`; empty = `native`), `BROWSERLESS_URL`/`BROWSERLESS_TOKEN` (self-host browserless), `CF_BROWSER_RENDERING_TOKEN`/`CF_ACCOUNT_ID` (Cloudflare Browser Rendering), `CAPSOLVER_API_KEY` (optional key-gated captcha tier)
+- Disable-local toggles (skip heavy in-process fallbacks per capability): `DISABLE_LOCAL_BROWSER`, `DISABLE_LOCAL_SEARCH`, `DISABLE_LOCAL_EMBED`, `DISABLE_LOCAL_RERANK`
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`
 - HTTP auth (live self-host): credentials are configured via the OAuth-AS browser form at `<PUBLIC_URL>/authorize`; `GET /mcp` without a Bearer token returns 401 + `www-authenticate` pointing at `/.well-known/oauth-protected-resource`. The browser form is gated by `MCP_RELAY_PASSWORD` (single shared password, gate only — empty disables it; not per-user). Multi-user remote mode also requires `CREDENTIAL_SECRET` (per-sub vault key) + `MCP_DCR_SERVER_SECRET` (proof of intentional multi-user deploy).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ mcp-name: io.github.n24q02m/wet-mcp
 - **Web Search** -- Embedded SearXNG metasearch (Google, Bing, DuckDuckGo, Brave) with query expansion, TTL cache (1 h general / 5 min time-sensitive), standardized citation format, and 200-token snippet cap. Optional cloud search backends (Tavily, Brave, Exa) as a fallback chain via `SEARCH_BACKENDS`
 - **Academic Research** -- Search Google Scholar, Semantic Scholar, arXiv, PubMed, CrossRef, BASE
 - **Library Docs** -- Auto-discover and index documentation with FTS5 hybrid search, HyDE-enhanced retrieval, and version-specific docs
-- **Content Extract** -- 5-strategy escalation chain via `n24q02m-web-core` `ScrapingAgent` (`basic_http` -> `tls_spoof` -> `headless` Crawl4AI), markitdown bridge for low-tier HTML/MD fallback, smart chunks structured output (clean text + markdown + JSON-LD + code blocks + metadata), batch processing (up to 50 URLs), deep crawling, site mapping
+- **Content Extract** -- 5-strategy escalation chain via `n24q02m-web-core` `ScrapingAgent` (`basic_http` -> `tls_spoof` -> render backends from `BROWSER_BACKENDS` (`native` / `browserless` / `cf-browser-rendering`) -> optional key-gated `captcha`), markitdown bridge for low-tier HTML/MD fallback, smart chunks structured output (clean text + markdown + JSON-LD + code blocks + metadata), batch processing (up to 50 URLs), deep crawling, site mapping
 - **Local File Conversion** -- Convert PDF, DOCX, XLSX, CSV, HTML, EPUB, PPTX to Markdown
 - **Media** -- List + download images / videos / audio files. `analyze` was removed in v2.0.0 -- use `imagine-mcp.understand` for vision/audio inference
 - **Anti-bot** -- Stealth strategies bypass Cloudflare, Medium, LinkedIn, Twitter
@@ -148,6 +148,19 @@ Any other litellm provider works via env passthrough -- see
 `searxng` (default, local) plus optional cloud providers `tavily` / `brave` /
 `exa`. Point at an external SearXNG with `SEARXNG_URL`. Cloud providers need
 `TAVILY_API_KEY` / `BRAVE_API_KEY` / `EXA_API_KEY`.
+
+**Browser render backends** -- `BROWSER_BACKENDS` (CSV, escalation chain) picks
+the headless render leg of `extract`: `native` (in-process chromium, the
+zero-config default), `browserless` (self-host render service -- set
+`BROWSERLESS_URL` + `BROWSERLESS_TOKEN`), and `cf-browser-rendering` (Cloudflare
+Browser Rendering -- set `CF_ACCOUNT_ID` + `CF_BROWSER_RENDERING_TOKEN`). Empty
+chain falls back to `native`. Set `CAPSOLVER_API_KEY` to append an optional,
+key-gated CAPTCHA tier as the last escalation step.
+
+**Disable local fallbacks** -- opt out of the heavy in-process local fallbacks
+per capability (e.g. on a slim container that renders/searches/embeds via cloud
+backends only): `DISABLE_LOCAL_BROWSER`, `DISABLE_LOCAL_SEARCH`,
+`DISABLE_LOCAL_EMBED`, `DISABLE_LOCAL_RERANK`.
 
 **Docs sync** -- `SYNC_ENABLED` (default `true`), `GOOGLE_DRIVE_CLIENT_ID`
 (required for sync), `SYNC_FOLDER` (default `wet-mcp`), `SYNC_INTERVAL` (default
@@ -289,6 +302,9 @@ Run your own single-user wet instance serverless on Cloudflare (Containers + D1 
    wrangler secret put MCP_RELAY_PASSWORD
    wrangler secret put MCP_DCR_SERVER_SECRET
    wrangler secret put SEARXNG_URL
+   wrangler secret put BROWSERLESS_URL          # render backend (BROWSER_BACKENDS default = browserless,cf-browser-rendering)
+   wrangler secret put BROWSERLESS_TOKEN
+   wrangler secret put CF_BROWSER_RENDERING_TOKEN
    ```
 6. `wrangler deploy` and complete setup in the browser relay form at your Worker domain.
 


### PR DESCRIPTION
## Problem

The self-host **browserless** / **cf-browser-rendering** render backends (added via `BROWSER_BACKENDS` and consumed by `web-core`'s `BrowserlessClient` / `CFBrowserRenderingClient` in `sources/crawler.py`) were never documented. The docs still described the `extract` headless leg as `Crawl4AI`, and none of the render-backend env vars appeared in the config tables.

## Changes

- **README `Content Extract` feature** — the extract escalation chain now reads `basic_http -> tls_spoof -> render backends from BROWSER_BACKENDS (native / browserless / cf-browser-rendering) -> optional key-gated captcha` instead of the stale `headless Crawl4AI`.
- **README / AGENTS.md / CLAUDE.md Configuration** — documented the previously-absent env vars: `BROWSER_BACKENDS`, `BROWSERLESS_URL`, `BROWSERLESS_TOKEN`, `CF_BROWSER_RENDERING_TOKEN`, `CF_ACCOUNT_ID`, `CAPSOLVER_API_KEY`, and the `DISABLE_LOCAL_BROWSER/SEARCH/EMBED/RERANK` toggles.
- **README "Deploy to Cloudflare" secrets** — added `BROWSERLESS_URL` / `BROWSERLESS_TOKEN` / `CF_BROWSER_RENDERING_TOKEN`. The container ships with `BROWSER_BACKENDS=browserless,cf-browser-rendering` (see `wrangler.jsonc`), so a README-driven deploy without these secrets left the primary render backend non-functional.

## Verification

Every documented var was checked against `src/wet_mcp/config.py` (`Settings` fields + `browser_backend_chain()`) and `src/worker.ts` (`CONTAINER_ENV_KEYS`). Docs-only change; no code touched.