### PR TITLE
fix: bump mcp-core to 1.20.0b2 for plugin-name and CLI fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,12 @@ dependencies = [
     "aiolimiter>=1.2.1",
     # 1.19.0 ships mcp_core.cli's argument-spec extra subcommand
     # support ((configure, handler) tuples) this repo's cli.py
-    # auth/docs subcommands consume.
-    "n24q02m-mcp-core[llm]>=1.19.0,<2",
+    # auth/docs subcommands consume. 1.20.0b2 fixes build_cli's
+    # `config`/`doctor` PerPluginStore key (#666): it defaulted to
+    # the display server_name ("wet-mcp") instead of the plugin
+    # slug ("wet") the server actually saves credentials under,
+    # so `wet-mcp config status` always reported "not configured".
+    "n24q02m-mcp-core[llm]>=1.20.0b2,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/uv.lock
+++ b/uv.lock
@@ -1775,7 +1775,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.19.0"
+version = "1.20.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1790,9 +1790,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/82/5cf9177a7188dbf074a30ad057b9f7aeca8c546d34587311315215f92a9c/n24q02m_mcp_core-1.19.0.tar.gz", hash = "sha256:2109af5f1bd8a9387c135d7477b3deadfdcc3adbcfce354c7d4e3d49068d757a", size = 320002, upload-time = "2026-07-14T12:27:39.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/92/68abd1fc6491e83b4a91271b2690952dfe13bffb7c5cf27954ae3fe35bea/n24q02m_mcp_core-1.20.0b2.tar.gz", hash = "sha256:b2e85cf7eacb45457fba491bdd8927cc92947ff0184904ba9719ecd94fbd28a4", size = 345349, upload-time = "2026-07-17T06:24:34.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/c6/d755370d27c6963dfa14e924b35c5ccfb2830361ed4d989813fbb4bc94ec/n24q02m_mcp_core-1.19.0-py3-none-any.whl", hash = "sha256:b91bae678620470f084ba91d9d4767ef05843d42316a3c9d5c4fb25325210be8", size = 178192, upload-time = "2026-07-14T12:27:38.065Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/79/a4c91fa9a9778ae7b1b58ac51b196a4b35de2de33faf6dfee0e79a6a3f6b/n24q02m_mcp_core-1.20.0b2-py3-none-any.whl", hash = "sha256:67b5ec30bd4712cf9a29a5de397a4c9338846cb2e6cf9233b98f976f44b5919a", size = 189470, upload-time = "2026-07-17T06:24:33.11Z" },
 ]
 
 [package.optional-dependencies]
@@ -3398,7 +3398,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.5.0"
+version = "3.6.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3459,7 +3459,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.20.0b2,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.3.1,<3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
## Summary
- Bump `n24q02m-mcp-core[llm]` floor from `>=1.19.0,<2` to `>=1.20.0b2,<2`.
- Picks up mcp-core#666: `build_cli`'s `config`/`doctor` credential-store key defaulted to the display `server_name` (`wet-mcp`) instead of the plugin slug (`wet`) this server actually saves credentials under, so `wet-mcp config status` / `wet-mcp doctor` always reported "not configured" even with a valid saved config.

## Test plan
- [x] `uv lock` resolves `n24q02m-mcp-core` 1.19.0 -> 1.20.0b2 from PyPI (no local path source).
- [x] Reproduced the bug pre-bump: saved a cred via `PerPluginStore("wet")`, `wet-mcp config status` (mcp-core 1.19.0) reported `wet-mcp: not configured`.
- [x] Verified the fix post-bump: same saved cred, `wet-mcp config status` (mcp-core 1.20.0b2) reports `wet-mcp: configured (source: file)`.
- [x] Full `uv run pytest` suite: 2070 passed, 33 skipped, 0 failed.