### PR TITLE
feat: track page changes with snapshot retention and extract diff

### DIFF
--- a/src/wet_mcp/cache.py
+++ b/src/wet_mcp/cache.py
@@ -27,6 +27,9 @@ _DEFAULT_TTLS: dict[str, int] = {
 # Purge expired entries every N operations
 _PURGE_INTERVAL = 50
 
+# Snapshots kept per URL for change tracking (extract action="diff")
+_SNAPSHOT_RETENTION = 5
+
 
 def _cache_key(action: str, params: dict) -> str:
     """Generate a deterministic cache key from action + params."""
@@ -75,6 +78,21 @@ class WebCache:
         self._conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_web_cache_action
             ON web_cache(action)
+        """)
+        # Append-only, unlike ``web_cache``'s INSERT OR REPLACE — a fresh
+        # extract must not overwrite the prior fetch, or there is nothing
+        # left to diff against.
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT NOT NULL,
+                fetched_at REAL NOT NULL,
+                content TEXT NOT NULL
+            )
+        """)
+        self._conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_snapshots_url_fetched
+            ON snapshots(url, fetched_at DESC)
         """)
         self._conn.commit()
 
@@ -148,6 +166,51 @@ class WebCache:
         if self._op_count >= _PURGE_INTERVAL:
             self._purge_expired()
             self._op_count = 0
+
+    def record_snapshot(self, url: str, content: str) -> None:
+        """Append a content snapshot for ``url``, pruning to the last N.
+
+        Unlike ``set()``, this never overwrites — each call adds a new row so
+        ``latest_snapshots`` has history to diff against. Retention keeps at
+        most ``_SNAPSHOT_RETENTION`` rows per URL.
+        """
+        now = time.time()
+        self._conn.execute(
+            "INSERT INTO snapshots (url, fetched_at, content) VALUES (?, ?, ?)",
+            (url, now, content),
+        )
+        self._conn.execute(
+            """
+            DELETE FROM snapshots
+            WHERE url = ? AND id NOT IN (
+                SELECT id FROM snapshots
+                WHERE url = ?
+                ORDER BY fetched_at DESC, id DESC
+                LIMIT ?
+            )
+            """,
+            (url, url, _SNAPSHOT_RETENTION),
+        )
+        self._conn.commit()
+        logger.debug(f"Snapshot recorded for {url}")
+
+    def latest_snapshots(self, url: str, n: int = 2) -> list[dict]:
+        """Return up to ``n`` most recent snapshots for ``url``, newest first.
+
+        Each item is ``{"fetched_at": float, "content": str}``.
+        """
+        rows = self._conn.execute(
+            """
+            SELECT fetched_at, content FROM snapshots
+            WHERE url = ?
+            ORDER BY fetched_at DESC, id DESC
+            LIMIT ?
+            """,
+            (url, n),
+        ).fetchall()
+        return [
+            {"fetched_at": row["fetched_at"], "content": row["content"]} for row in rows
+        ]
 
     def _purge_expired(self) -> None:
         """Remove expired cache entries."""

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1,6 +1,7 @@
 """WET MCP Server - Main server definition."""
 
 import asyncio
+import difflib
 import functools
 import io
 import json
@@ -742,6 +743,68 @@ def _payload(result: str | dict[str, Any] | list[Any]) -> dict[str, Any]:
     return data if isinstance(data, dict) else {"results": data}
 
 
+# Cap on diff text landed in a tool payload (token guard), matching the
+# ``token_budget`` convention used elsewhere in this file.
+_DIFF_MAX_CHARS = 20_000
+
+
+def _unified_diff_truncated(old_content: str, new_content: str, url: str) -> str:
+    """Line-based unified diff (stdlib) between two snapshot bodies.
+
+    Truncated at ``_DIFF_MAX_CHARS`` with a note appended, so a large page
+    rewrite can't blow the tool's output budget.
+    """
+    diff_lines = difflib.unified_diff(
+        old_content.splitlines(),
+        new_content.splitlines(),
+        fromfile=f"{url} (old)",
+        tofile=f"{url} (new)",
+        lineterm="",
+        n=3,
+    )
+    diff_text = "\n".join(diff_lines)
+    if len(diff_text) > _DIFF_MAX_CHARS:
+        diff_text = (
+            diff_text[:_DIFF_MAX_CHARS] + "\n... (diff truncated at 20000 chars)"
+        )
+    return diff_text
+
+
+def _build_diff_result(url: str, snapshots: list[dict[str, Any]]) -> dict[str, Any]:
+    """Turn up to 2 ``latest_snapshots`` rows (newest first) into a diff payload."""
+    if not snapshots:
+        return {
+            "url": url,
+            "error": f"Error: no snapshot history for {url}. Extract it once "
+            "(refetch=True, the default) to start tracking changes.",
+        }
+    newest = snapshots[0]
+    if len(snapshots) == 1:
+        return {
+            "url": url,
+            "change_status": "new",
+            "diff": "",
+            "old_fetched_at": None,
+            "new_fetched_at": newest["fetched_at"],
+        }
+    old = snapshots[1]
+    if old["content"] == newest["content"]:
+        return {
+            "url": url,
+            "change_status": "same",
+            "diff": "",
+            "old_fetched_at": old["fetched_at"],
+            "new_fetched_at": newest["fetched_at"],
+        }
+    return {
+        "url": url,
+        "change_status": "changed",
+        "diff": _unified_diff_truncated(old["content"], newest["content"], url),
+        "old_fetched_at": old["fetched_at"],
+        "new_fetched_at": newest["fetched_at"],
+    }
+
+
 def _wrap_tool(tool_name: str):
     """Decorator to wrap tool results with XPIA safety markers.
 
