### PR TITLE
fix: forward CF AI Gateway litellm envs into container

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -86,6 +86,8 @@ const CONTAINER_ENV_KEYS = [
   'BROWSERLESS_URL', 'BROWSERLESS_TOKEN', 'CAPSOLVER_API_KEY',
   'DISABLE_LOCAL_EMBED', 'DISABLE_LOCAL_RERANK',
   'DISABLE_LOCAL_SEARCH', 'DISABLE_LOCAL_BROWSER',
+  // CF AI Gateway (llm-main) litellm routing
+  'OPENROUTER_API_BASE', 'OPENROUTER_API_KEY', 'JINA_AI_API_BASE',
 ] as const
 
 function pickContainerEnv(env: Env): Record<string, string> {

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -45,7 +45,7 @@
     "MCP_VECTORIZE_IDX": "${CF_VECTORIZE_ID}",
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
-    "LLM_MODELS": "vertex_express/gemini-3.5-flash,xai/grok-4.3",
+    "LLM_MODELS": "openrouter/minimax/minimax-m3",
     "SEARCH_BACKEND": "searxng",
     "WET_AUTO_SEARXNG": "false"
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -47,7 +47,7 @@
     "MCP_VECTORIZE_IDX": "wet-docs-vectors",
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
-    "LLM_MODELS": "vertex_express/gemini-3.5-flash,xai/grok-4.3",
+    "LLM_MODELS": "openrouter/minimax/minimax-m3",
     "SEARCH_BACKEND": "searxng",
     "WET_AUTO_SEARXNG": "false"
   },


### PR DESCRIPTION
The container never receives CF AI Gateway litellm routing config because `CONTAINER_ENV_KEYS` in `src/worker.ts` does not forward `OPENROUTER_API_BASE`, `OPENROUTER_API_KEY`, and `JINA_AI_API_BASE`. These values are already provisioned as Worker secrets, so litellm inside the container silently falls back to defaults instead of routing through the gateway.

This adds the three keys to the forwarding list so they reach the container at runtime.

Also updates the default `LLM_MODELS` chain to `openrouter/minimax/minimax-m3` in both `wrangler.deploy.template.jsonc` (CI-rendered deploy template) and `wrangler.jsonc` (self-host example config), moving the default LLM chain to OpenRouter (MiniMax M3) behind the CF AI Gateway. `EMBEDDING_MODELS`/`RERANK_MODELS` are unchanged in both files.