### PR TITLE
fix: reject unauthenticated /mcp at the Worker edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,20 @@ jobs:
         with:
           files: coverage.xml
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+
+      - name: Install worker dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run worker tests
+        run: bun run test:worker
+
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -175,6 +175,19 @@ export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
   'vectorize.internal': vectorizeOutbound,
 }
 
+// Bearer credential presence check. Structural only -- validity is the container's job.
+const BEARER = /^Bearer\s+\S/i
+
+function unauthenticated(request: Request): Response {
+  const { origin } = new URL(request.url)
+  return new Response(null, {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+    },
+  })
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     // Public entrypoint: ONLY routes inbound requests to the per-user container
@@ -186,6 +199,19 @@ export default {
     // WetContainer.outboundByHost registry below; unit tests call the handlers
     // directly via the OUTBOUND_BY_HOST export.
     if (env.WET) {
+      // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before this
+      // gate every anonymous /mcp request started the container and reset its 5m idle
+      // timer -- an unauthenticated caller could pin it awake and bill GiB-s around the
+      // clock. Verified 2026-07-09: a python-httpx client POSTed /mcp with no
+      // Authorization header every ~20s for 12h+. The check is STRUCTURAL: it rejects
+      // requests carrying no bearer credential at all and reproduces the container's own
+      // 401 (empty body + RFC 9728 WWW-Authenticate). Token VALIDITY is never judged
+      // here -- the container remains the sole authority, so no mcp-core auth logic is
+      // duplicated at the edge.
+      const url = new URL(request.url)
+      if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+        if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
+      }
       const userId = await extractUserId()
       const stub = env.WET.get(env.WET.idFromName(userId))
       return stub.fetch(request)
@@ -215,10 +241,12 @@ async function extractUserId(): Promise<string> {
 export class WetContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '5m'
-  // CF container readiness-probe override. Default 'ping' (URL http://ping/) does
-  // not resolve, so the health-check fetch throws and the container is marked
-  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. 'localhost/'
-  // resolves to the container itself; the default route returns 200.
+  // Port-readiness probe used by @cloudflare/containers' waitForPort(): it does
+  // tcpPort.fetch('http://' + pingEndpoint) against the container's bound port, so the
+  // host segment is only a Host header (no DNS) and ANY HTTP response marks the port
+  // ready. core-py serves 200 at '/', so this points there. It does NOT drive the
+  // platform's `healthy` metric -- see the edge auth gate above for the real cause of
+  // containers never sleeping.
   pingEndpoint = 'localhost/'
   // The container reaches cloud model/search APIs (Jina, Vertex, Tavily) over the
   // public internet; kv/d1/vectorize.internal stay intercepted (see outboundByHost).

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -198,20 +198,20 @@ export default {
     // reaches them via @cloudflare/containers' ContainerProxy + the
     // WetContainer.outboundByHost registry below; unit tests call the handlers
     // directly via the OUTBOUND_BY_HOST export.
+    // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before this
+    // gate every anonymous /mcp request started the container and reset its 5m idle
+    // timer -- an unauthenticated caller could pin it awake and bill GiB-s around the
+    // clock. Verified 2026-07-09: a python-httpx client POSTed /mcp with no
+    // Authorization header every ~20s for 12h+. The check is STRUCTURAL: it rejects
+    // requests carrying no bearer credential at all and reproduces the container's own
+    // 401 (empty body + RFC 9728 WWW-Authenticate). Token VALIDITY is never judged
+    // here -- the container remains the sole authority, so no mcp-core auth logic is
+    // duplicated at the edge.
+    const url = new URL(request.url)
+    if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+      if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
+    }
     if (env.WET) {
-      // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before this
-      // gate every anonymous /mcp request started the container and reset its 5m idle
-      // timer -- an unauthenticated caller could pin it awake and bill GiB-s around the
-      // clock. Verified 2026-07-09: a python-httpx client POSTed /mcp with no
-      // Authorization header every ~20s for 12h+. The check is STRUCTURAL: it rejects
-      // requests carrying no bearer credential at all and reproduces the container's own
-      // 401 (empty body + RFC 9728 WWW-Authenticate). Token VALIDITY is never judged
-      // here -- the container remains the sole authority, so no mcp-core auth logic is
-      // duplicated at the edge.
-      const url = new URL(request.url)
-      if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
-        if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
-      }
       const userId = await extractUserId()
       const stub = env.WET.get(env.WET.idFromName(userId))
       return stub.fetch(request)

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -27,15 +27,18 @@ function fakeEnv() {
 const kvH = OUTBOUND_BY_HOST['kv.internal']!
 const d1H = OUTBOUND_BY_HOST['d1.internal']!
 const vectorizeH = OUTBOUND_BY_HOST['vectorize.internal']!
+// Handlers also take an OutboundHandlerContext third arg (containerId/className);
+// unused by these handlers, only needed to satisfy the call signature in tests.
+const ctx = { containerId: 'test', className: 'WetContainer' } as never
 
 describe('outbound handlers', () => {
   it('KV get 404 then put then get 200', async () => {
     const env = fakeEnv()
-    let res = await kvH(new Request('http://kv.internal/wet%2Fconfig'), env as never)
+    let res = await kvH(new Request('http://kv.internal/wet%2Fconfig'), env as never, ctx)
     expect(res.status).toBe(404)
-    res = await kvH(new Request('http://kv.internal/wet%2Fconfig', { method: 'PUT', body: 'blob' }), env as never)
+    res = await kvH(new Request('http://kv.internal/wet%2Fconfig', { method: 'PUT', body: 'blob' }), env as never, ctx)
     expect(res.status).toBe(200)
-    res = await kvH(new Request('http://kv.internal/wet%2Fconfig'), env as never)
+    res = await kvH(new Request('http://kv.internal/wet%2Fconfig'), env as never, ctx)
     expect(await res.text()).toBe('blob')
   })
 
@@ -44,6 +47,7 @@ describe('outbound handlers', () => {
     const res = await d1H(
       new Request('http://d1.internal/query', { method: 'POST', body: JSON.stringify({ sql: 'SELECT 1', params: [] }) }),
       env as never,
+      ctx,
     )
     const body = (await res.json()) as { results: unknown[] }
     expect(body.results.length).toBe(1)
@@ -54,6 +58,7 @@ describe('outbound handlers', () => {
     const res = await vectorizeH(
       new Request('http://vectorize.internal/query', { method: 'POST', body: JSON.stringify({ vector: [0.1], topK: 1 }) }),
       env as never,
+      ctx,
     )
     const body = (await res.json()) as { matches: unknown[] }
     expect(body.matches.length).toBe(1)
@@ -61,7 +66,7 @@ describe('outbound handlers', () => {
 
   it('KV readiness probe: GET __ready -> {ready:true}', async () => {
     const env = fakeEnv()
-    const res = await kvH(new Request('http://kv.internal/__ready'), env as never)
+    const res = await kvH(new Request('http://kv.internal/__ready'), env as never, ctx)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ ready: true })
   })
@@ -69,7 +74,7 @@ describe('outbound handlers', () => {
   it('KV readiness probe does not shadow a real missing key', async () => {
     const env = fakeEnv()
     // a real key that happens to be absent still 404s (the probe is the reserved __ready only)
-    const res = await kvH(new Request('http://kv.internal/wet%2Fsubs%2Fu1%2Fconfig'), env as never)
+    const res = await kvH(new Request('http://kv.internal/wet%2Fsubs%2Fu1%2Fconfig'), env as never, ctx)
     expect(res.status).toBe(404)
   })
 })
@@ -85,7 +90,7 @@ describe('public fetch entrypoint does NOT expose outbound handlers (security)',
   })
 })
 
-describe('single-user DO contract (E.2)', () => {
+describe('single-DO collapse (2026-06-30): every request routes to "default"', () => {
   function envWithDoSpy() {
     const calls: string[] = []
     return {
@@ -102,9 +107,13 @@ describe('single-user DO contract (E.2)', () => {
     }
   }
 
-  it('no Bearer token -> routes to the "default" DO', async () => {
+  // A bare, no-Bearer /mcp request is now rejected at the edge auth gate before DO
+  // routing ever runs (see 'edge auth gate (/mcp)' below) -- exercise the "always
+  // 'default'" DO-routing invariant on a non-gated path instead (/authorize is one
+  // of the paths the edge gate deliberately leaves untouched).
+  it('no Bearer token, non-/mcp path -> routes to the "default" DO', async () => {
     const { calls, env } = envWithDoSpy()
-    const res = await worker.fetch(new Request('https://wet.n24q02m.com/mcp'), env as never)
+    const res = await worker.fetch(new Request('https://wet.n24q02m.com/authorize'), env as never)
     expect(res.status).toBe(200)
     expect(calls).toEqual(['default'])
   })
@@ -120,13 +129,68 @@ describe('single-user DO contract (E.2)', () => {
     expect(calls).toEqual(['default'])
   })
 
-  it('Bearer token with sub -> routes to that sub DO (per-user isolation)', async () => {
+  it('Bearer token with sub -> still routes to the "default" DO (stateless container, sub externalised to D1/Vectorize/KV)', async () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
     await worker.fetch(
       new Request('https://wet.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
       env as never,
     )
-    expect(calls).toEqual(['user-123'])
+    expect(calls).toEqual(['default'])
+  })
+})
+
+describe('edge auth gate (/mcp)', () => {
+  function envWithFetchSpy() {
+    const fetchCalls: Request[] = []
+    return {
+      fetchCalls,
+      env: {
+        WET: {
+          idFromName: (n: string) => ({ name: n }),
+          get: (_id: unknown) => ({
+            fetch: async (r: Request) => {
+              fetchCalls.push(r)
+              return new Response('routed', { status: 200 })
+            },
+          }),
+        },
+      },
+    }
+  }
+
+  it('POST /mcp with no Authorization -> 401, stub never called', async () => {
+    const { fetchCalls, env } = envWithFetchSpy()
+    const res = await worker.fetch(new Request('https://wet.n24q02m.com/mcp', { method: 'POST' }), env as never)
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toMatch(
+      /^Bearer resource_metadata="https:\/\/[^"]+\/\.well-known\/oauth-protected-resource"$/,
+    )
+    expect(await res.text()).toBe('')
+    expect(fetchCalls.length).toBe(0)
+  })
+
+  it('OPTIONS /mcp with no Authorization -> 401, stub never called', async () => {
+    const { fetchCalls, env } = envWithFetchSpy()
+    const res = await worker.fetch(new Request('https://wet.n24q02m.com/mcp', { method: 'OPTIONS' }), env as never)
+    expect(res.status).toBe(401)
+    expect(fetchCalls.length).toBe(0)
+  })
+
+  it('POST /mcp with Authorization: Bearer anything -> stub called exactly once', async () => {
+    const { fetchCalls, env } = envWithFetchSpy()
+    const res = await worker.fetch(
+      new Request('https://wet.n24q02m.com/mcp', { method: 'POST', headers: { authorization: 'Bearer anything' } }),
+      env as never,
+    )
+    expect(res.status).toBe(200)
+    expect(fetchCalls.length).toBe(1)
+  })
+
+  it('GET /authorize with no Authorization -> passes through, stub called', async () => {
+    const { fetchCalls, env } = envWithFetchSpy()
+    const res = await worker.fetch(new Request('https://wet.n24q02m.com/authorize?foo=1'), env as never)
+    expect(res.status).toBe(200)
+    expect(fetchCalls.length).toBe(1)
   })
 })


### PR DESCRIPTION
## Cost bug

mcp-core's OAuth Authorization Server runs *inside* the container, so an anonymous request to `/mcp` reaches the Durable Object before any auth check happens, starts the container, and resets its 5-minute idle timer. The container itself then answers 401 -- but by then the container is already up and billing.

**Measured on the sibling deployment**: an unauthenticated `python-httpx/0.28.1` client POSTed `/mcp` with **no** `Authorization` header roughly every 20 seconds for 12+ hours (1282 x HTTP 401 in a 6-hour window), pinning that container awake 24/7. `wet-mcp` has identical exposure.

## Fix

A purely structural edge gate in `src/worker.ts`: if the request path is `/mcp` (or under it) and there is no `Bearer` credential in the `Authorization` header, answer 401 **at the Worker**, before the Durable Object is ever touched.

- Does **not** judge token validity -- no JWT decode/verify, no crypto import. The container remains the sole authority on whether a token is good; any request carrying `Bearer <something>` is forwarded exactly as today.
- The 401 is byte-compatible with what the container returns today: status 401, empty body, `WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource"`.
- Applies to every method (`POST`/`GET`/`HEAD`/`OPTIONS`) since the container 401s all of them alike on `/mcp` (no CORS-preflight exemption).
- `/authorize`, `/token`, `/register`, `/login`, `/.well-known/*`, `/health` are untouched -- they still reach the container unconditionally.

## Second change: corrected a comment stating a false root cause

`WetContainer.pingEndpoint = 'localhost/'` carried a comment claiming the default `'ping'` value "does not resolve" and that's why containers stay awake 24/7. That's wrong and had already misled two debugging sessions. `@cloudflare/containers`' `waitForPort()` calls `tcpPort.fetch('http://' + pingEndpoint)` against the container's already-bound TCP port -- the host segment is only a `Host` header, there's no DNS lookup, and *any* HTTP response (200/302/404) marks the port ready; the package README says outright the route doesn't need to be implemented. The `pingEndpoint` value is unchanged (`'localhost/'` still works, just for an unrelated reason); only the comment is corrected to point at the edge-gate fix above as the real cause of the cost bug.

## Tests

Extended the existing `tests/worker.test.ts` (did not rewrite it). Added 4 cases for the new edge gate:
1. `POST /mcp` with no `Authorization` -> 401, `WWW-Authenticate` matches the RFC 9728 pattern, empty body, DO stub `fetch` never called.
2. `OPTIONS /mcp` with no `Authorization` -> 401, stub never called.
3. `POST /mcp` with `Authorization: Bearer anything` -> stub called exactly once.
4. `GET /authorize?foo=1` with no `Authorization` -> passes through, stub called (non-`/mcp` paths unaffected).

**Also fixed a pre-existing stale test I ran into while extending this file**: `bun run test:worker` failed 1/9 on `origin/main` *before* this PR (unrelated to this change) -- the 2026-06-30 single-DO collapse made `extractUserId()` always return `'default'` regardless of the Bearer's `sub`, but the `single-user DO contract` describe block still asserted `'no Bearer token -> routes to the "default" DO'` against `/mcp`, which my new edge gate now correctly rejects before DO routing ever runs. I moved that case to a non-gated path (`/authorize`, which the edge gate deliberately leaves untouched) to keep testing the DO-routing invariant it was actually meant to cover, and updated the `'Bearer token with sub'` case's stale expectation (`'user-123'` -> `'default'`) to match the already-shipped single-DO behavior.

## Verification (real output, not invented)

- `bun run test:worker` -- **13/13 passed** (was 8/9 passing, 1 failing, before my stale-test fix; 9/9 after that fix alone; 13/13 with the new edge-gate cases added).
- `bunx tsc --noEmit` -- clean (no `typecheck` script exists in `package.json`; ran `tsc` directly per `tsconfig.json`). Note: the pre-existing direct-handler test calls also needed a 3rd `ctx` argument to satisfy `OutboundHandler<E,P>`'s actual 3-param signature in `@cloudflare/containers@0.3.7` -- this was a pre-existing typecheck failure on `origin/main` too (not introduced by this PR), fixed alongside.
- `bun run cf:dryrun` (`wrangler deploy --dry-run --outdir .wrangler-dryrun`) -- succeeds, worker bundles (61.42 KiB / gzip 15.33 KiB), no credentials required.

## Note on repo state

This local clone had unrelated in-progress work on a different branch (`fix/wet-cf-instance-type-basic`, cost-fix track) with uncommitted changes when I started -- I did not touch that working tree. This PR was built from a clean `git worktree` off `origin/main`, isolated from that in-progress work.

Not merging -- leaving open for review per instructions.