@@ -1343,6 +1406,7 @@ async def extract(  # noqa: PLR0913
     session: str | None = None,
     screenshot: bool = False,
     url: str | None = None,
+    refetch: bool = True,
 ) -> dict[str, Any]:
     """Read and return full page content from URLs or local files. Use this when you have a specific URL and need its content. For finding URLs first, use the `search` tool instead.
 
@@ -1355,9 +1419,10 @@ async def extract(  # noqa: PLR0913
     - extract_structured: Extract structured data using JSON Schema + LLM. Example: extract(action="extract_structured", urls=["https://example.com/pricing"], schema={"type": "object", "properties": {"price": {"type": "string"}}})
     - agent: Multi-step research orchestration -- search the web, extract top results, synthesize a cited Markdown answer. Example: extract(action="agent", query="latest pydantic 2 changes", max_urls=5)
     - interact: Drive a page with click/fill/submit via patchright. Example: extract(action="interact", url="https://example.com/login", actions=[{"type": "fill", "selector": "#email", "value": "x@y.com"}, {"type": "submit", "selector": "form"}])
+    - diff: Track content changes across fetches of the same URL(s). Example: extract(action="diff", urls=["https://example.com/pricing"])
 
     Key parameters:
-    - urls (required for extract/batch/crawl/map/extract_structured): List of URLs
+    - urls (required for extract/batch/crawl/map/extract_structured/diff): List of URLs
     - paths (required for convert): List of local file paths
     - query (required for agent): Research question to answer
     - url (required for interact): Page URL to drive
@@ -1372,6 +1437,8 @@ async def extract(  # noqa: PLR0913
     - max_pages: Max pages for crawl/map (default: 20, max: 100)
     - stealth: Enable anti-bot bypass for protected sites (default: false)
     - schema: JSON Schema dict for extract_structured
+    - refetch (diff): Fetch a fresh copy before comparing (default: true). Set
+      false to compare already-recorded snapshots without a new network fetch.
 
     Use `help` tool with tool_name="extract" for full parameter documentation.
     """
@@ -1551,14 +1618,57 @@ async def extract(  # noqa: PLR0913
                 )
             )
 
