### PR TITLE
feat: adopt bundled client BYO resolution chain for Google Drive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # 1.18.0b13) used by the search chain + disable-local toggles + the
     # mcp_core.llm.key_rotation primitive (split_keys / rotate_keys, 1.18.0b14)
     # for search-backend multi-key rotation. Beta pin until 1.18.0 stable.
-    "n24q02m-mcp-core[llm]>=1.18.2,<2",
+    "n24q02m-mcp-core[llm]>=1.19.0b2,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,14 +54,8 @@ dependencies = [
     "jsonschema>=4.26.0",
     # Per-domain rate limiting for batch operations
     "aiolimiter>=1.2.1",
-    # Relay setup (zero-env-config) + LLM passthrough (litellm via [llm] extra) +
-    # pluggable credential storage backends (CredentialBackend / CfKvBackend,
-    # shipped in 1.18.0b4) + PerPluginStore token sub-key (1.18.0b5) +
-    # CfKvBackend.ready() E.1 readiness probe (1.18.0b6) + the mcp_core.chains
-    # capability provider-chain primitive (resolve_backend / run_with_fallback,
-    # 1.18.0b13) used by the search chain + disable-local toggles + the
-    # mcp_core.llm.key_rotation primitive (split_keys / rotate_keys, 1.18.0b14)
-    # for search-backend multi-key rotation. Beta pin until 1.18.0 stable.
+    # Beta pin: 1.19.0b2 ships the mcp_core.auth BYO resolver
+    # (resolve_bundled_client + token_client_mismatch) this repo consumes.
     "n24q02m-mcp-core[llm]>=1.19.0b2,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -5,9 +5,10 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from mcp_core.auth import BundledClientSpec, resolve_bundled_client
 from mcp_core.chains import resolve_backend
 from mcp_core.llm.providers import key_env_for_model
-from pydantic import SecretStr
+from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings
 
 
@@ -39,6 +40,25 @@ def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
     if _detect_gpu() and _has_gguf_support():
         return gguf_name
     return onnx_name
+
+
+# Google Drive OAuth client identity (BYO resolver chain: CLI > env pair >
+# bundled default, unless USE_BUNDLED_GOOGLE_CLIENT explicitly disables it).
+# The Desktop/Installed OAuth client_secret is public by design per
+# https://developers.google.com/identity/protocols/oauth2#installed -- hardcoding
+# it here is safe and gives users zero-config sync after relay submit.
+_BUNDLED_GOOGLE_CLIENT_ID = (
+    "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
+)
+_BUNDLED_GOOGLE_CLIENT_SECRET = "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"  # gitleaks:allow
+_GOOGLE_CLIENT_SPEC = BundledClientSpec(
+    provider="google-drive",
+    env_id="GOOGLE_DRIVE_CLIENT_ID",
+    env_secret="GOOGLE_DRIVE_CLIENT_SECRET",
+    bundled_id=_BUNDLED_GOOGLE_CLIENT_ID,
+    bundled_secret=_BUNDLED_GOOGLE_CLIENT_SECRET,
+    use_bundled_env="USE_BUNDLED_GOOGLE_CLIENT",
+)
 
 
 class Settings(BaseSettings):
@@ -229,10 +249,14 @@ class Settings(BaseSettings):
     sync_enabled: bool = True
     sync_folder: str = "wet-mcp"  # Google Drive folder name
     sync_interval: int = 300  # seconds, 0 = manual only
