### PR TITLE
feat: mount shared cli builder with auth/warmup/docs subcommands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dev = [
 ]
 
 [project.scripts]
-wet-mcp = "wet_mcp:main"
+wet-mcp = "wet_mcp.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/n24q02m/wet-mcp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,10 @@ dependencies = [
     "jsonschema>=4.26.0",
     # Per-domain rate limiting for batch operations
     "aiolimiter>=1.2.1",
-    # Beta pin: 1.19.0b2 ships the mcp_core.auth BYO resolver
-    # (resolve_bundled_client + token_client_mismatch) this repo consumes.
-    "n24q02m-mcp-core[llm]>=1.19.0b2,<2",
+    # Beta pin: 1.19.0b4 ships mcp_core.cli's argument-spec extra
+    # subcommand support ((configure, handler) tuples) this repo's
+    # cli.py auth/docs subcommands consume.
+    "n24q02m-mcp-core[llm]>=1.19.0b4,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/__init__.py
+++ b/src/wet_mcp/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import version
 
-from wet_mcp.__main__ import _cli as main
+from wet_mcp.cli import main
 from wet_mcp.server import mcp
 
 __version__ = version("wet-mcp")

--- a/src/wet_mcp/__main__.py
+++ b/src/wet_mcp/__main__.py
@@ -1,12 +1,16 @@
 """WET MCP Server entry point."""
 
-from wet_mcp.server import main
+from wet_mcp.cli import main as _cli_main
 
 
-def _cli() -> None:
-    """Start the MCP server."""
-    main()
+def _cli() -> int:
+    """Dispatch argv through the shared mcp_core CLI builder.
+
+    Bare invocation and any leading-dash argv (e.g. --http) start the
+    server; a leading positional argv[0] routes to a subcommand instead.
+    """
+    return _cli_main()
 
 
 if __name__ == "__main__":  # pragma: no cover
-    _cli()
+    raise SystemExit(_cli())

--- a/src/wet_mcp/cli.py
+++ b/src/wet_mcp/cli.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
+import sys
 
 from mcp_core import build_cli
 
@@ -34,20 +34,34 @@ def _configure_auth(p: argparse.ArgumentParser) -> None:
 
 
 def _handle_auth(args: argparse.Namespace) -> int:
+    from wet_mcp.setup_tool import run_setup_sync
+
     # Single-user / local machine only: writes the token via the local store.
+    # The BYO pair is threaded through run_setup_sync's client_id/client_secret
+    # params rather than os.environ -- wet_mcp.config.settings is a module-level
+    # singleton built at import time, so an env write here would never reach it.
     if args.client_id or args.client_secret:
         from mcp_core.auth import resolve_bundled_client
 
         from wet_mcp.config import _GOOGLE_CLIENT_SPEC
 
