### PR TITLE
fix: downgrade wet-mcp CF instance_type to basic

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,7 +15,7 @@
       // image first: `docker pull ghcr.io/n24q02m/wet-mcp:beta && docker tag ... wet-mcp:beta
       // && wrangler containers push wet-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/wet-mcp:beta",
-      "instance_type": "standard-1",
+      "instance_type": "basic",
       "max_instances": 1
     }
   ],


### PR DESCRIPTION
## Summary
- Slim CF image (SLIM=1 build-arg, ~940MB) fits `basic`'s 4GB disk; downgrade `instance_type` from `standard-1` to `basic` in the canonical `wrangler.jsonc`, matching telegram/email/notion.
- Live CF redeploy + canary + real `search` domain-tool round-trip already verified PASS on `basic` before this PR (this only syncs the committed template with the already-applied gitignored deploy config).

## Test plan
- [x] `wrangler deploy --config wrangler.deploy.jsonc` rollout with `instance_type: basic` -- canary PASS (Gate A/B, JWKS)
- [x] `scripts/cf_full_flow.py` real search round-trip -- PASS on `basic`