### PR TITLE
fix: document public-by-design identifiers for secret scanners

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,12 @@
+# Public-by-design app identifiers -- reviewed and deliberately kept.
+# Google treats the Desktop/installed-app OAuth client_secret as PUBLIC
+# (https://developers.google.com/identity/protocols/oauth2#installed).
+# Scanner alerts on these exact values are false positives. Do NOT rotate,
+# do NOT placeholder-ize.
+version: 2
+secret:
+  ignored_matches:
+    - name: google-drive-desktop-oauth-client-id
+      match: "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
+    - name: google-drive-desktop-oauth-client-secret
+      match: "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"


### PR DESCRIPTION
## Summary
- Adds `.gitguardian.yaml` recording the Google Drive Desktop/installed-app OAuth `client_id` + `client_secret` in `src/wet_mcp/config.py` as reviewed, public-by-design identifiers, using ggshield's `secret.ignored_matches` raw-string-equality format.
- Google officially documents the Desktop/installed-app OAuth `client_secret` as not confidential (https://developers.google.com/identity/protocols/oauth2#installed). This is not a leak; do not rotate, do not placeholder-ize.

## Scope note
- This file is read by ggshield (the CLI/pre-commit scanner) and silences the local/CI re-raise. The GitGuardian **dashboard** app keeps its own separate ignore list, so if a dashboard incident exists for these values it still needs a one-time manual "ignore" resolution there — this file only records the decision in-repo for the scanner tooling that reads it.

## Test plan
- [x] `pre-commit` (gitleaks + other hooks) passed locally on this commit, no allowlist changes needed
- [ ] CI green on this PR