-        resolved = resolve_bundled_client(
-            _GOOGLE_CLIENT_SPEC, cli_id=args.client_id, cli_secret=args.client_secret
+        try:
+            resolved = resolve_bundled_client(
+                _GOOGLE_CLIENT_SPEC,
+                cli_id=args.client_id,
+                cli_secret=args.client_secret,
+            )
+        except ValueError as exc:
+            print(f"wet-mcp: {exc}", file=sys.stderr)
+            return 2
+        result = asyncio.run(
+            run_setup_sync(
+                client_id=resolved.client_id, client_secret=resolved.client_secret
+            )
         )
-        os.environ[_GOOGLE_CLIENT_SPEC.env_id] = resolved.client_id
-        os.environ[_GOOGLE_CLIENT_SPEC.env_secret] = resolved.client_secret
-    from wet_mcp.setup_tool import run_setup_sync
+    else:
+        result = asyncio.run(run_setup_sync())
 
-    result = asyncio.run(run_setup_sync())
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0 if result.get("status") == "ok" else 1
 

--- a/src/wet_mcp/cli.py
+++ b/src/wet_mcp/cli.py
@@ -1,0 +1,106 @@
+"""Console-script entry: mounts the shared mcp_core CLI builder.
+
+Bare invocation and any leading-dash argv (e.g. --http) start the server
+exactly as before; subcommands run one-shot operator actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+
+from mcp_core import build_cli
+
+
+def _serve(argv: list[str]) -> int | None:
+    from wet_mcp.server import main as server_main
+
+    server_main()
+    return 0
+
+
+def _configure_auth(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "provider", choices=["google"], help="Credential provider to authorize"
+    )
+    p.add_argument(
+        "--client-id",
+        default=None,
+        help="BYO OAuth client id (must be paired with --client-secret)",
+    )
+    p.add_argument("--client-secret", default=None, help="BYO OAuth client secret")
+
+
+def _handle_auth(args: argparse.Namespace) -> int:
+    # Single-user / local machine only: writes the token via the local store.
+    if args.client_id or args.client_secret:
+        from mcp_core.auth import resolve_bundled_client
+
+        from wet_mcp.config import _GOOGLE_CLIENT_SPEC
+
+        resolved = resolve_bundled_client(
+            _GOOGLE_CLIENT_SPEC, cli_id=args.client_id, cli_secret=args.client_secret
+        )
+        os.environ[_GOOGLE_CLIENT_SPEC.env_id] = resolved.client_id
+        os.environ[_GOOGLE_CLIENT_SPEC.env_secret] = resolved.client_secret
+    from wet_mcp.setup_tool import run_setup_sync
+
+    result = asyncio.run(run_setup_sync())
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result.get("status") == "ok" else 1
+
+
+def _handle_warmup(args: argparse.Namespace) -> int:
+    from wet_mcp.setup_tool import run_warmup
+
+    result = asyncio.run(run_warmup())
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result.get("status") == "ok" else 1
+
+
+def _configure_docs(p: argparse.ArgumentParser) -> None:
+    p.add_argument("docs_action", choices=["reindex"], help="Docs index action")
+    p.add_argument("library", help="Library name to reindex")
+
+
+def _handle_docs(args: argparse.Namespace) -> int:
+    from wet_mcp.server import make_docs_db
+
+    # Standalone DB handle (not the lifespan-owned global _docs_db) so this
+    # subcommand works without a running server.
+    db = make_docs_db()
+    lib = db.get_library(args.library)
+    if not lib:
+        result = {"error": f"Library '{args.library}' not found in index"}
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 1
+    ver = db.get_best_version(lib["id"])
+    if ver:
+        db.clear_version_chunks(ver["id"])
+    result = {
+        "status": "cleared",
+        "library": args.library,
+        "hint": "Next docs search will re-index",
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _extras() -> dict:
+    return {
+        "auth": (_configure_auth, _handle_auth),
+        "warmup": _handle_warmup,
+        "docs": (_configure_docs, _handle_docs),
+    }
+
+
+def _version() -> str:
+    from wet_mcp import __version__
+
+    return __version__
+
+
+def main() -> int:
+    return build_cli("wet-mcp", serve=_serve, extra=_extras(), version=_version())(None)

--- a/src/wet_mcp/setup_tool.py
+++ b/src/wet_mcp/setup_tool.py
@@ -248,27 +248,37 @@ async def run_warmup() -> dict:
     }
 
 
-async def run_setup_sync(remote_type: str = "drive") -> dict:
+async def run_setup_sync(
+    remote_type: str = "drive",
+    client_id: str | None = None,
+    client_secret: str | None = None,
+) -> dict:
     """Run Google Drive sync setup (OAuth Device Code flow).
 
+    ``client_id``/``client_secret`` optionally override the upstream OAuth
+    client identity for this call (BYO client, e.g. from the CLI's ``auth
+    google --client-id/--client-secret`` flags) without mutating the
+    ``wet_mcp.config.settings`` singleton -- both default to ``None``,
+    which falls back to ``settings.google_drive_client_id/secret`` exactly
+    as before.
+
     Returns a structured dict with setup results. When the upstream Google
-    Drive env vars (``GOOGLE_DRIVE_CLIENT_ID`` / ``..._CLIENT_SECRET``) are
-    missing this returns an explicit ``missing_env`` error so stdio users
-    understand which env var to set, instead of a generic
-    "authentication failed" message.
+    Drive credentials (BYO pair, or ``GOOGLE_DRIVE_CLIENT_ID`` /
+    ``..._CLIENT_SECRET`` env vars) are missing this returns an explicit
+    ``missing_env`` error so stdio users understand which env var to set,
+    instead of a generic "authentication failed" message.
     """
     try:
         from wet_mcp.config import settings
 
-        if (
-            not settings.google_drive_client_id
-            or not settings.google_drive_client_secret
-        ):
+        effective_id = client_id or settings.google_drive_client_id
+        effective_secret = client_secret or settings.google_drive_client_secret
+        if not effective_id or not effective_secret:
             missing = [
                 name
                 for name, value in (
-                    ("GOOGLE_DRIVE_CLIENT_ID", settings.google_drive_client_id),
-                    ("GOOGLE_DRIVE_CLIENT_SECRET", settings.google_drive_client_secret),
+                    ("GOOGLE_DRIVE_CLIENT_ID", effective_id),
+                    ("GOOGLE_DRIVE_CLIENT_SECRET", effective_secret),
                 )
                 if not value
             ]
@@ -287,7 +297,9 @@ async def run_setup_sync(remote_type: str = "drive") -> dict:
 
         from wet_mcp.sync import setup_google_auth
 
-        success = await setup_google_auth()
+        success = await setup_google_auth(
+            client_id=client_id, client_secret=client_secret
+        )
         if success:
             return {
                 "status": "ok",

--- a/src/wet_mcp/sync/gdrive.py
+++ b/src/wet_mcp/sync/gdrive.py
@@ -605,18 +605,25 @@ async def check_health() -> bool:
 async def setup_google_auth(
     relay_url: str | None = None,
     session_id: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
 ) -> bool:
     """Interactive Google OAuth setup via Device Code flow.
 
     If relay_url + session_id provided, send device code via relay messaging.
     Otherwise print to stderr.
 
+    ``client_id``/``client_secret`` optionally override the OAuth client
+    identity used for the device-code request, token poll, and saved token
+    payload; both default to ``None``, which falls back to
+    ``settings.google_drive_client_id/secret`` exactly as before.
+
     Returns True on success, False on failure.
     """
     import sys
 
-    client_id = settings.google_drive_client_id
-    client_secret = settings.google_drive_client_secret
+    client_id = client_id or settings.google_drive_client_id
+    client_secret = client_secret or settings.google_drive_client_secret
     if not client_id or not client_secret:
         logger.error("GOOGLE_DRIVE_CLIENT_ID or CLIENT_SECRET not configured")
         return False

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -920,6 +920,63 @@ class TestSetupGoogleAuthSuccess:
             assert result is True
             mock_save.assert_called_once()
 
+    async def test_byo_client_pair_overrides_frozen_settings_singleton(self):
+        """client_id/client_secret args must override settings, not be dropped.
+
+        wet_mcp.config.settings is a module-level singleton resolved once at
+        import time -- a BYO client pair can never reach it via os.environ
+        after that point. This guards the actual fix: the override has to
+        win at every point client_id/client_secret are used (outgoing
+        device-code request, outgoing token request, saved token payload).
+        """
+        from wet_mcp.sync import setup_google_auth
+
+        device_response = MagicMock()
+        device_response.status_code = 200
+        device_response.json.return_value = {
+            "device_code": "dev123",
+            "user_code": "ABC-DEF",
+            "verification_url": "https://google.com/device",
+            "interval": 0,
+            "expires_in": 5,
+        }
+        token_response = MagicMock()
+        token_response.status_code = 200
+        token_response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        with (
+            patch("wet_mcp.sync.settings") as mock_settings,
+            patch("wet_mcp.sync.httpx.AsyncClient") as mock_httpx,
+            patch("wet_mcp.sync._save_token") as mock_save,
+            patch("wet_mcp.sync.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            # Settings singleton still holds the bundled defaults -- the BYO
+            # pair below must win over these, not be silently ignored.
+            mock_settings.google_drive_client_id = "bundled-id"
+            mock_settings.google_drive_client_secret = "bundled-secret"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=[device_response, token_response])
+            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await setup_google_auth(
+                client_id="byo-id", client_secret="byo-secret"
+            )
+
+            assert result is True
+            device_call, token_call = mock_client.post.await_args_list
+            assert device_call.kwargs["data"]["client_id"] == "byo-id"
+            assert token_call.kwargs["data"]["client_id"] == "byo-id"
+            assert token_call.kwargs["data"]["client_secret"] == "byo-secret"
+            saved_token = mock_save.call_args.args[0]
+            assert saved_token["client_id"] == "byo-id"
+
     async def test_authorization_pending_then_success(self):
         """Polling returns pending then success."""
         from wet_mcp.sync import setup_google_auth

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,8 +8,6 @@ or model calls -- run_setup_sync/run_warmup/make_docs_db are mocked.
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 
 class TestServeDispatch:
     """Bare/flag argv route to the server unchanged."""
@@ -42,23 +40,33 @@ class TestServeDispatch:
 class TestAuthSubcommand:
     """`wet-mcp auth google` -- BYO client resolution + run_setup_sync."""
 
-    def test_half_pair_flags_raise(self):
+    def test_half_pair_flags_returns_clean_error(self, capsys):
         from wet_mcp import cli
 
         with patch.object(
             sys, "argv", ["wet-mcp", "auth", "google", "--client-secret", "shh"]
         ):
-            with pytest.raises(ValueError, match="set both together"):
-                cli.main()
+            rc = cli.main()
 
-    def test_happy_path_sets_env_and_prints_json(self, capsys):
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "set both together" in err
+        assert "shh" not in err  # never print the secret value
+
+    def test_happy_path_threads_byo_pair_to_setup_google_auth(self, capsys):
+        """auth google --client-id/--client-secret must reach setup_google_auth.
+
+        wet_mcp.config.settings is a module-level singleton resolved at
+        import time, so a prior regression wrote the BYO pair to os.environ
+        (a no-op -- the singleton was already frozen) instead of threading
+        it through run_setup_sync's params. This does NOT blanket-mock
+        run_setup_sync: it lets the real function run (including its
+        missing-credentials check) and only mocks the network-touching
+        setup_google_auth, so the assertion below proves the pair actually
+        reaches that call rather than being silently dropped.
+        """
         from wet_mcp import cli
 
-        result = {
-            "status": "ok",
-            "provider": "google_drive",
-            "message": "Google Drive sync setup complete. Token saved locally.",
-        }
         with (
             patch.object(
                 sys,
@@ -74,21 +82,18 @@ class TestAuthSubcommand:
                 ],
             ),
             patch(
-                "wet_mcp.setup_tool.run_setup_sync",
-                new=AsyncMock(return_value=result),
-            ) as mock_setup,
-            patch.dict("os.environ", {}, clear=False),
+                "wet_mcp.sync.setup_google_auth",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_setup_google_auth,
         ):
             rc = cli.main()
-            import os
 
-            assert os.environ["GOOGLE_DRIVE_CLIENT_ID"] == "my-id"
-            assert os.environ["GOOGLE_DRIVE_CLIENT_SECRET"] == "my-secret"
-
-        mock_setup.assert_awaited_once_with()
+        mock_setup_google_auth.assert_awaited_once_with(
+            client_id="my-id", client_secret="my-secret"
+        )
         assert rc == 0
-        out = capsys.readouterr().out
-        assert '"status": "ok"' in out
+        assert '"status": "ok"' in capsys.readouterr().out
 
     def test_no_flags_skips_byo_resolution(self, capsys):
         from wet_mcp import cli
@@ -105,6 +110,23 @@ class TestAuthSubcommand:
 
         mock_setup.assert_awaited_once_with()
         assert rc == 1
+
+
+class TestUnknownSubcommand:
+    """build_cli's own unrecognized-subcommand handling -- rc 2, no server start."""
+
+    def test_unknown_subcommand_returns_rc_2(self, capsys):
+        from wet_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "bogus"]),
+            patch("wet_mcp.server.main") as mock_server_main,
+        ):
+            rc = cli.main()
+
+        mock_server_main.assert_not_called()
+        assert rc == 2
+        assert "unknown subcommand" in capsys.readouterr().err
 
 
 class TestWarmupSubcommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,179 @@
