### PR TITLE
feat: per-sub custom endpoint (api_base) in relay for gateway routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,10 @@ dependencies = [
     "aiolimiter>=1.2.1",
     # 1.19.0 ships mcp_core.cli's argument-spec extra subcommand
     # support ((configure, handler) tuples) this repo's cli.py
-    # auth/docs subcommands consume.
-    "n24q02m-mcp-core[llm]>=1.19.0,<2",
+    # auth/docs subcommands consume; 1.20.0b2 keys build_cli's credential
+    # store by plugin slug (not console name) so `wet-mcp config status`
+    # reads the right per-plugin bucket (core #666).
+    "n24q02m-mcp-core[llm]>=1.20.0b2,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",
     # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance

--- a/src/wet_mcp/credential_state.py
+++ b/src/wet_mcp/credential_state.py
@@ -60,6 +60,12 @@ CLOUD_KEYS = [
     "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
+    # Per-sub custom endpoints (SSRF-vetted in mcp_core.llm dispatch). Listed
+    # here so credentials_for_current_request() keeps them through the
+    # os.environ filter and the per-sub bucket carries them, same as the keys.
+    "EMBEDDING_API_BASE",
+    "RERANK_API_BASE",
+    "LLM_API_BASE",
 ]
 
 
@@ -394,6 +400,32 @@ def api_key_for_model(model: str) -> str | None:
     if not key_env:
         return None
     return read_for_sub(sub).get(key_env) or None
+
+
+def api_base_for_task(env_key: str) -> str | None:
+    """Resolve a ``*_API_BASE`` custom endpoint for the CURRENT request.
+
+    HTTP multi-user (``_current_sub`` set): return the endpoint from THAT
+    subject's per-sub bucket so the cloud dispatch (embedder / reranker / llm)
+    passes it EXPLICITLY per call — never reading the process-global
+    ``os.environ``, which would let one ``sub``'s gateway URL serve another
+    concurrent user. Because these endpoints only ever live in the sub bucket
+    (never the shared env), reading ``os.getenv`` here would make the per-sub
+    relay field a silent no-op in multi-user mode.
+
+    Single-user / stdio (no sub): read ``os.environ``. Unlike provider keys —
+    where :func:`api_key_for_model` returns ``None`` so litellm resolves the
+    ``<PROVIDER>_API_KEY`` env itself — litellm does not know wet's own
+    ``*_API_BASE`` names, so the single-user path must surface the env value or
+    the configured endpoint would be dropped.
+
+    The returned value is SSRF-vetted downstream by ``mcp_core.llm`` dispatch
+    (``_prep_api_base`` -> ``vet_api_base``) before any request is made.
+    """
+    sub = _current_sub.get()
+    if sub is None:
+        return os.getenv(env_key) or None
+    return read_for_sub(sub).get(env_key) or None
 
 
 def _await_backend_ready() -> None:

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -228,7 +228,7 @@ class CloudEmbeddingBackend:
         # Lazy import: litellm costs ~1-2s on first import.
         from mcp_core.llm import aembedding
 
-        from wet_mcp.credential_state import api_key_for_model
+        from wet_mcp.credential_state import api_base_for_task, api_key_for_model
 
         kwargs: dict = {}
         if dimensions:
@@ -237,14 +237,15 @@ class CloudEmbeddingBackend:
             kwargs["input_type"] = "search_document"
 
         litellm_model = self._litellm_model()
-        # Resolve the provider key from the request-scoped per-sub bucket
-        # (HTTP multi-user) or the process env (single-user); explicit
-        # api_key (init-time override) wins. Avoids relying on os.environ,
-        # which bled keys across concurrent users.
+        # Resolve the provider key AND custom endpoint from the request-scoped
+        # per-sub bucket (HTTP multi-user) or the process env (single-user);
+        # explicit init-time overrides win. Avoids relying on os.environ, which
+        # bled keys/endpoints across concurrent users. SSRF-vetted downstream
+        # in mcp_core.llm dispatch.
         response = await aembedding(
             model=litellm_model,
             input=texts,
-            api_base=self.api_base or os.getenv("EMBEDDING_API_BASE") or None,
+            api_base=self.api_base or api_base_for_task("EMBEDDING_API_BASE"),
             api_key=self.api_key or api_key_for_model(litellm_model),
             **kwargs,
         )

--- a/src/wet_mcp/llm.py
+++ b/src/wet_mcp/llm.py
@@ -120,14 +120,15 @@ async def acompletion(
     if response_format is not None:
         call_kwargs["response_format"] = response_format
 
-    from wet_mcp.credential_state import api_key_for_model
+    from wet_mcp.credential_state import api_base_for_task, api_key_for_model
 
-    resolved_api_base = api_base or os.getenv("LLM_API_BASE") or None
-    # Resolve the provider key from the request-scoped per-sub bucket (HTTP
-    # multi-user) or the process env (single-user); an explicit api_key wins.
-    # Resolved per model so a fallback to a different provider gets its own
-    # key. Avoids relying on os.environ (cross-user bleed). Empty string ->
-    # None so litellm's own provider env fallback still applies single-user.
+    resolved_api_base = api_base or api_base_for_task("LLM_API_BASE")
+    # Resolve the provider key AND custom endpoint from the request-scoped
+    # per-sub bucket (HTTP multi-user) or the process env (single-user); an
+    # explicit arg wins. Key is resolved per model so a fallback to a different
+    # provider gets its own key. Avoids relying on os.environ (cross-user
+    # bleed). Empty string -> None so litellm's own provider env fallback still
+    # applies single-user. api_base is SSRF-vetted downstream in dispatch.
     resolved_api_key = api_key or api_key_for_model(model) or None
 
     try:

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -32,6 +32,22 @@ def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
     }
 
 
+def _api_base_field(key: str, label: str, help_text: str) -> dict[str, Any]:
+    # Always-visible (not derived): the renderer only reveals a derived field
+    # when a model chip derives that exact provider ENV key, and no model
+    # derives *_API_BASE, so a derived endpoint field would stay hidden. The
+    # optional badge comes from required:false. Value is SSRF-vetted per-sub in
+    # mcp_core.llm dispatch before any request.
+    return {
+        "key": key,
+        "label": label,
+        "type": "url",
+        "placeholder": "https://gateway.example/…",
+        "helpText": help_text,
+        "required": False,
+    }
+
+
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "wet-mcp",
     "displayName": "Web Extended Toolkit",
@@ -51,6 +67,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": True,
             "placeholder": "add embedding model…",
         },