-        case _:
-            import difflib
+        case "diff":
+            if not urls:
+                return {
+                    "error": 'Error: urls is required for diff action. Example: extract(action="diff", urls=["https://example.com"])'
+                }
+            if not _web_cache:
+                return {
+                    "error": "Error: diff action requires the web cache to be "
+                    "enabled (set WET_CACHE=true)."
+                }
+            urls = urls[:_MAX_EXTRACT_URLS]
+            diff_items: list[dict[str, Any]] = []
+            for target_url in urls:
+                if refetch:
+                    fresh = await _with_timeout(
+                        _extract(urls=[target_url], format=format, stealth=stealth),
+                        "diff",
+                    )
+                    if fresh.startswith("Error"):
+                        diff_items.append({"url": target_url, "error": fresh})
+                        continue
+                    try:
+                        parsed = json.loads(fresh)
+                    except json.JSONDecodeError:
+                        diff_items.append(
+                            {
+                                "url": target_url,
+                                "error": f"Error: failed to parse extract result for diff: {fresh}",
+                            }
+                        )
+                        continue
+                    item = parsed[0] if parsed else {}
+                    if item.get("error"):
+                        diff_items.append({"url": target_url, "error": item["error"]})
+                        continue
+                    await asyncio.to_thread(
+                        _web_cache.record_snapshot, target_url, item.get("markdown", "")
+                    )
+                snapshots = await asyncio.to_thread(
+                    _web_cache.latest_snapshots, target_url, 2
+                )
+                diff_items.append(_build_diff_result(target_url, snapshots))
+            return _payload(diff_items[0] if len(diff_items) == 1 else diff_items)
 
+        case _:
             valid_actions = [
                 "agent",
                 "batch",
                 "convert",
                 "crawl",
+                "diff",
                 "extract",
                 "extract_structured",
                 "interact",
@@ -1575,7 +1685,8 @@ async def extract(  # noqa: PLR0913
                     f"Error: Unknown action '{action}'.{suggestion} "
                     "Valid actions: extract (read URL content), batch (bulk extract), crawl (follow links), "
                     "map (site structure), convert (local files to markdown), extract_structured (schema-based), "
-                    "agent (multi-step research orchestration), interact (drive a page with click/fill/submit). "
+                    "agent (multi-step research orchestration), interact (drive a page with click/fill/submit), "
+                    "diff (track changes between fetches). "
                     "If you want to search for information, use the `search` tool instead."
                 )
             }

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -265,6 +265,54 @@ class TestStats:
 # -----------------------------------------------------------------------
 
 
+class TestSnapshots:
+    def test_latest_snapshots_returns_newest_first(self, cache):
+        """record 3 snapshots -> latest_snapshots(n=2) returns the 2 newest, newest first."""
+        cache.record_snapshot("https://example.com", "v1")
+        cache.record_snapshot("https://example.com", "v2")
+        cache.record_snapshot("https://example.com", "v3")
+
+        latest = cache.latest_snapshots("https://example.com", n=2)
+        assert len(latest) == 2
+        assert latest[0]["content"] == "v3"
+        assert latest[1]["content"] == "v2"
+
+    def test_retention_keeps_last_five(self, cache):
+        """record 7 snapshots for one URL -> only the 5 most recent survive."""
+        for i in range(7):
+            cache.record_snapshot("https://example.com", f"v{i}")
+
+        remaining = cache.latest_snapshots("https://example.com", n=10)
+        assert len(remaining) == 5
+        assert [row["content"] for row in remaining] == [
+            "v6",
+            "v5",
+            "v4",
+            "v3",
+            "v2",
+        ]
+
+    def test_retention_is_per_url(self, cache):
+        """Snapshots for different URLs don't count against each other's retention."""
+        for i in range(7):
+            cache.record_snapshot("https://a.com", f"a{i}")
+        cache.record_snapshot("https://b.com", "b0")
+
+        assert len(cache.latest_snapshots("https://a.com", n=10)) == 5
+        assert len(cache.latest_snapshots("https://b.com", n=10)) == 1
+
+    def test_latest_snapshots_empty_url(self, cache):
+        """No snapshots recorded yet -> empty list."""
+        assert cache.latest_snapshots("https://never-seen.com") == []
+
+    def test_latest_snapshots_single_snapshot(self, cache):
+        """Only one snapshot recorded -> list of length 1."""
+        cache.record_snapshot("https://example.com", "only")
+        latest = cache.latest_snapshots("https://example.com", n=2)
+        assert len(latest) == 1
+        assert latest[0]["content"] == "only"
+
+
 class TestCacheEdgeCases:
     def test_close_and_reopen(self, tmp_path):
         """Cache persists after close and reopen."""