+"""Tests for wet_mcp.cli -- shared mcp_core CLI builder mount.
+
+Bare invocation and any leading-dash argv start the server unchanged;
+subcommands (auth/warmup/docs) run one-shot operator actions. No network
+or model calls -- run_setup_sync/run_warmup/make_docs_db are mocked.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestServeDispatch:
+    """Bare/flag argv route to the server unchanged."""
+
+    def test_bare_invocation_starts_server(self):
+        from wet_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["wet-mcp"]),
+            patch("wet_mcp.server.main") as mock_server_main,
+        ):
+            rc = cli.main()
+
+        mock_server_main.assert_called_once()
+        assert rc == 0
+
+    def test_http_flag_passes_through_argv_unchanged(self):
+        from wet_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "--http"]),
+            patch("wet_mcp.server.main") as mock_server_main,
+        ):
+            rc = cli.main()
+
+        mock_server_main.assert_called_once()
+        assert rc == 0
+
+
+class TestAuthSubcommand:
+    """`wet-mcp auth google` -- BYO client resolution + run_setup_sync."""
+
+    def test_half_pair_flags_raise(self):
+        from wet_mcp import cli
+
+        with patch.object(
+            sys, "argv", ["wet-mcp", "auth", "google", "--client-secret", "shh"]
+        ):
+            with pytest.raises(ValueError, match="set both together"):
+                cli.main()
+
+    def test_happy_path_sets_env_and_prints_json(self, capsys):
+        from wet_mcp import cli
+
+        result = {
+            "status": "ok",
+            "provider": "google_drive",
+            "message": "Google Drive sync setup complete. Token saved locally.",
+        }
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "wet-mcp",
+                    "auth",
+                    "google",
+                    "--client-id",
+                    "my-id",
+                    "--client-secret",
+                    "my-secret",
+                ],
+            ),
+            patch(
+                "wet_mcp.setup_tool.run_setup_sync",
+                new=AsyncMock(return_value=result),
+            ) as mock_setup,
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            rc = cli.main()
+            import os
+
+            assert os.environ["GOOGLE_DRIVE_CLIENT_ID"] == "my-id"
+            assert os.environ["GOOGLE_DRIVE_CLIENT_SECRET"] == "my-secret"
+
+        mock_setup.assert_awaited_once_with()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert '"status": "ok"' in out
+
+    def test_no_flags_skips_byo_resolution(self, capsys):
+        from wet_mcp import cli
+
+        result = {"status": "error", "provider": "google_drive", "error": "boom"}
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "auth", "google"]),
+            patch(
+                "wet_mcp.setup_tool.run_setup_sync",
+                new=AsyncMock(return_value=result),
+            ) as mock_setup,
+        ):
+            rc = cli.main()
+
+        mock_setup.assert_awaited_once_with()
+        assert rc == 1
+
+
+class TestWarmupSubcommand:
+    """`wet-mcp warmup` -- run_warmup, no argument-taking configure."""
+
+    def test_happy_path(self, capsys):
+        from wet_mcp import cli
+
+        result = {"status": "ok", "mode": "local", "steps": []}
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "warmup"]),
+            patch(
+                "wet_mcp.setup_tool.run_warmup", new=AsyncMock(return_value=result)
+            ) as mock_warmup,
+        ):
+            rc = cli.main()
+
+        mock_warmup.assert_awaited_once_with()
+        assert rc == 0
+        assert '"mode": "local"' in capsys.readouterr().out
+
+    def test_error_status_returns_nonzero(self):
+        from wet_mcp import cli
+
+        result = {"status": "error", "steps": []}
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "warmup"]),
+            patch("wet_mcp.setup_tool.run_warmup", new=AsyncMock(return_value=result)),
+        ):
+            rc = cli.main()
+
+        assert rc == 1
+
+
+class TestDocsReindexSubcommand:
+    """`wet-mcp docs reindex <library>` -- standalone DocsDB, not the global."""
+
+    def test_reindex_known_library_clears_chunks(self, capsys):
+        from wet_mcp import cli
+
+        mock_db = MagicMock()
+        mock_db.get_library.return_value = {"id": "lib-1", "name": "requests"}
+        mock_db.get_best_version.return_value = {"id": "ver-1"}
+
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "docs", "reindex", "requests"]),
+            patch("wet_mcp.server.make_docs_db", return_value=mock_db) as mock_make_db,
+        ):
+            rc = cli.main()
+
+        mock_make_db.assert_called_once_with()
+        mock_db.get_library.assert_called_once_with("requests")
+        mock_db.get_best_version.assert_called_once_with("lib-1")
+        mock_db.clear_version_chunks.assert_called_once_with("ver-1")
+        assert rc == 0
+        assert '"status": "cleared"' in capsys.readouterr().out
+
+    def test_reindex_unknown_library_returns_error(self, capsys):
+        from wet_mcp import cli
+
+        mock_db = MagicMock()
+        mock_db.get_library.return_value = None
+
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "docs", "reindex", "ghost-lib"]),
+            patch("wet_mcp.server.make_docs_db", return_value=mock_db),
+        ):
+            rc = cli.main()
+
+        mock_db.get_best_version.assert_not_called()
+        assert rc == 1
+        assert "not found" in capsys.readouterr().out

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,29 +1,27 @@
 """Tests for wet_mcp.__main__ — CLI entry point and setup_tool functions."""
 
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 
 
 class TestCli:
-    """CLI dispatcher starts MCP server."""
+    """__main__._cli is a thin wrapper delegating to wet_mcp.cli.main.
 
