### PR TITLE
fix: never open a real browser during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,20 @@ pytest_plugins = ["conftest_e2e", "conftest_cf"]
 
 
 @pytest.fixture(autouse=True)
+def _never_open_a_real_browser(monkeypatch):
+    """Keep the GDrive device-code path from hijacking the developer's browser.
+
+    ``credential_state._trigger_gdrive_device_code`` calls ``try_open_browser``
+    on the verification URL. Newer mcp-core honours ``MCP_NO_BROWSER``, but the
+    import is lazy and older installs lack that guard, so patch the symbol too.
+    Tests that assert on the launch patch ``mcp_core.try_open_browser``
+    themselves, which shadows this fixture.
+    """
+    monkeypatch.setenv("MCP_NO_BROWSER", "1")
+    monkeypatch.setattr("mcp_core.try_open_browser", lambda url: False, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _stub_phase2_lifespan_hooks():
     """Phase 2 wires migrations + Tier 1 warmup into the FastMCP lifespan.
 

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -1053,3 +1053,17 @@ class TestLlmProviderDetection:
             assert has_llm_provider() is True
         with patch.dict(os.environ, {}, clear=True):
             assert has_llm_provider() is False
+
+
+def test_conftest_blocks_real_browser_launch():
+    """The autouse fixture must neutralise try_open_browser for the whole suite.
+
+    Regression guard: the GDrive device-code path used to open a real tab in the
+    developer's browser on every unmocked test run.
+    """
+    import os
+
+    import mcp_core
+
+    assert os.environ.get("MCP_NO_BROWSER") == "1"
+    assert mcp_core.try_open_browser("https://example.com/device") is False


### PR DESCRIPTION
## Problem

Running the test suite hijacked the developer's browser: `credential_state._trigger_gdrive_device_code()` calls `try_open_browser(verification_url)` for real, so every unmocked test run that reached the GDrive device-code path opened tabs in whatever browser the developer was using.

mcp-core grew an `MCP_NO_BROWSER` / `NO_BROWSER` env guard (`relay/browser.py`), but the import in `credential_state` is lazy and older installed builds predate the guard — so relying on the env var alone is not sufficient across the versions a contributor may have in their venv.

## Fix

An autouse fixture in `tests/conftest.py` that does both:
- sets `MCP_NO_BROWSER=1` (honoured by current mcp-core, and inherited by any subprocess), and
- patches `mcp_core.try_open_browser` to a no-op returning `False` (version-independent, works even on installs without the guard).

The one test that deliberately asserts the launch (`test_credential_state.py`) patches `mcp_core.try_open_browser` itself; that inner patch shadows the fixture, so its assertion is unaffected. A regression test pins both halves of the guard.

## Evidence

`uv run pytest -q` → 1999 passed / 35 skipped. (The single `test_resolve_embedding_backend_none` failure seen locally is a pre-existing ambient-env leak — it fails identically on unmodified `origin/main` and passes with the provider env vars unset; unrelated to this change.)