+        _api_base_field(
+            "EMBEDDING_API_BASE",
+            "Embedding endpoint",
+            "Custom endpoint / CF AI Gateway. Cohere: {gw}/cohere/v2/embed",
+        ),
         {
             "key": "RERANK_MODELS",
             "label": "Rerank models",
@@ -59,6 +80,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": True,
             "placeholder": "add rerank model…",
         },
+        _api_base_field(
+            "RERANK_API_BASE",
+            "Rerank endpoint",
+            "Custom endpoint / CF AI Gateway. Cohere: {gw}/cohere (litellm appends /v1/rerank)",
+        ),
         {
             "key": "LLM_MODELS",
             "label": "LLM models",
@@ -67,6 +93,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": False,
             "placeholder": "add LLM model…",
         },
+        _api_base_field(
+            "LLM_API_BASE",
+            "LLM endpoint",
+            "Custom endpoint / CF AI Gateway for LLM calls.",
+        ),
         {
             "key": "SEARCH_BACKENDS",
             "label": "Search providers",

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -13,7 +13,6 @@ for better precision. Pipeline: retrieve top-30 -> rerank -> return top-N.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Protocol
 
 from loguru import logger
@@ -81,18 +80,19 @@ class CloudReranker:
         # Lazy import: litellm costs ~1-2s on first import.
         from mcp_core.llm import rerank as core_rerank
 
-        from wet_mcp.credential_state import api_key_for_model
+        from wet_mcp.credential_state import api_base_for_task, api_key_for_model
 
         litellm_model = self._litellm_model()
-        # Resolve the provider key from the request-scoped per-sub bucket
-        # (HTTP multi-user) or the process env (single-user); explicit
-        # api_key wins. Avoids os.environ cross-user bleed.
+        # Resolve the provider key AND custom endpoint from the request-scoped
+        # per-sub bucket (HTTP multi-user) or the process env (single-user);
+        # explicit api_key wins. Avoids os.environ cross-user bleed. SSRF-vetted
+        # downstream in mcp_core.llm dispatch.
         response = core_rerank(
             model=litellm_model,
             query=query,
             documents=documents,
             top_n=top_n,
-            api_base=os.getenv("RERANK_API_BASE") or None,
+            api_base=api_base_for_task("RERANK_API_BASE"),
             api_key=self.api_key or api_key_for_model(litellm_model),
         )
 

--- a/tests/test_per_sub_credential_isolation.py
+++ b/tests/test_per_sub_credential_isolation.py
@@ -7,11 +7,20 @@ read whatever the previous request left behind (cross-user key bleed /
 billing + data-isolation breach). The fix resolves each provider key per
 call from the request-scoped per-sub bucket via ``api_key_for_model`` and
 stops mutating ``os.environ``.
+
+The same isolation applies to the per-sub custom endpoints
+(``EMBEDDING_API_BASE`` / ``RERANK_API_BASE`` / ``LLM_API_BASE``): they are
+resolved per request via ``api_base_for_task`` so one ``sub``'s gateway URL
+never serves another. Reading ``os.getenv`` instead would make the per-sub
+relay endpoint a silent no-op in multi-user mode (the endpoint only lives in
+the sub bucket, never the shared process env).
 """
 
 from __future__ import annotations
 
 import os
+
+import pytest
 
 
 def test_require_credentials_does_not_bleed_keys_to_os_environ(monkeypatch, tmp_path):
@@ -176,5 +185,203 @@ async def test_llm_acompletion_forwards_per_sub_api_key(monkeypatch, tmp_path):
             messages=[{"role": "user", "content": "hi"}],
         )
         assert captured["api_key"] == "key_a"
+    finally:
+        set_current_sub(None)
+
+
+# ---------------------------------------------------------------------------
+# Per-sub custom endpoint (api_base) — mirror of the api_key isolation above.
+# ---------------------------------------------------------------------------
+
+
+def test_api_base_for_task_resolves_per_sub(monkeypatch, tmp_path):
+    """``*_API_BASE`` resolves from the request's per-sub bucket, no bleed."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("EMBEDDING_API_BASE", raising=False)
+    monkeypatch.delenv("RERANK_API_BASE", raising=False)
+
+    from wet_mcp.credential_state import (
+        api_base_for_task,
+        set_current_sub,
+        store_for_sub,
+    )
+
+    store_for_sub("user_a", {"EMBEDDING_API_BASE": "https://gw-a/cohere/v2/embed"})
+    store_for_sub("user_b", {"EMBEDDING_API_BASE": "https://gw-b/cohere/v2/embed"})
+
+    try:
+        set_current_sub("user_a")
+        assert api_base_for_task("EMBEDDING_API_BASE") == "https://gw-a/cohere/v2/embed"
+        # user_a set no rerank endpoint -> None (not a value bled from elsewhere).
+        assert api_base_for_task("RERANK_API_BASE") is None
+
+        set_current_sub("user_b")
+        assert api_base_for_task("EMBEDDING_API_BASE") == "https://gw-b/cohere/v2/embed"
+        # no bleed of user_a's endpoint into user_b's request.
+        assert api_base_for_task("RERANK_API_BASE") is None
+    finally:
+        set_current_sub(None)
+
+
+def test_api_base_for_task_env_fallback_single_user(monkeypatch, tmp_path):
+    """Single-user / stdio (no sub): read ``os.environ``.
+
+    Unlike provider keys (where ``None`` lets litellm read the env itself),
+    litellm does not know wet's ``*_API_BASE`` names, so the single-user path
+    must surface the env value here or the custom endpoint would be dropped.
+    """
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("EMBEDDING_API_BASE", "https://env-gw/v1")
+    monkeypatch.delenv("RERANK_API_BASE", raising=False)
+
+    from wet_mcp.credential_state import api_base_for_task, set_current_sub
+
+    set_current_sub(None)
+    assert api_base_for_task("EMBEDDING_API_BASE") == "https://env-gw/v1"
+    assert api_base_for_task("RERANK_API_BASE") is None
+
+
+async def test_embedder_per_sub_api_base_isolation(monkeypatch, tmp_path):
+    """Crux of the Y decision: two subs with different EMBEDDING_API_BASE each
+    drive their OWN endpoint through the embedder.
+
+    If the embedder read ``os.getenv`` instead of the resolver, both subs would
+    share the server-wide env value (or ``None``), making the per-sub relay
+    endpoint a silent no-op.
+    """
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("EMBEDDING_API_BASE", raising=False)
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.embedder import CloudEmbeddingBackend
+
+    store_for_sub(
+        "user_a", {"JINA_AI_API_KEY": "key_a", "EMBEDDING_API_BASE": "https://gw-a/v1"}
+    )
+    store_for_sub(
+        "user_b", {"JINA_AI_API_KEY": "key_b", "EMBEDDING_API_BASE": "https://gw-b/v1"}
+    )
+
+    captured: list[dict] = []
+
+    async def fake_aembedding(**kwargs):
+        captured.append(dict(kwargs))
+
+        class _R:
+            data = [{"index": 0, "embedding": [0.1]}]
+
+        return _R()
+
+    monkeypatch.setattr("mcp_core.llm.aembedding", fake_aembedding)
+    try:
+        set_current_sub("user_a")
+        await CloudEmbeddingBackend("jina_ai/jina-embeddings-v5").embed_single("x")
+        set_current_sub("user_b")
+        await CloudEmbeddingBackend("jina_ai/jina-embeddings-v5").embed_single("y")
+    finally:
+        set_current_sub(None)
+
+    assert captured[0]["api_base"] == "https://gw-a/v1"
+    assert captured[0]["api_key"] == "key_a"
+    assert captured[1]["api_base"] == "https://gw-b/v1"
+    assert captured[1]["api_key"] == "key_b"
+
+
+def test_reranker_forwards_per_sub_api_base(monkeypatch, tmp_path):
+    """CloudReranker forwards the request's per-sub endpoint to litellm."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("RERANK_API_BASE", raising=False)
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.reranker import CloudReranker
+
+    store_for_sub(
+        "user_a", {"JINA_AI_API_KEY": "key_a", "RERANK_API_BASE": "https://gw-a/rerank"}
+    )
+
+    captured: dict = {}
+
+    def fake_rerank(**kwargs):
+        captured.update(kwargs)
+
+        class _R:
+            results = [{"index": 0, "relevance_score": 0.9}]
+
+        return _R()
+
+    monkeypatch.setattr("mcp_core.llm.rerank", fake_rerank)
+    backend = CloudReranker(model="jina_ai/jina-reranker-v3", api_key=None)
+    try:
+        set_current_sub("user_a")
+        backend.rerank("q", ["doc"], top_n=1)
+        assert captured["api_base"] == "https://gw-a/rerank"
+        assert captured["api_key"] == "key_a"
+    finally:
+        set_current_sub(None)
+
+
+async def test_llm_acompletion_forwards_per_sub_api_base(monkeypatch, tmp_path):
+    """llm.acompletion forwards the request's per-sub endpoint to litellm."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.delenv("LLM_API_BASE", raising=False)
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.llm import acompletion
+
+    store_for_sub(
+        "user_a", {"GEMINI_API_KEY": "key_a", "LLM_API_BASE": "https://gw-a/llm"}
+    )
+
+    captured: dict = {}
+
+    async def fake_core_acompletion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_core_acompletion)
+    try:
+        set_current_sub("user_a")
+        await acompletion(
+            model="gemini/gemini-3-flash-preview",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert captured["api_base"] == "https://gw-a/llm"
+        assert captured["api_key"] == "key_a"
+    finally:
+        set_current_sub(None)
+
+
+async def test_per_sub_api_base_ssrf_rejected_in_multi_user(monkeypatch, tmp_path):
+    """A per-sub loopback endpoint is rejected by the SSRF vet in multi-user mode.
+
+    The resolved ``api_base`` flows into the REAL ``mcp_core.llm`` dispatch,
+    which vets it via ``vet_api_base`` (``_prep_api_base``) before any network
+    call. ``PUBLIC_URL`` set => multi-user => loopback/private blocked
+    unconditionally. This proves the per-sub endpoint stays on the vetted path
+    rather than bypassing it.
+    """
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    monkeypatch.setenv("PUBLIC_URL", "https://wet.example")  # multi-user mode
+    monkeypatch.delenv("EMBEDDING_API_BASE", raising=False)
+
+    from mcp_core.http import SSRFBlockedError
+
+    from wet_mcp.credential_state import set_current_sub, store_for_sub
+    from wet_mcp.embedder import CloudEmbeddingBackend
+
+    store_for_sub(
+        "user_a",
+        {"JINA_AI_API_KEY": "key_a", "EMBEDDING_API_BASE": "http://127.0.0.1:9000"},
+    )
+
+    try:
+        set_current_sub("user_a")
+        with pytest.raises(SSRFBlockedError):
+            await CloudEmbeddingBackend("jina_ai/jina-embeddings-v5").embed_single("x")
     finally:
         set_current_sub(None)

--- a/uv.lock
+++ b/uv.lock
@@ -1775,7 +1775,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.19.0"
+version = "1.20.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1790,9 +1790,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/82/5cf9177a7188dbf074a30ad057b9f7aeca8c546d34587311315215f92a9c/n24q02m_mcp_core-1.19.0.tar.gz", hash = "sha256:2109af5f1bd8a9387c135d7477b3deadfdcc3adbcfce354c7d4e3d49068d757a", size = 320002, upload-time = "2026-07-14T12:27:39.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/92/68abd1fc6491e83b4a91271b2690952dfe13bffb7c5cf27954ae3fe35bea/n24q02m_mcp_core-1.20.0b2.tar.gz", hash = "sha256:b2e85cf7eacb45457fba491bdd8927cc92947ff0184904ba9719ecd94fbd28a4", size = 345349, upload-time = "2026-07-17T06:24:34.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/c6/d755370d27c6963dfa14e924b35c5ccfb2830361ed4d989813fbb4bc94ec/n24q02m_mcp_core-1.19.0-py3-none-any.whl", hash = "sha256:b91bae678620470f084ba91d9d4767ef05843d42316a3c9d5c4fb25325210be8", size = 178192, upload-time = "2026-07-14T12:27:38.065Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/79/a4c91fa9a9778ae7b1b58ac51b196a4b35de2de33faf6dfee0e79a6a3f6b/n24q02m_mcp_core-1.20.0b2-py3-none-any.whl", hash = "sha256:67b5ec30bd4712cf9a29a5de397a4c9338846cb2e6cf9233b98f976f44b5919a", size = 189470, upload-time = "2026-07-17T06:24:33.11Z" },
 ]
 
 [package.optional-dependencies]
