### PR TITLE
⚡ Bolt: Optimize chunk_markdown length check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2024-07-06 - Optimize string length checks in loops
 **Learning:** Checking the length of accumulated string lists via `len("\n".join(lines))` inside a loop is O(N^2) time complexity and causes repeated memory allocations.
 **Action:** Instead of joining strings purely to measure length, track length incrementally with an integer variable (e.g. `current_length += len(line) + (1 if lines else 0)`) to reduce time complexity to O(1) per iteration.
+
+## 2024-07-06 - Fixing `ty` typchecker issues with `ty: ignore`
+**Learning:** The typechecker used in this project is `ty`, not `mypy`. Ignore pragmas must take the form of `# ty: ignore[<rule>]`. For example, `type: ignore` and `ty: ignore` alone don't work, we need `# ty: ignore[unsupported-base]`. Additionally, we also have to clean up unused ignore pragmas or `ty check` fails with unused ignore comments.
+**Action:** Always run `uv run ty check` as part of CI checks. Only add `# ty: ignore[<error>]` after verifying what the exact error name is, and remove obsolete `# ty: ignore` lines if they trigger `warning[unused-ignore-comment]`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-03-24 - Avoid string joining for length checks in tight loops
 **Learning:** In `_strip_nav_heading_blocks` (a hot path in markdown chunking), joining multiple string lines into a single string (`"\n".join(...)`) just to check if the combined length exceeds a small limit (50 chars) causes unnecessary memory allocation overhead and slows down processing.
 **Action:** Replace `"\n".join` with an iterative loop that calculates the cumulative length (`content_length += len(line.strip())`), and exit early once the limit is reached.
+## 2024-07-06 - Optimize string length checks in loops
+**Learning:** Checking the length of accumulated string lists via `len("\n".join(lines))` inside a loop is O(N^2) time complexity and causes repeated memory allocations.
+**Action:** Instead of joining strings purely to measure length, track length incrementally with an integer variable (e.g. `current_length += len(line) + (1 if lines else 0)`) to reduce time complexity to O(1) per iteration.

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -2265,9 +2265,10 @@ def chunk_markdown(
     current_title = ""
     heading_path = ""
     current_lines: list[str] = []
+    current_length = 0
 
     def _flush():
-        nonlocal current_lines
+        nonlocal current_lines, current_length
         text = "\n".join(current_lines).strip()
         if len(text) >= min_chunk_size:
             # Split oversized chunks by double newline, preserving code blocks
@@ -2293,6 +2294,7 @@ def chunk_markdown(
                     }
                 )
         current_lines = []
+        current_length = 0
 
     h1 = ""
     h2 = ""
@@ -2316,11 +2318,12 @@ def chunk_markdown(
 
             elif level <= 4:
                 # Flush if current chunk is big enough
-                if len("\n".join(current_lines)) > max_chunk_size // 2:
+                if current_length > max_chunk_size // 2:
                     _flush()
                 current_title = heading_text
                 heading_path = " > ".join(filter(None, [h1, h2, heading_text]))
 
+        current_length += len(line) + (1 if current_lines else 0)
         current_lines.append(line)
 
     # Flush remaining


### PR DESCRIPTION
💡 What: Replaced an $O(N^2)$ string allocation `len("\n".join(current_lines))` with an $O(1)$ tracked integer `current_length` inside the `chunk_markdown` function loop.
🎯 Why: The previous method continuously allocated strings of increasing size inside a loop simply to measure length, which creates unnecessary memory churn and processing time, particularly on large files.
📊 Impact: Expected to measurably reduce CPU and memory usage when parsing large Markdown documents, making document chunking faster.
🔬 Measurement: Verified by unit test suite passing and a manual local benchmark confirming that iterative tracking eliminates the geometric processing time cost.

---
*PR created automatically by Jules for task [13372179145225952494](https://jules.google.com/task/13372179145225952494) started by @n24q02m*