### PR TITLE
fix: resolve ty diagnostics blocking the type check

### DIFF
--- a/src/wet_mcp/sync/__init__.py
+++ b/src/wet_mcp/sync/__init__.py
@@ -33,6 +33,7 @@ Backend selection (XOR semantics):
 from __future__ import annotations
 
 import sys
+from types import ModuleType
 
 from wet_mcp.sync import gdrive as _gdrive_module
 from wet_mcp.sync.base import SyncBackend
@@ -58,7 +59,7 @@ for _name in _DELEGATE_NAMES:
     globals()[_name] = getattr(_gdrive_module, _name)
 
 
-class _SyncModuleProxy(type(sys.modules[__name__])):
+class _SyncModuleProxy(ModuleType):
     """Module subclass that mirrors writes -> gdrive AND reads <- gdrive.
 
     Tests do ``patch("wet_mcp.sync._foo", mock)`` which calls

--- a/tests/test_db_extra.py
+++ b/tests/test_db_extra.py
@@ -63,7 +63,7 @@ def test_sqlite_vec_extension(mock_connect: Any):
 
 def test_clear_version_chunks():
     database = db.DocsDB(Path("/tmp/test2.db"))
-    database.clear_version_chunks = MagicMock(return_value=1)  # ty: ignore[invalid-assignment]
+    database.clear_version_chunks = MagicMock(return_value=1)
     database.clear_version_chunks("test")
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -94,7 +94,7 @@ async def session(request, tmp_path):
     errlog_kwargs = {"errlog": capture} if capture else {}
 
     try:
-        async with stdio_client(params, **errlog_kwargs) as (read_stream, write_stream):  # ty: ignore[invalid-argument-type]
+        async with stdio_client(params, **errlog_kwargs) as (read_stream, write_stream):
             async with ClientSession(read_stream, write_stream) as s:
                 await s.initialize()
 


### PR DESCRIPTION
## Why

`Lint & Test` has been red on `main` across all three OS runners (ubuntu, windows, macos) since 2026-07-05, failing at `uv run --no-sync ty check`. Verified against the real GitHub Actions logs on both the first failing commit (`99d6e2b`, 2026-07-05) and the current HEAD (`3ed6d71`): every runner reports the same three diagnostics and exits 1. This blocks the job before `pytest` even runs.

This PR removes all three diagnostics without weakening the type check. `ty check` now exits 0 with `All checks passed!`.

## What

**1. `unsupported-base` in `src/wet_mcp/sync/__init__.py`**

`_SyncModuleProxy` derived from a runtime-computed base, `type(sys.modules[__name__])`, which `ty` cannot resolve an MRO for. At import time that expression *is* `types.ModuleType` (the type of a module object), so the base is now named directly:

```python
from types import ModuleType
...
class _SyncModuleProxy(ModuleType):
```

This is semantically identical and statically resolvable. Proven equivalent before changing:
- `_SyncModuleProxy.__bases__ == (types.ModuleType,)` at class-creation time.
- The only base-dependent operations are `super().__setattr__` (line 79) and the `sys.modules[__name__].__class__` reassignment (line 89). `types.ModuleType.__setattr__ is object.__setattr__`, and the class stays a `ModuleType` subclass, so both behave exactly as before.
- The delicate module-proxy contract is covered by tests: the full `test_sync*` suite plus the two edited test files (117 tests) pass unchanged.

`import sys` is retained because it is still used at line 89.

**2. Two dead `# ty: ignore[...]` directives (`unused-ignore-comment`)**

`ty` no longer raises the diagnostics these suppressed, so the directives are dead and `ty` flags them:
- `tests/test_db_extra.py:66`
- `tests/test_e2e.py:97`

Both are removed. The `# ty: ignore[invalid-argument-type]` directives in `relay_setup.py` (lines 108, 119) and the others in the tree were verified to still suppress live diagnostics (removing them makes `ty` re-raise `invalid-argument-type` / `float | None` errors) and were left untouched.

## Verification

```
uv run --no-sync ty check            # All checks passed! (exit 0)
uv run --no-sync ruff check .        # All checks passed!
uv run --no-sync ruff format --check .  # 186 files already formatted
uv run pytest                        # 1984 passed, 33 skipped (clean env)
```

Pre-commit hooks (ruff, ty, full pytest, gitleaks) ran and passed on commit; no `--no-verify`.