--- a/tests/test_extract_diff.py
+++ b/tests/test_extract_diff.py
@@ -105,6 +105,10 @@ async def test_diff_second_fetch_changed(real_cache):
     assert "+line THREE" in data["diff"]
     assert data["old_fetched_at"] is not None
     assert data["new_fetched_at"] is not None
+    # Diff output is external content -- XPIA marker must be present on both
+    # response channels (structuredContent envelope + text-block boundary tag).
+    assert data["_untrusted_source"] == "web"
+    assert "<untrusted_extract_content>" in text(result)
 
 
 @pytest.mark.asyncio

--- a/tests/test_extract_diff.py
+++ b/tests/test_extract_diff.py
@@ -1,0 +1,174 @@
+"""Tests for ``extract(action="diff")`` -- snapshot retention + change tracking (S14 Task 7)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.types import CallToolResult
+from structured import payload, text
+
+from wet_mcp.cache import WebCache
+from wet_mcp.server import extract
+
+
+def _extract_json(url: str, markdown: str) -> str:
+    """Build a JSON string matching ``sources.crawler.extract``'s per-URL shape."""
+    return json.dumps(
+        [
+            {
+                "url": url,
+                "markdown": markdown,
+                "clean_text": markdown,
+                "structured_data": [],
+                "code_blocks": [],
+                "metadata": {"title": "", "url": url},
+            }
+        ]
+    )
+
+
+@pytest.fixture
+def real_cache(tmp_path):
+    """A real (not mocked) WebCache so record_snapshot/latest_snapshots/diff
+    run against actual SQLite state instead of a hand-wired mock.
+    """
+    import wet_mcp.server as server
+
+    cache = WebCache(tmp_path / "diff_test.db")
+    old_cache = server._web_cache
+    server._web_cache = cache
+    yield cache
+    cache.close()
+    server._web_cache = old_cache
+
+
+@pytest.mark.asyncio
+async def test_diff_missing_urls_returns_error():
+    result = await extract(action="diff")
+    assert isinstance(result, CallToolResult)
+    assert "urls is required" in text(result)
+
+
+@pytest.mark.asyncio
+async def test_diff_requires_cache_enabled():
+    import wet_mcp.server as server
+
+    old_cache = server._web_cache
+    server._web_cache = None
+    try:
+        result = await extract(action="diff", urls=["https://example.com"])
+    finally:
+        server._web_cache = old_cache
+    assert isinstance(result, CallToolResult)
+    assert "requires the web cache" in text(result)
+
+
+@pytest.mark.asyncio
+async def test_diff_first_fetch_is_new(real_cache):
+    """Only one snapshot exists so far -> change_status 'new', empty diff."""
+    with patch(
+        "wet_mcp.server._extract",
+        new_callable=AsyncMock,
+        return_value=_extract_json("https://example.com", "hello v1"),
+    ):
+        result = await extract(action="diff", urls=["https://example.com"])
+
+    data = payload(result)
+    assert data["change_status"] == "new"
+    assert data["diff"] == ""
+    assert data["old_fetched_at"] is None
+    assert data["new_fetched_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_diff_second_fetch_changed(real_cache):
+    """Two differing snapshots -> change_status 'changed' with -old/+new lines."""
+    with patch(
+        "wet_mcp.server._extract",
+        new_callable=AsyncMock,
+        return_value=_extract_json("https://example.com", "line one\nline two"),
+    ):
+        await extract(action="diff", urls=["https://example.com"])
+
+    with patch(
+        "wet_mcp.server._extract",
+        new_callable=AsyncMock,
+        return_value=_extract_json("https://example.com", "line one\nline THREE"),
+    ):
+        result = await extract(action="diff", urls=["https://example.com"])
+
+    data = payload(result)
+    assert data["change_status"] == "changed"
+    assert "-line two" in data["diff"]
+    assert "+line THREE" in data["diff"]
+    assert data["old_fetched_at"] is not None
+    assert data["new_fetched_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_diff_unchanged_content_is_same(real_cache):
+    """Refetching identical content -> change_status 'same', empty diff."""
+    with patch(
+        "wet_mcp.server._extract",
+        new_callable=AsyncMock,
+        return_value=_extract_json("https://example.com", "static content"),
+    ):
+        await extract(action="diff", urls=["https://example.com"])
+        result = await extract(action="diff", urls=["https://example.com"])
+
+    data = payload(result)
+    assert data["change_status"] == "same"
+    assert data["diff"] == ""
+
+
+@pytest.mark.asyncio
+async def test_diff_no_refetch_uses_existing_snapshots_only(real_cache):
+    """refetch=False must not trigger a new fetch; diff the 2 newest stored snapshots."""
+    real_cache.record_snapshot("https://example.com", "line one\nline two")
+    real_cache.record_snapshot("https://example.com", "line one\nline THREE")
+
+    with patch("wet_mcp.server._extract", new_callable=AsyncMock) as mock_extract:
+        result = await extract(
+            action="diff", urls=["https://example.com"], refetch=False
+        )
+        mock_extract.assert_not_called()
+
+    data = payload(result)
+    assert data["change_status"] == "changed"
+    assert "-line two" in data["diff"]
+    assert "+line THREE" in data["diff"]
+
+
+@pytest.mark.asyncio
+async def test_diff_no_history_and_no_refetch_returns_error(real_cache):
+    """refetch=False with zero prior snapshots -> per-URL error, not a fabricated status."""
+    with patch("wet_mcp.server._extract", new_callable=AsyncMock) as mock_extract:
+        result = await extract(
+            action="diff", urls=["https://never-fetched.com"], refetch=False
+        )
+        mock_extract.assert_not_called()
+
+    data = payload(result)
+    assert "no snapshot history" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_diff_multiple_urls_wraps_in_results(real_cache):
+    """More than one URL -> list of per-URL diff dicts under 'results'."""
+
+    async def fake_extract(urls, format, stealth):
+        return _extract_json(urls[0], f"content for {urls[0]}")
+
+    with patch(
+        "wet_mcp.server._extract", new_callable=AsyncMock, side_effect=fake_extract
+    ):
+        result = await extract(action="diff", urls=["https://a.com", "https://b.com"])
+
+    data = payload(result)
+    assert [item["url"] for item in data["results"]] == [
+        "https://a.com",
+        "https://b.com",
+    ]
+    assert all(item["change_status"] == "new" for item in data["results"])


### PR DESCRIPTION
## Feature (S14 Task 7, Wave 3)

`extract` had no way to tell if a page changed since you last read it. New `extract(action="diff", urls=[...])` returns a unified diff + `change_status` (new / same / changed).

## Re-scoped from the plan (verified against the code)

The web cache uses `INSERT OR REPLACE` on a content-hash key — a refetch OVERWRITES the prior content, so no history existed to diff against. This adds a SEPARATE append-only `snapshots(url, fetched_at, content)` table (retains the last 5 per URL), leaving the existing `web_cache` untouched.

## Behavior

- `diff` with `refetch=True` (default): fetch fresh, record a snapshot, compare new-vs-previous. `refetch=False`: compare the two most recent stored snapshots without fetching.
- Diff via stdlib `difflib.unified_diff` (no new dep), 3 lines of context, truncated at 20 000 chars with a note.
- Snapshots store the `markdown` render (not `clean_text`, which collapses newlines and would make a line diff meaningless).
- Diff output is external web content → flows through the existing `@_wrap_tool("extract")` XPIA wrapper, marked on both channels (asserted in the diff tests).
- The normal `extract` path is unchanged — no snapshot write added to the hot path.

## Tests

2063 passed. Retention (3→2 newest, 7→keep-5, per-URL isolation), change_status new/same/changed, refetch=False skips the fetch, and the XPIA marker on diff output.

Reviewed (opus, adversarial): SPEC + CODE QUALITY pass, no XPIA bypass; the brief-mandated XPIA assertion was folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)