### PR TITLE
fix: bun install in deploy-cf so wrangler can bundle worker.ts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -312,6 +312,8 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
       - name: Setup Bun (bunx wrangler)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install worker deps (wrangler bundles worker.ts, needs @cloudflare/containers)
+        run: bun install --frozen-lockfile
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:


### PR DESCRIPTION
First deploy-cf run failed at `wrangler deploy`: `Could not resolve "@cloudflare/containers"` — the fresh CI checkout has no node_modules so wrangler cannot bundle `src/worker.ts`. Adds `bun install --frozen-lockfile` after Setup Bun. Found by piloting on wet before replicating to the other 5 CF repos.