### PR TITLE
fix: bump mcp-core to 1.18.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # 1.18.0b13) used by the search chain + disable-local toggles + the
     # mcp_core.llm.key_rotation primitive (split_keys / rotate_keys, 1.18.0b14)
     # for search-backend multi-key rotation. Beta pin until 1.18.0 stable.
-    "n24q02m-mcp-core[llm]>=1.18.0b20,<2",
+    "n24q02m-mcp-core[llm]>=1.18.1,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/uv.lock
+++ b/uv.lock
@@ -1780,7 +1780,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.1b1"
+version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1795,9 +1795,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/2f/1d7d959c288767da22b2ede972b3f469726f7956a3007e0dededfa8517b3/n24q02m_mcp_core-1.18.1b1.tar.gz", hash = "sha256:e508d95350c2c0f6ad1538b8e9038629d4652132d4a365d1b2f5275b534a3ec3", size = 305285, upload-time = "2026-07-01T16:16:36.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e8/957c85d6b8effedcddb4cfbab62555f62314fb9e755a8f10afc4229a0733/n24q02m_mcp_core-1.18.1.tar.gz", hash = "sha256:94126b32d0c314a1436968cdba15a24f4bccdb835ec4ee22383d413aa07b9a43", size = 305261, upload-time = "2026-07-02T04:46:34.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/17/cfbb9120e17c5bea3e47d709789ed3c179970010d847351a123fb2229fa3/n24q02m_mcp_core-1.18.1b1-py3-none-any.whl", hash = "sha256:b173071fbbbe7aec7665676e58ff9faf68b4dfb257083f4b7f976bc5363cb01f", size = 169902, upload-time = "2026-07-01T16:16:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/24/21149472647f78fe62c3a5e5abc8fcb4ee13fd9360aafa67b295c672c775/n24q02m_mcp_core-1.18.1-py3-none-any.whl", hash = "sha256:1c1305350ee02ded7f976e2b80092910bd52862003f02e2acf1ac1e32b0cd3a7", size = 169882, upload-time = "2026-07-02T04:46:32.874Z" },
 ]
 
 [package.optional-dependencies]
@@ -3429,7 +3429,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.3.0"
+version = "3.4.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3490,7 +3490,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b20,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.1,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.3.0b2,<3" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
Closes #1477. Bumps n24q02m-mcp-core to the 1.18.1 stable (vertex_express relay dropdown fix) just released, so the stable build + CF image resolve stable mcp-core (Docker uses uv sync --frozen).