### PR TITLE
feat: add setup_start config action and logout CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ wet-mcp                        # start the server over stdio (default transport)
 wet-mcp --http                 # start the server over Streamable HTTP (self-host mode)
 
 wet-mcp auth google            # authorize the Google credential provider for Drive sync
+wet-mcp logout                 # clear the local Google Drive sync token
 wet-mcp warmup                 # pre-download local models + run auto-setup (SearXNG, browser) to avoid first-run delays
 wet-mcp docs reindex <library> # drop the cached docs index for <library>; the next docs search re-indexes it
 ```

--- a/src/wet_mcp/cli.py
+++ b/src/wet_mcp/cli.py
@@ -74,6 +74,18 @@ def _handle_warmup(args: argparse.Namespace) -> int:
     return 0 if result.get("status") == "ok" else 1
 
 
+def _handle_logout(args: argparse.Namespace) -> int:
+    from wet_mcp.token_store import delete_token, load_token
+
+    if load_token("google_drive") is None:
+        print("Nothing to log out (no saved Google Drive token).")
+        return 0
+
+    delete_token("google_drive")
+    print("Logged out. Google Drive sync token cleared.")
+    return 0
+
+
 def _configure_docs(p: argparse.ArgumentParser) -> None:
     p.add_argument("docs_action", choices=["reindex"], help="Docs index action")
     p.add_argument("library", help="Library name to reindex")
@@ -107,6 +119,7 @@ def _extras() -> dict:
         "auth": (_configure_auth, _handle_auth),
         "warmup": _handle_warmup,
         "docs": (_configure_docs, _handle_docs),
+        "logout": _handle_logout,
     }
 
 

--- a/src/wet_mcp/docs/config.md
+++ b/src/wet_mcp/docs/config.md
@@ -90,6 +90,26 @@ Show current credential state and configured keys.
 
 Returns: credential state (`awaiting_setup`, `configured`, `local`), setup URL, detected cloud keys.
 
+### setup_start
+
+Trigger relay setup / show the current setup URL for configuring cloud provider keys via browser. Does not spawn a separate relay session.
+
+```json
+{"action": "setup_start"}
+```
+
+With `force=true` to reconfigure even when already configured:
+
+```json
+{"action": "setup_start", "force": true}
+```
+
+| Parameter | Required | Default | Description |
+|:----------|:---------|:--------|:------------|
+| `force` | No | `false` | Re-trigger setup even if already configured |
+
+Returns `status: "already_configured"` (unless forced), `status: "setup_started"` with `setup_url` in HTTP mode, or `status: "stdio_unsupported"` with env-var guidance in stdio mode.
+
 ### setup_skip
 
 Opt into local-only mode (uses local ONNX models, no cloud API keys required).

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1998,6 +1998,31 @@ def _handle_config_setup_status() -> dict[str, Any]:
     }
 
 
+def _handle_config_setup_start(force: bool) -> dict[str, Any]:
+    from wet_mcp import credential_state as _cs
+
+    if _cs.get_state() == _cs.CredentialState.CONFIGURED and not force:
+        return {
+            "status": "already_configured",
+            "message": "Already configured. Use force=true to reconfigure.",
+        }
+    url = _cs.get_setup_url()
+    if url:
+        return {
+            "status": "setup_started",
+            "setup_url": url,
+            "message": "Open this URL to configure cloud provider keys.",
+        }
+    return {
+        "status": "stdio_unsupported",
+        "message": (
+            "Browser-based setup is HTTP-mode only. For stdio mode, set "
+            "cloud provider keys directly as env vars (JINA_AI_API_KEY, "
+            "GEMINI_API_KEY, OPENAI_API_KEY, COHERE_API_KEY, ...)."
+        ),
+    }
+
+
 def _handle_config_setup_skip() -> dict[str, Any]:
     from mcp_core import set_local_mode
 
@@ -2050,7 +2075,7 @@ async def _handle_config_setup_complete() -> dict[str, Any]:
     description=(
         "Server config and management. Actions: "
         "status|set|cache_clear|docs_reindex|warmup|setup_sync|"
-        "setup_status|setup_skip|setup_reset|setup_complete. "
+        "setup_status|setup_start|setup_skip|setup_reset|setup_complete. "
         "Use help tool with tool_name='config' for full docs."
     ),
     annotations=ToolAnnotations(
@@ -2078,6 +2103,7 @@ async def config(
     - warmup: Pre-download models and run first-time setup
     - setup_sync: Configure Google Drive sync (OAuth Device Code flow)
     - setup_status: Show current credential state and configured keys
+    - setup_start: Trigger relay setup / show setup URL (force=true to reconfigure)
     - setup_skip: Use local ONNX models (explicit opt-in, no cloud features)
     - setup_reset: Clear all credentials and reset state
     - setup_complete: Re-resolve credentials from environment
@@ -2104,6 +2130,9 @@ async def config(
         case "setup_status":
             return _handle_config_setup_status()
 
+        case "setup_start":
+            return _handle_config_setup_start(force)
+
         case "setup_skip":
             return _handle_config_setup_skip()
 
@@ -2123,6 +2152,7 @@ async def config(
                 "setup_complete",
                 "setup_reset",
                 "setup_skip",
+                "setup_start",
                 "setup_status",
                 "setup_sync",
                 "status",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,6 +161,40 @@ class TestWarmupSubcommand:
         assert rc == 1
 
 
+class TestLogoutSubcommand:
+    """`wet-mcp logout` -- clears the local Google Drive sync token."""
+
+    def test_clears_saved_token(self, capsys):
+        from wet_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "logout"]),
+            patch(
+                "wet_mcp.token_store.load_token", return_value={"refresh_token": "x"}
+            ),
+            patch("wet_mcp.token_store.delete_token") as mock_delete,
+        ):
+            rc = cli.main()
+
+        mock_delete.assert_called_once_with("google_drive")
+        assert rc == 0
+        assert "cleared" in capsys.readouterr().out.lower()
+
+    def test_nothing_to_clear(self, capsys):
+        from wet_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["wet-mcp", "logout"]),
+            patch("wet_mcp.token_store.load_token", return_value=None),
+            patch("wet_mcp.token_store.delete_token") as mock_delete,
+        ):
+            rc = cli.main()
+
+        mock_delete.assert_not_called()
+        assert rc == 0
+        assert "nothing to log out" in capsys.readouterr().out.lower()
+
+
 class TestDocsReindexSubcommand:
     """`wet-mcp docs reindex <library>` -- standalone DocsDB, not the global."""
 

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -275,6 +275,58 @@ class TestSetupMcpTool:
             assert "unknown action" not in text(result).lower()
             assert "state" in text(result)
 
+    async def test_config_tool_dispatches_setup_start_action_already_configured(self):
+        """setup_start returns already_configured when configured and not forced."""
+        from wet_mcp.credential_state import CredentialState
+
+        with patch(
+            "wet_mcp.credential_state.get_state",
+            return_value=CredentialState.CONFIGURED,
+        ):
+            from wet_mcp.server import config
+
+            result = await config(action="setup_start")
+            assert "unknown action" not in text(result).lower()
+            assert "already_configured" in text(result)
+
+    async def test_config_tool_dispatches_setup_start_action_returns_setup_url(self):
+        """setup_start returns the relay URL when a setup form is active."""
+        from wet_mcp.credential_state import CredentialState
+
+        with (
+            patch(
+                "wet_mcp.credential_state.get_state",
+                return_value=CredentialState.AWAITING_SETUP,
+            ),
+            patch(
+                "wet_mcp.credential_state.get_setup_url",
+                return_value="http://127.0.0.1:8080/authorize",
+            ),
+        ):
+            from wet_mcp.server import config
+
+            result = await config(action="setup_start")
+            assert "unknown action" not in text(result).lower()
+            assert "setup_started" in text(result)
+            assert "http://127.0.0.1:8080/authorize" in text(result)
+
+    async def test_config_tool_dispatches_setup_start_action_stdio_unsupported(self):
+        """setup_start reports stdio_unsupported when no relay URL is active."""
+        from wet_mcp.credential_state import CredentialState
+
+        with (
+            patch(
+                "wet_mcp.credential_state.get_state",
+                return_value=CredentialState.AWAITING_SETUP,
+            ),
+            patch("wet_mcp.credential_state.get_setup_url", return_value=None),
+        ):
+            from wet_mcp.server import config
+
+            result = await config(action="setup_start", force=True)
+            assert "unknown action" not in text(result).lower()
+            assert "stdio_unsupported" in text(result)
+
     async def test_config_tool_dispatches_setup_reset_action(self):
         """setup_reset action (formerly on setup tool) should work via config tool."""
         with patch("wet_mcp.credential_state.reset_state") as mock_reset:


### PR DESCRIPTION
## Summary

Cross-server taxonomy parity work (WS6/WS5 of the S16 backlog spec):

- **`config(action='setup_start')`**: 5 of the other 7 MCP servers in the stack (crg, telegram, notion, email, godot) expose this action to trigger/show the credential relay URL. wet-mcp had no equivalent — its existing `setup_sync` action is a distinct Google Drive docs-sync OAuth flow (Device Code), unrelated to the generic relay-setup convention. This adds a genuine `setup_start` action (not an alias of `setup_sync`) mirroring the `crg`/`telegram` shape: `already_configured` / `setup_started` + `setup_url` / `stdio_unsupported`, using the existing (previously unused) `force: bool` param on `config()`.
- **`wet-mcp logout` CLI subcommand**: pairs with the existing `auth google` subcommand (clears the local Google Drive sync token), matching the `auth`+`logout` shape used elsewhere in the stack.
- BYOK (env var + CLI flag, flag overrides env) was already conformant on `origin/main` via `resolve_bundled_client` — no change needed there.

Docs updated: `src/wet_mcp/docs/config.md` (new `setup_start` section) + `README.md` (CLI subcommand list).

## Test plan

- [x] TDD: failing tests added first (`tests/test_setup_tool.py::TestSetupMcpTool::test_config_tool_dispatches_setup_start_action_*`, `tests/test_cli.py::TestLogoutSubcommand::*`), then implementation, then green.
- [x] Full suite: `uv run pytest` — 2069 passed, 33 skipped (1 pre-existing unrelated failure confirmed present on unmodified `origin/main` too, environment-dependent, out of scope).
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` all pass.
- [x] Pre-commit hooks pass (gitleaks, ruff, ty, full pytest, whitespace/EOF/CLAUDE.md sync).