### PR TITLE
fix: set WetContainer pingEndpoint to localhost/ so CF health check passes

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -215,6 +215,11 @@ async function extractUserId(): Promise<string> {
 export class WetContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '5m'
+  // CF container readiness-probe override. Default 'ping' (URL http://ping/) does
+  // not resolve, so the health-check fetch throws and the container is marked
+  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. 'localhost/'
+  // resolves to the container itself; the default route returns 200.
+  pingEndpoint = 'localhost/'
   // The container reaches cloud model/search APIs (Jina, Vertex, Tavily) over the
   // public internet; kv/d1/vectorize.internal stay intercepted (see outboundByHost).
   enableInternet = true


### PR DESCRIPTION
## Summary
- `WetContainer` was missing a `pingEndpoint` override, so it fell back to the CF default `'ping'` (URL `http://ping/`), which does not resolve. The health-check fetch throws, the container reports unhealthy, and CF keeps it running 24/7 instead of sleeping on idle after `sleepAfter = '5m'`.
- Verified live: the `wet-mcp` Cloudflare container is currently `active=1 healthy=0`.
- Mirrors the already-merged fix in sibling repos `better-notion-mcp` and `mnemo-mcp` (`NotionContainer`/equivalent `pingEndpoint = 'localhost/'`).

## Test plan
- [ ] Deploy and confirm the container reports `healthy=1` on Cloudflare
- [ ] Confirm the container sleeps after ~5m of idle instead of running continuously