### PR TITLE
⚡ Bolt: short-circuit blocked marker check in docs.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,12 @@
 ## 2023-11-20 - Fast String Suffix/Prefix matching with tuples
 **Learning:** Python generator expressions inside `any()` for checking multiple prefixes/suffixes (e.g. `any(path.endswith(ext) for ext in EXTENSIONS)`) are slow due to Python-level iteration overhead.
 **Action:** Always prefer passing a tuple of strings directly to `str.startswith()` and `str.endswith()` (e.g., `path.endswith(tuple(EXTENSIONS))`). This pushes the iteration down into optimized C code, yielding roughly ~5-7x speedup for prefix/suffix matching. Ensure the tuple is defined at the module level if used repeatedly.
+## 2024-05-24 - Avoid micro-optimizing cold paths
+
+**Learning:** Replacing idiomatic Python generator expressions (like `sum(1 for ...)`) with manual `for` loops in cold paths (like project locking logic) sacrifices code readability for negligible performance gains, and is considered a negative micro-optimization.
+**Action:** When searching for performance improvements, verify that the targeted code is actually in a hot path or tight loop before applying optimizations that reduce readability.
+
+## 2024-05-24 - Use short-circuiting in threshold checks
+
+**Learning:** When checking for a threshold (e.g., detecting if a page is blocked by checking if `hits >= 2`), iterating over the full list of markers using `sum(1 for ...)` wastes cycles. An inline `for` loop with a `break` statement can short-circuit the evaluation as soon as the threshold is met.
+**Action:** Apply early exits (`break` or `return`) when counting matches if a fixed threshold defines success or failure.

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -2160,7 +2160,13 @@ def _is_blocked_content(content: str) -> bool:
         return False
     lower = content.lower()
     # Count how many blocked markers appear
-    hits = sum(1 for marker in _BLOCKED_MARKERS if marker in lower)
+    # Bolt optimization: inline for-loop to eliminate generator overhead
+    hits = 0
+    for marker in _BLOCKED_MARKERS:
+        if marker in lower:
+            hits += 1
+            if hits >= 2:
+                break
     # A single "Ray ID" in a long page isn't enough; require 2+ markers
     # or a single strong marker in a short page (< 2000 chars).
     if hits >= 2:


### PR DESCRIPTION
💡 What: Replaced a `sum(1 for ...)` generator with a manual `for` loop and an early `break` in `_is_blocked_content`.
🎯 Why: To avoid checking the entire list of `_BLOCKED_MARKERS` once we already know the page is blocked (threshold is 2 hits).
📊 Impact: Minor speedup on long challenge pages by short-circuiting the evaluation.
🔬 Measurement: Verified via unit tests (`uv run pytest -n0`).

---
*PR created automatically by Jules for task [11791728644831086513](https://jules.google.com/task/11791728644831086513) started by @n24q02m*