-    @patch("wet_mcp.__main__.main")
-    def test_default_runs_server(self, mock_main):
+    Subcommand dispatch (bare/--http/auth/warmup/docs) is exercised in
+    tests/test_cli.py against the real mcp_core build_cli builder; this
+    only verifies the delegation wiring for `python -m wet_mcp`.
+    """
+
+    @patch("wet_mcp.__main__._cli_main")
+    def test_delegates_to_cli_main(self, mock_cli_main):
         from wet_mcp.__main__ import _cli
 
-        _cli()
-        mock_main.assert_called_once()
+        mock_cli_main.return_value = 0
+        rc = _cli()
 
-    @patch("wet_mcp.__main__.main")
-    def test_cli_always_runs_server(self, mock_main):
-        """_cli() always starts MCP server (no subcommands)."""
-        from wet_mcp.__main__ import _cli
-
-        with patch.object(sys, "argv", ["wet-mcp", "anything"]):
-            _cli()
-        mock_main.assert_called_once()
+        mock_cli_main.assert_called_once_with()
+        assert rc == 0
 
 
 class TestClearModelCache:

--- a/uv.lock
+++ b/uv.lock
@@ -1774,7 +1774,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.19.0b2"
+version = "1.19.0b4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1789,9 +1789,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/12/43db620c359e88c634c0f88a784a9f1fb0c4d4750c5803717c55f5e7560c/n24q02m_mcp_core-1.19.0b2.tar.gz", hash = "sha256:fbda9b57e462e3361f387527a797ee5e924dba975c36a92a5b7fb79c2340b173", size = 310576, upload-time = "2026-07-11T03:05:22.383Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/94/4a0f9d5407080cf82cc96d666ea9ec60fc4f34e2db9421181cc71cf39eee/n24q02m_mcp_core-1.19.0b4.tar.gz", hash = "sha256:37a9895b2dad090b1299642d812b5ebf31a3fcb884bf825355edfa1f142d6c58", size = 317619, upload-time = "2026-07-11T07:13:12.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/17/1d3d68aac7b6734fd1fd9f9ea0d77169ecefa8e7015d9636001ee37ebe3f/n24q02m_mcp_core-1.19.0b2-py3-none-any.whl", hash = "sha256:59e1b7961db1c04d1b4195f98d391679ea974f21c05731a0ba59834916f2b87a", size = 172726, upload-time = "2026-07-11T03:05:21.111Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f5/c979129112a73c433559be78d613c6ec989f5e11423e9257b51bcbdc7c47/n24q02m_mcp_core-1.19.0b4-py3-none-any.whl", hash = "sha256:65cb2060b37d3d726ff573509b6ff443812dc71d44654475b38c1c0840e6752f", size = 176888, upload-time = "2026-07-11T07:13:11.319Z" },
 ]
 
 [package.optional-dependencies]
@@ -3396,7 +3396,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.5.0b2"
+version = "3.5.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3457,7 +3457,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0b2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0b4,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.3.1,<3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
## S6 / WS-B2 (wet half — mnemo mirror ships in the same batch)

- New `wet_mcp.cli:main` mounts `mcp_core.build_cli`: bare/`--http` start the server byte-identically; subcommands:
  - `auth google [--client-id X --client-secret Y]` — BYO pair validated via `resolve_bundled_client` and THREADED EXPLICITLY through `run_setup_sync` → `setup_google_auth` (device-code request, token poll, and saved token payload all use the effective pair). The env-var route was rejected in review: the settings singleton freezes at package import, so env writes after entry are silent no-ops — the threading fix closes that hole and a dedicated anti-regression test pins BYO override against a deliberately different frozen singleton.
  - `warmup` — existing `run_warmup()` (SearXNG/Playwright auto-setup + cloud-or-local embedding/reranker checks), JSON to stdout.
  - `docs reindex <lib>` — bootstraps its own `DocsDB` via `make_docs_db()` (no lifespan, no global), replicating the MCP tool logic as-is.
- Half-pair flags → one clean stderr line + rc 2; unknown subcommand → rc 2 (both pinned by tests).
- Pin bump `n24q02m-mcp-core[llm]>=1.19.0b4,<2`.

Evidence: 2001 passed / 33 skipped; ruff/ty/pre-commit clean; opus task review + Critical fix re-review: RESOLVED/Approved.