-    google_drive_client_id: str = (
-        "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
+    google_drive_client_id: str = Field(
+        default_factory=lambda: resolve_bundled_client(_GOOGLE_CLIENT_SPEC).client_id
     )
-    google_drive_client_secret: str = "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"
+    google_drive_client_secret: str = Field(
+        default_factory=lambda: (
+            resolve_bundled_client(_GOOGLE_CLIENT_SPEC).client_secret
+        )
+    )
 
     # S3-compatible sync (operator deploy mode).
     # When SYNC_S3_BUCKET is non-empty the active backend resolves to "s3"

--- a/src/wet_mcp/sync/gdrive.py
+++ b/src/wet_mcp/sync/gdrive.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 from loguru import logger
+from mcp_core.auth import token_client_mismatch
 
 from wet_mcp.config import settings
 
@@ -75,6 +76,13 @@ def _save_token(token: dict) -> None:
     save_token(_TOKEN_PROVIDER, token)
 
 
+def _clear_token() -> None:
+    """Delete the stored Google Drive OAuth token from local storage."""
+    from wet_mcp.token_store import delete_token
+
+    delete_token(_TOKEN_PROVIDER)
+
+
 def _has_token_available() -> bool:
     """Check if a Google Drive token is available."""
     return _load_token() is not None
@@ -85,12 +93,22 @@ async def _refresh_token(token: dict) -> dict | None:
 
     Returns updated token dict, or None if refresh failed.
     """
+    if token_client_mismatch(token, settings.google_drive_client_id):
+        logger.warning(
+            "Stored Google Drive token was minted by a different client_id; "
+            "clearing it -- re-run setup_sync to authorize with the current client"
+        )
+        _clear_token()
+        return None
+
     refresh_token = token.get("refresh_token")
     client_id = token.get("client_id", settings.google_drive_client_id)
     client_secret = settings.google_drive_client_secret
 
-    if not refresh_token or not client_id:
-        logger.warning("Cannot refresh token: missing refresh_token or client_id")
+    if not refresh_token or not client_id or not client_secret:
+        logger.warning(
+            "Cannot refresh token: missing refresh_token, client_id, or client_secret"
+        )
         return None
 
     try:

--- a/src/wet_mcp/token_store.py
+++ b/src/wet_mcp/token_store.py
@@ -99,6 +99,13 @@ def save_token(provider: str, token: dict, backend=None) -> None:
     logger.info(f"Token saved (encrypted): wet/tokens/{provider}")
 
 
+def delete_token(provider: str, backend=None) -> None:
+    """Delete a provider's stored OAuth token (e.g. after a client_id mismatch)."""
+    _validate_safe_name(provider)
+    _token_store(provider, None, backend).clear()
+    logger.info(f"Token cleared: wet/tokens/{provider}")
+
+
 def save_token_for_sub(sub: str, provider: str, token: dict, backend=None) -> None:
     """Save a per-JWT-sub OAuth token, encrypted via PerPluginStore."""
     _validate_safe_name(sub)

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -1234,7 +1234,10 @@ class TestRefreshTokenExtraEdges:
             "client_id": "client123",
         }
 
-        with patch("wet_mcp.sync.httpx.AsyncClient") as mock_httpx:
+        with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "client123"),
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_httpx,
+        ):
             mock_httpx.return_value.__aenter__ = AsyncMock(
                 side_effect=Exception("connection refused")
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import os
 from unittest import mock
 
+import pytest
 from pydantic import SecretStr
 
 from wet_mcp.config import Settings
@@ -702,3 +703,54 @@ def test_llm_chain_for_creds():
     assert s.llm_chain_for_creds(creds) == ["gemini/gemini-3-flash-preview"]
     # Default filtered - none
     assert s.llm_chain_for_creds({}) == []
+
+
+# -----------------------------------------------------------------------
+# Google Drive BYO client resolver (bundled default + env pair + kill-switch)
+# -----------------------------------------------------------------------
+
+_GOOGLE_CLIENT_ENV_VARS = (
+    "GOOGLE_DRIVE_CLIENT_ID",
+    "GOOGLE_DRIVE_CLIENT_SECRET",
+    "USE_BUNDLED_GOOGLE_CLIENT",
+)
+
+
+def test_google_drive_default_ships_desktop_oauth_client(monkeypatch):
+    """No env, no kill-switch -> resolves to the bundled Desktop OAuth client."""
+    for v in _GOOGLE_CLIENT_ENV_VARS:
+        monkeypatch.delenv(v, raising=False)
+    s = Settings()
+    assert s.google_drive_client_id.endswith(".apps.googleusercontent.com")
+    assert s.google_drive_client_secret.startswith("GOCSPX-")
+
+
+def test_google_drive_env_pair_beats_bundled(monkeypatch):
+    """A full BYO env pair overrides the bundled default."""
+    for v in _GOOGLE_CLIENT_ENV_VARS:
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_ID", "my-id")
+    monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_SECRET", "my-secret")
+    s = Settings()
+    assert (s.google_drive_client_id, s.google_drive_client_secret) == (
+        "my-id",
+        "my-secret",
+    )
+
+
+def test_google_drive_env_half_pair_fails_loud(monkeypatch):
+    """Setting only one half of the BYO pair raises instead of silently falling back."""
+    for v in _GOOGLE_CLIENT_ENV_VARS:
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_ID", "only-id")
+    with pytest.raises(Exception, match="together"):
+        Settings()
+
+
+def test_google_drive_kill_switch_fails_loud_without_override(monkeypatch):
+    """USE_BUNDLED_GOOGLE_CLIENT=false with no BYO pair raises instead of using bundled."""
+    for v in _GOOGLE_CLIENT_ENV_VARS:
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("USE_BUNDLED_GOOGLE_CLIENT", "false")
+    with pytest.raises(Exception, match="disables the bundled client"):
+        Settings()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -60,6 +60,7 @@ class TestTokenManagement:
         }
 
         with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "client123"),
             patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
             patch("wet_mcp.sync._save_token") as mock_save,
         ):
