### PR TITLE
fix: decline standing GET /mcp SSE stream at the edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -211,6 +211,17 @@ export default {
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
+    // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
+    // scale-to-zero container this is pure idle cost: @cloudflare/containers
+    // counts an open stream as an in-flight request forever (inflight > 0 =>
+    // activity never expires), so a single idle client pins the container
+    // awake 24/7. None of this stack's servers send server-initiated
+    // messages; request-scoped notifications ride the POST's own SSE
+    // response. The spec allows declining the stream: both official SDKs
+    // treat 405 as the optional-feature path and continue POST-only.
+    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+      return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
+    }
     if (env.WET) {
       const userId = await extractUserId()
       const stub = env.WET.get(env.WET.idFromName(userId))

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -122,8 +122,10 @@ describe('single-DO collapse (2026-06-30): every request routes to "default"', (
     const { calls, env } = envWithDoSpy()
     // header.payload.sig where payload has no `sub`
     const jwt = `h.${btoa(JSON.stringify({ aud: 'x' }))}.s`
+    // POST: this exercises DO-routing/sub-extraction, not GET-stream semantics
+    // (a bare GET now declines 405 before DO routing, see 'edge auth gate' below).
     await worker.fetch(
-      new Request('https://wet.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://wet.n24q02m.com/mcp', { method: 'POST', headers: { authorization: `Bearer ${jwt}` } }),
       env as never,
     )
     expect(calls).toEqual(['default'])
@@ -132,8 +134,9 @@ describe('single-DO collapse (2026-06-30): every request routes to "default"', (
   it('Bearer token with sub -> still routes to the "default" DO (stateless container, sub externalised to D1/Vectorize/KV)', async () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
+    // POST: see rationale above.
     await worker.fetch(
-      new Request('https://wet.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://wet.n24q02m.com/mcp', { method: 'POST', headers: { authorization: `Bearer ${jwt}` } }),
       env as never,
     )
     expect(calls).toEqual(['default'])
@@ -185,6 +188,34 @@ describe('edge auth gate (/mcp)', () => {
     )
     expect(res.status).toBe(200)
     expect(fetchCalls.length).toBe(1)
+  })
+
+  it('GET /mcp with Authorization: Bearer x -> 405, Allow: POST, DELETE, stub never called', async () => {
+    const { fetchCalls, env } = envWithFetchSpy()
+    const res = await worker.fetch(
+      new Request('https://wet.n24q02m.com/mcp', { method: 'GET', headers: { authorization: 'Bearer x' } }),
+      env as never,
+    )
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('POST, DELETE')
+    expect(fetchCalls.length).toBe(0)
+  })
+
+  it('GET /mcp/sub with Authorization: Bearer x -> 405', async () => {
+    const { fetchCalls, env } = envWithFetchSpy()
+    const res = await worker.fetch(
+      new Request('https://wet.n24q02m.com/mcp/sub', { method: 'GET', headers: { authorization: 'Bearer x' } }),
+      env as never,
+    )
+    expect(res.status).toBe(405)
+    expect(fetchCalls.length).toBe(0)
+  })
+
+  it('GET /mcp with no Authorization -> still 401 (bearer gate runs before the 405 decline)', async () => {
+    const { fetchCalls, env } = envWithFetchSpy()
+    const res = await worker.fetch(new Request('https://wet.n24q02m.com/mcp', { method: 'GET' }), env as never)
+    expect(res.status).toBe(401)
+    expect(fetchCalls.length).toBe(0)
   })
 
   it('GET /authorize with no Authorization -> passes through, stub called', async () => {


### PR DESCRIPTION
## Summary
- `@cloudflare/containers` counts an open proxied stream as an in-flight request forever (inflight > 0 => activity never expires), so a standing GET `/mcp` SSE stream from any MCP client pins the container awake 24/7 and bills continuously even when idle.
- The streamable-HTTP spec allows a server to decline the GET stream with 405; both official SDKs already treat this as the optional-feature path (TS client: expected case; Python client: retries twice then continues POST-only).
- None of this stack's servers send server-initiated push messages — request-scoped notifications ride the POST's own SSE response — so nothing observable is lost by declining the standing stream.
- Edge worker now returns `405` with `Allow: POST, DELETE` for any GET on `/mcp` or `/mcp/*`, placed immediately after the existing bearer gate (so an unauthenticated GET still gets `401` first) and before the container routing branch.

## Test plan
- [x] `npm run test:worker` (vitest run tests/worker.test.ts) — 16/16 passed
- [x] New cases: GET `/mcp` with bearer -> 405 + `Allow: POST, DELETE`; GET `/mcp/sub` with bearer -> 405; GET `/mcp` without bearer -> still 401 (bearer gate runs first)
- [x] Fixed 2 pre-existing DO-routing tests that implicitly relied on default-GET requests to `/mcp` — pinned to explicit `method: 'POST'` since they test sub-extraction/DO-routing, not GET-stream semantics
- [x] `grep -c` sanity: `BEARER` = 2, `unauthenticated(request)` = 1 (unchanged)