@@ -3398,7 +3398,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.5.0"
+version = "3.6.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3459,7 +3459,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx"] },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.20.0b2,<2" },
     { name = "n24q02m-web-core", specifier = ">=2.3.1,<3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },


### PR DESCRIPTION
## What

Adds `EMBEDDING_API_BASE` / `RERANK_API_BASE` / `LLM_API_BASE` to the relay form so each JWT `sub` can route litellm through its own CF AI Gateway (or any custom endpoint), instead of a single server-wide env shared across all users.

## Why per-sub resolution (not `os.getenv`)

wet already resolves the provider **key** per request via `api_key_for_model` (reads the sub's `PerPluginStore` bucket, passes `api_key=` explicitly, never touches `os.environ`). If `api_base` only read `os.getenv`, the per-sub endpoint field would be a **silent no-op** in multi-user mode — those endpoints only ever live in the sub bucket, never the shared process env, so every sub would fall back to the same server-wide value (or `None`).

New resolver `api_base_for_task(env_key)` mirrors `api_key_for_model` with one deliberate difference:
- **HTTP multi-user** (`sub` set): read the sub's bucket via `read_for_sub`.
- **Single-user / stdio** (no sub): read `os.getenv(env_key)` — unlike provider keys (where `None` lets litellm read the `<PROVIDER>_API_KEY` env itself), litellm does not know wet's own `*_API_BASE` names, so returning `None` here would drop the endpoint.

`embedder` / `reranker` / `llm` now pass `api_base` explicitly from the resolver.

## SSRF

The resolved endpoint stays on the vetted path: it flows into `mcp_core.llm` dispatch (`_prep_api_base` -> `vet_api_base`), which blocks loopback/private targets **unconditionally** when `PUBLIC_URL` is set (multi-user). No bypass. Covered by a test that drives a per-sub loopback endpoint through the real dispatch and asserts `SSRFBlockedError`.

## Relay field shape

The `*_API_BASE` fields are **always-visible** (not `derived`) + `required: false` (optional badge). The renderer only reveals a `derived` field when a model chip derives that exact provider ENV key, and no model derives `*_API_BASE`, so a derived endpoint field would stay hidden forever.

Cohere gateway paths (help text): `EMBEDDING_API_BASE={gw}/cohere/v2/embed`, `RERANK_API_BASE={gw}/cohere` (litellm appends `/v1/rerank`).

## Tests

Per-sub isolation (the crux): two subs with different `EMBEDDING_API_BASE` each drive their own endpoint through the embedder — no bleed. Plus resolver-level per-sub resolution, single-user env fallback, reranker/llm forwarding, and the SSRF reject. All green.

## Pin

Bumps `n24q02m-mcp-core[llm]` floor to `>=1.20.0b2` so `build_cli` keys the credential store by plugin slug (core #666) and `wet-mcp config status` reads the right per-plugin bucket. `uv.lock` updated.