@@ -90,7 +91,10 @@ class TestTokenManagement:
         mock_response.status_code = 400
         mock_response.text = "invalid_grant"
 
-        with patch("wet_mcp.sync.httpx.AsyncClient") as mock_client:
+        with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "client123"),
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
+        ):
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -104,8 +108,38 @@ class TestTokenManagement:
         """Returns None when token has no refresh_token."""
         from wet_mcp.sync import _refresh_token
 
-        result = await _refresh_token({"access_token": "old"})
+        # client_id matches the effective client so this exercises the
+        # missing-refresh_token branch, not the client-mismatch guard.
+        token = {
+            "access_token": "old",
+            "client_id": sync.settings.google_drive_client_id,
+        }
+        result = await _refresh_token(token)
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_clears_token_on_client_mismatch(self):
+        """A token minted by a different client_id is cleared, not refreshed."""
+        from wet_mcp.sync import _refresh_token
+
+        token = {
+            "access_token": "old",
+            "refresh_token": "refresh123",
+            "client_id": "other-client",
+        }
+
+        with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "current-client"),
+            patch("wet_mcp.sync._clear_token") as mock_clear,
+            patch("wet_mcp.sync.logger.warning") as mock_warn,
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
+        ):
+            result = await _refresh_token(token)
+
+            assert result is None
+            mock_clear.assert_called_once()
+            mock_warn.assert_called_once()
+            mock_client.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_valid_token_no_token(self):

--- a/tests/test_sync_comprehensive.py
+++ b/tests/test_sync_comprehensive.py
@@ -69,6 +69,7 @@ class TestTokenManagement:
         }
 
         with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "client123"),
             patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
             patch("wet_mcp.sync._save_token"),
         ):
@@ -95,7 +96,10 @@ class TestTokenManagement:
         mock_response.status_code = 401
         mock_response.text = "unauthorized"
 
-        with patch("wet_mcp.sync.httpx.AsyncClient") as mock_client:
+        with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "c"),
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
+        ):
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -108,7 +112,13 @@ class TestTokenManagement:
     async def test_refresh_token_no_refresh(self):
         from wet_mcp.sync import _refresh_token
 
-        result = await _refresh_token({"access_token": "old"})
+        # client_id matches the effective client so this exercises the
+        # missing-refresh_token branch, not the client-mismatch guard.
+        token = {
+            "access_token": "old",
+            "client_id": wet_mcp.sync.settings.google_drive_client_id,
+        }
+        result = await _refresh_token(token)
         assert result is None
 
     @pytest.mark.asyncio
@@ -121,7 +131,10 @@ class TestTokenManagement:
             "client_id": "c",
         }
 
-        with patch("wet_mcp.sync.httpx.AsyncClient") as mock_client:
+        with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "c"),
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
+        ):
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(side_effect=Exception("Network error"))
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -46,6 +46,7 @@ class TestRefreshToken:
         }
 
         with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "client123"),
             patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
             patch("wet_mcp.sync._save_token") as mock_save,
         ):
@@ -78,6 +79,7 @@ class TestRefreshToken:
         }
 
         with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "client123"),
             patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
             patch("wet_mcp.sync._save_token"),
         ):
@@ -100,7 +102,10 @@ class TestRefreshToken:
         mock_response.status_code = 400
         mock_response.text = "invalid_grant"
 
-        with patch("wet_mcp.sync.httpx.AsyncClient") as mock_client:
+        with (
+            patch("wet_mcp.sync.settings.google_drive_client_id", "c"),
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_client,
+        ):
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -7,6 +7,7 @@ import pytest
 from wet_mcp.token_store import (
     _get_token_dir,
     _get_token_dir_for_sub,
+    delete_token,
     get_token_path,
     get_token_path_for_sub,
     load_token,
@@ -80,6 +81,23 @@ def test_save_and_load_token(token_dir, tmp_path):
 
     # Verify the encrypted token file landed under the LocalFs layout.
     assert (tmp_path / ".wet-mcp" / "tokens" / "drive.json").exists()
+
+
+def test_delete_token(token_dir, tmp_path):
+    """delete_token clears a stored token so load_token returns None afterward."""
+    token = {"access_token": "abc123", "token_type": "Bearer"}
+    save_token("drive", token)
+    assert load_token("drive") == token
+
+    delete_token("drive")
+
+    assert load_token("drive") is None
+
+
+def test_delete_token_missing_is_noop(token_dir):
+    """delete_token on a provider with no stored token does not raise."""
+    delete_token("drive")
+    assert load_token("drive") is None
 
 
 def test_load_corrupt_blob_returns_none(token_dir, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1774,7 +1774,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.2"
+version = "1.19.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1789,9 +1789,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/de/0e08cc5b07e1818d9028b3ea9da7e6852ffd14bc3893143e20c4eb3bdf85/n24q02m_mcp_core-1.18.2.tar.gz", hash = "sha256:0ea9e06c89fc8427c175cad14121b68ad9f8e4a2e9be03e5fa0beb62382d3d19", size = 305617, upload-time = "2026-07-05T13:09:09.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/12/43db620c359e88c634c0f88a784a9f1fb0c4d4750c5803717c55f5e7560c/n24q02m_mcp_core-1.19.0b2.tar.gz", hash = "sha256:fbda9b57e462e3361f387527a797ee5e924dba975c36a92a5b7fb79c2340b173", size = 310576, upload-time = "2026-07-11T03:05:22.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/22/462bc0faebcd9f322cd4fff96bd0fb6bcc0464fb994836c97c2af59505d3/n24q02m_mcp_core-1.18.2-py3-none-any.whl", hash = "sha256:5a26acaa7d57267e5b7d42a1c4d1367ac33a3b27346db995e1cc982f77e01262", size = 170061, upload-time = "2026-07-05T13:09:08.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/17/1d3d68aac7b6734fd1fd9f9ea0d77169ecefa8e7015d9636001ee37ebe3f/n24q02m_mcp_core-1.19.0b2-py3-none-any.whl", hash = "sha256:59e1b7961db1c04d1b4195f98d391679ea974f21c05731a0ba59834916f2b87a", size = 172726, upload-time = "2026-07-11T03:05:21.111Z" },
 ]
 
 [package.optional-dependencies]
@@ -2902,8 +2902,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3457,7 +3457,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0b2,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.3.1,<3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
## S5 / WS-A2 (wet half — ships in the same batch as mnemo-mcp per category parity)

- `config.py`: Google client pair now resolves via `mcp_core.auth.resolve_bundled_client` (default_factory) — env pair still beats bundled; NEW: half-pair env fails loud at Settings() construction; NEW: `USE_BUNDLED_GOOGLE_CLIENT=false` kill-switch fails loud without an override. Bundled Desktop OAuth pair unchanged (public by design).
- `_refresh_token`: NEW `token_client_mismatch` guard — a stored token minted by a different client_id is cleared (provider-scoped delete only) and re-auth is forced, closing the mixed id/secret `invalid_client` trap. Refresh guard also now checks `client_secret` (parity with mnemo).
- Value-pin + BYO tests added (wet previously had zero default-value assertions); exhaustive audit: all 12 `_refresh_token` test call sites individually verified against real guard semantics.
- Pin bump `n24q02m-mcp-core[llm]>=1.19.0b2,<2`.

Evidence: full suite 1990 passed / 33 skipped; ruff + pre-commit hooks green; task-reviewed (opus) + collision audit table in session records.