### PR TITLE
fix: classify embed errors by semantics so dims-rejection recovers

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -24,27 +24,66 @@ MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.0  # seconds, doubles each retry
 
 
+# Patterns marking a PERMANENT client-side error (invalid request, unsupported
+# capability, auth). litellm frequently re-wraps these as APIConnectionError --
+# whose class name contains "connection" and whose status_code is a hardcoded
+# 500 -- so classification MUST look at the message semantics, not the exception
+# class or status code. Retrying a permanent error re-sends the same doomed
+# request and (worse) would block capability fallbacks such as dropping an
+# unsupported `dimensions` argument.
+_PERMANENT_PATTERNS = (
+    "not a valid",
+    "not support",
+    "unsupported",
+    "invalid request",
+    "invalid_request",
+    "invalid api key",
+    "output_dimension",
+    "unauthorized",
+    "forbidden",
+    "authentication",
+    "no such model",
+    "model not found",
+    "does not exist",
+    "401",
+    "403",
+    "404",
+    "422",
+)
+
+# Patterns marking a TRANSIENT error worth retrying (rate limit, 5xx, network).
+_RETRYABLE_PATTERNS = (
+    "rate limit",
+    "rate_limit",
+    "429",
+    "quota",
+    "too many requests",
+    "500",
+    "502",
+    "503",
+    "504",
+    "timeout",
+    "timed out",
+    "connection",
+    "temporarily unavailable",
+    "unavailable",
+    "overloaded",
+)
+
+
 def _is_retryable(exc: Exception) -> bool:
-    """Check if an exception is transient and worth retrying."""
+    """Return True only for TRANSIENT errors worth retrying.
+
+    Classifies on error semantics, NOT the exception class name or a synthetic
+    status_code: litellm wraps a provider's permanent 4xx (e.g. a 422 "invalid
+    output_dimension") as ``APIConnectionError`` whose repr contains "connection"
+    and whose ``status_code`` is a hardcoded 500 -- matching either would wrongly
+    retry a request that can never succeed and skip the dimensions fallback.
+    """
     msg = str(exc).lower()
-    retryable_patterns = [
-        "rate limit",
-        "rate_limit",
-        "429",
-        "quota",
-        "too many requests",
-        "500",
-        "502",
-        "503",
-        "504",
-        "timeout",
-        "timed out",
-        "connection",
-        "temporarily unavailable",
-        "unavailable",
-        "overloaded",
-    ]
-    return any(p in msg for p in retryable_patterns)
+    if any(p in msg for p in _PERMANENT_PATTERNS):
+        return False
+    return any(p in msg for p in _RETRYABLE_PATTERNS)
 
 
 def _is_unsupported_param(exc: Exception, param: str) -> bool:
@@ -180,15 +219,16 @@ class CloudEmbeddingBackend:
                     embeddings = [e[:dimensions] for e in embeddings]
                 return embeddings
             except Exception as e:
-                # If the provider rejects `dimensions`, retry without it
-                if (
-                    use_dimensions
-                    and not _is_retryable(e)
-                    and _is_unsupported_param(e, "dimensions")
-                ):
-                    logger.debug(
-                        f"Provider does not support dimensions param, "
-                        f"will truncate locally: {e}"
+                # A dimensions rejection is PERMANENT -- retrying with the same
+                # dims can never succeed. Recover (drop `dimensions`, truncate
+                # locally) BEFORE the retryability check: litellm may wrap the
+                # provider's 422 as an APIConnectionError, so retry
+                # classification must not gate this capability fallback.
+                if use_dimensions and _is_unsupported_param(e, "dimensions"):
+                    logger.warning(
+                        f"Provider {self.model} rejected dimensions="
+                        f"{use_dimensions}; retrying without it and truncating "
+                        f"locally: {e}"
                     )
                     use_dimensions = None
                     continue

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -620,7 +620,11 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
         is_query: If True, use query_embed for instruction-aware asymmetric
             retrieval (Qwen3). Document embeddings stay raw.
     """
-    from wet_mcp.embedder import Qwen3EmbedBackend, resolve_embed_backend_for_request
+    from wet_mcp.embedder import (
+        Qwen3EmbedBackend,
+        _is_retryable,
+        resolve_embed_backend_for_request,
+    )
 
     backend = resolve_embed_backend_for_request()
     if not backend:
@@ -630,13 +634,26 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
             return await backend.embed_single_query(text, _embedding_dims)
         return await backend.embed_single(text, _embedding_dims)
     except Exception as e:
-        logger.debug(f"Embedding failed: {e}")
-        return None
+        if _is_retryable(e):
+            # Transient (rate-limit / network; the backend already exhausted
+            # its retries). Degrade THIS call to keyword search -- the next
+            # may succeed.
+            logger.warning(f"Embedding transiently unavailable, degrading call: {e}")
+            return None
+        # Permanent config/capability error (bad key, unknown model, dims the
+        # backend could not work around): every embed will fail. Surface it
+        # loudly instead of silently returning None and hiding a broken
+        # semantic search behind a keyword-only fallback.
+        logger.error(
+            f"Embedding permanently failing: {e}. "
+            "Check EMBEDDING_MODELS and the provider API key."
+        )
+        raise
 
 
 async def _embed_batch(texts: list[str]) -> list[list[float]] | None:
     """Embed batch of texts if backend is available."""
-    from wet_mcp.embedder import resolve_embed_backend_for_request
+    from wet_mcp.embedder import _is_retryable, resolve_embed_backend_for_request
 
     backend = resolve_embed_backend_for_request()
     if not backend:
@@ -644,8 +661,22 @@ async def _embed_batch(texts: list[str]) -> list[list[float]] | None:
     try:
         return await backend.embed_texts(texts, _embedding_dims)
     except Exception as e:
-        logger.debug(f"Batch embedding failed: {e}")
-        return None
+        if _is_retryable(e):
+            # Transient (rate-limit / network; the backend already exhausted
+            # its retries). Degrade THIS batch to keyword-only -- a later
+            # index pass may succeed.
+            logger.warning(
+                f"Batch embedding transiently unavailable, degrading call: {e}"
+            )
+            return None
+        # Permanent config/capability error: every embed will fail. Surface it
+        # loudly instead of silently storing keyword-only chunks that masquerade
+        # as a working semantic index.
+        logger.error(
+            f"Batch embedding permanently failing: {e}. "
+            "Check EMBEDDING_MODELS and the provider API key."
+        )
+        raise
 
 
 async def _rerank_results(

--- a/tests/test_boost_coverage.py
+++ b/tests/test_boost_coverage.py
@@ -1785,11 +1785,15 @@ class TestServerHelpers:
             assert result is None
 
     async def test_embed_failure(self):
-        """_embed returns None on error."""
+        """_embed returns None on a transient error (keyword-only degrade)."""
+        from litellm.exceptions import RateLimitError
+
         from wet_mcp.server import _embed
 
         mock_backend = MagicMock()
-        mock_backend.embed_single.side_effect = Exception("embed error")
+        mock_backend.embed_single.side_effect = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="m"
+        )
         with patch("wet_mcp.embedder.get_backend", return_value=mock_backend):
             result = await _embed("test text")
             assert result is None
@@ -1803,11 +1807,15 @@ class TestServerHelpers:
             assert result is None
 
     async def test_embed_batch_failure(self):
-        """_embed_batch returns None on error."""
+        """_embed_batch returns None on a transient error (degrade this call)."""
+        from litellm.exceptions import RateLimitError
+
         from wet_mcp.server import _embed_batch
 
         mock_backend = MagicMock()
-        mock_backend.embed_texts.side_effect = Exception("batch error")
+        mock_backend.embed_texts.side_effect = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="m"
+        )
         with patch("wet_mcp.embedder.get_backend", return_value=mock_backend):
             result = await _embed_batch(["text1"])
             assert result is None

--- a/tests/test_embedder_silent_dims.py
+++ b/tests/test_embedder_silent_dims.py
@@ -1,0 +1,120 @@
+"""Regression tests for the silent semantic-degrade bug.
+
+When a cloud provider rejects the requested output ``dimensions`` (e.g.
+``cohere/embed-v4.0`` at wet's default 768; cohere-v4 supports only
+{256, 512, 1024, 1536}), litellm wraps the provider's HTTP 422 as an
+``APIConnectionError`` whose class name contains "connection" and whose
+``status_code`` is a synthetic 500. The old ``_is_retryable`` matched the
+"connection" substring, so the dimensions-fallback was bypassed and the call
+was retried 3x with the SAME rejected dims, then gave up -> ``_embed`` returned
+None -> semantic search silently degraded to keyword search with no error
+surfaced.
+
+These tests reproduce that exact shape (litellm exceptions, dims-aware mock)
+and lock in the fix: unsupported-dimensions recover via retry-without-dims +
+local truncate, and permanent client errors are never retried.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from litellm.exceptions import APIConnectionError, RateLimitError
+
+from wet_mcp.embedder import MAX_RETRIES, CloudEmbeddingBackend, _is_retryable
+
+# The exact provider body cohere returns for an unsupported output_dimension,
+# as litellm surfaces it after wrapping the 422 in APIConnectionError.
+_COHERE_422_BODY = (
+    'CohereException - {"message": "768 is not a valid output_dimension, '
+    'use one of 256, 512, 1024, 1536"}'
+)
+
+
+def _wrapped_422() -> APIConnectionError:
+    """A litellm APIConnectionError wrapping cohere's 422 dims rejection."""
+    return APIConnectionError(
+        message=_COHERE_422_BODY, llm_provider="cohere", model="embed-v4.0"
+    )
+
+
+class TestIsRetryableClassification:
+    """`_is_retryable` must classify on error semantics, not class name."""
+
+    def test_wrapped_422_unsupported_dimension_is_not_retryable(self):
+        exc = _wrapped_422()
+        # Guard: this really is the tricky shape (class name -> "connection",
+        # synthetic 500) that fooled the old substring matcher.
+        assert "connection" in str(exc).lower()
+        assert getattr(exc, "status_code", None) == 500
+
+        assert _is_retryable(exc) is False
+
+    def test_genuine_connection_error_is_retryable(self):
+        exc = APIConnectionError(
+            message="Connection error.", llm_provider="cohere", model="embed-v4.0"
+        )
+        assert _is_retryable(exc) is True
+
+    def test_rate_limit_is_retryable(self):
+        exc = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="embed-v4.0"
+        )
+        assert _is_retryable(exc) is True
+
+    def test_invalid_api_key_is_not_retryable(self):
+        exc = APIConnectionError(
+            message="AuthenticationError - invalid api key",
+            llm_provider="cohere",
+            model="embed-v4.0",
+        )
+        assert _is_retryable(exc) is False
+
+
+class TestWrappedDimsRejectionRecovery:
+    """The litellm-wrapped 422 must trigger the retry-without-dims fallback."""
+
+    async def test_wrapped_422_triggers_dims_fallback_and_truncates(self):
+        # Dims-aware fake: the provider REJECTS every dims-bearing call (as
+        # cohere-v4 does at 768) and only succeeds when dims are dropped.
+        # A non-dims-aware mock would let the buggy retry "recover" by luck and
+        # hide the defect.
+        native_dim = 1536
+
+        async def fake_call(texts, dimensions=None):
+            if dimensions is not None:
+                raise _wrapped_422()
+            return [[0.1] * native_dim for _ in texts]
+
+        backend = CloudEmbeddingBackend(model="cohere/embed-v4.0")
+        with patch.object(
+            backend, "_call_provider", new=AsyncMock(side_effect=fake_call)
+        ) as mock_call:
+            result = await backend._embed_batch_inner(["hello"], dimensions=768)
+
+        # Recovered: valid vector truncated locally to the requested 768.
+        assert len(result[0]) == 768
+        assert result[0] == [0.1] * 768
+        # Exactly two provider calls: dims=768 (rejected) then dims=None (ok).
+        assert mock_call.call_count == 2
+        assert mock_call.call_args_list[0].args[1] == 768
+        assert mock_call.call_args_list[1].args[1] is None
+
+    async def test_wrapped_422_is_not_retried_with_same_dims(self):
+        # If the fallback did NOT fire, the buggy code would retry MAX_RETRIES
+        # times with the same rejected dims. Assert it does NOT.
+        async def always_reject(texts, dimensions=None):
+            raise _wrapped_422()
+
+        backend = CloudEmbeddingBackend(model="cohere/embed-v4.0")
+        with patch.object(
+            backend, "_call_provider", new=AsyncMock(side_effect=always_reject)
+        ) as mock_call:
+            with pytest.raises(APIConnectionError):
+                await backend._embed_batch_inner(["hello"], dimensions=768)
+
+        # 1 dims=768 attempt (rejected) + 1 dims=None fallback attempt (also
+        # rejected) = 2. NOT MAX_RETRIES retries of the same bad dims.
+        assert mock_call.call_count == 2
+        assert mock_call.call_count < MAX_RETRIES + 1
+        assert mock_call.call_args_list[0].args[1] == 768
+        assert mock_call.call_args_list[1].args[1] is None

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -1228,15 +1228,31 @@ async def test_embed_query_mode():
 
 
 @pytest.mark.asyncio
-async def test_embed_exception():
-    """Test _embed returns None on exception (lines 332-334)."""
+async def test_embed_transient_exception_returns_none():
+    """A transient embedding error degrades this call to None (keyword-only)."""
+    from litellm.exceptions import RateLimitError
+
     with patch("wet_mcp.embedder.get_backend") as mock_get:
         mock_backend = MagicMock()
-        mock_backend.embed_single.side_effect = Exception("embed error")
+        mock_backend.embed_single.side_effect = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="m"
+        )
         mock_get.return_value = mock_backend
 
         res = await server._embed("hello")
         assert res is None
+
+
+@pytest.mark.asyncio
+async def test_embed_permanent_exception_raises():
+    """A permanent embedding error is surfaced loudly, not swallowed to None."""
+    with patch("wet_mcp.embedder.get_backend") as mock_get:
+        mock_backend = MagicMock()
+        mock_backend.embed_single.side_effect = Exception("model does not exist")
+        mock_get.return_value = mock_backend
+
+        with pytest.raises(Exception, match="does not exist"):
+            await server._embed("hello")
 
 
 @pytest.mark.asyncio
@@ -1248,15 +1264,31 @@ async def test_embed_batch_no_backend():
 
 
 @pytest.mark.asyncio
-async def test_embed_batch_exception():
-    """Test _embed_batch returns None on exception (lines 346-348)."""
+async def test_embed_batch_transient_exception_returns_none():
+    """A transient batch embedding error degrades this call to None."""
+    from litellm.exceptions import RateLimitError
+
     with patch("wet_mcp.embedder.get_backend") as mock_get:
         mock_backend = MagicMock()
-        mock_backend.embed_texts.side_effect = Exception("batch error")
+        mock_backend.embed_texts.side_effect = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="m"
+        )
         mock_get.return_value = mock_backend
 
         res = await server._embed_batch(["hello"])
         assert res is None
+
+
+@pytest.mark.asyncio
+async def test_embed_batch_permanent_exception_raises():
+    """A permanent batch embedding error is surfaced loudly, not swallowed."""
+    with patch("wet_mcp.embedder.get_backend") as mock_get:
+        mock_backend = MagicMock()
+        mock_backend.embed_texts.side_effect = Exception("model does not exist")
+        mock_get.return_value = mock_backend
+
+        with pytest.raises(Exception, match="does not exist"):
+            await server._embed_batch(["hello"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -438,15 +438,30 @@ async def test_embed_no_backend():
         assert res is None
 
 
-async def test_embed_exception():
-    """Lines 332-334: embedding raises exception."""
+async def test_embed_transient_exception_returns_none():
+    """A transient embedding error degrades this call to keyword-only (None)."""
+    from litellm.exceptions import RateLimitError
+
     with patch("wet_mcp.embedder.get_backend") as mock_get:
         mock_backend = MagicMock()
-        mock_backend.embed_single.side_effect = Exception("embed error")
+        mock_backend.embed_single.side_effect = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="m"
+        )
         mock_get.return_value = mock_backend
 
         res = await server._embed("test")
         assert res is None
+
+
+async def test_embed_permanent_exception_raises():
+    """A permanent embedding error is surfaced loudly, not swallowed to None."""
+    with patch("wet_mcp.embedder.get_backend") as mock_get:
+        mock_backend = MagicMock()
+        mock_backend.embed_single.side_effect = Exception("model does not exist")
+        mock_get.return_value = mock_backend
+
+        with pytest.raises(Exception, match="does not exist"):
+            await server._embed("test")
 
 
 # ---------------------------------------------------------------------------
@@ -461,15 +476,30 @@ async def test_embed_batch_no_backend():
         assert res is None
 
 
-async def test_embed_batch_exception():
-    """Lines 346-348: batch embedding raises exception."""
+async def test_embed_batch_transient_exception_returns_none():
+    """A transient batch embedding error degrades this call to None."""
+    from litellm.exceptions import RateLimitError
+
     with patch("wet_mcp.embedder.get_backend") as mock_get:
         mock_backend = MagicMock()
-        mock_backend.embed_texts.side_effect = Exception("batch fail")
+        mock_backend.embed_texts.side_effect = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="m"
+        )
         mock_get.return_value = mock_backend
 
         res = await server._embed_batch(["test"])
         assert res is None
+
+
+async def test_embed_batch_permanent_exception_raises():
+    """A permanent batch embedding error is surfaced loudly, not swallowed."""
+    with patch("wet_mcp.embedder.get_backend") as mock_get:
+        mock_backend = MagicMock()
+        mock_backend.embed_texts.side_effect = Exception("model does not exist")
+        mock_get.return_value = mock_backend
+
+        with pytest.raises(Exception, match="does not exist"):
+            await server._embed_batch(["test"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The cloud embedder silently degraded semantic search to keyword-only whenever a provider rejected the requested output `dimensions`.

litellm re-wraps a provider's permanent HTTP 422 (e.g. `cohere/embed-v4.0` rejecting wet's default 768 -- it supports only {256, 512, 1024, 1536}) as an `APIConnectionError` whose class name contains "connection" and whose `status_code` is a hardcoded 500. The old `_is_retryable` did a substring match on that shape and classified it as **transient**. Because the retry-without-dims fallback was gated behind `not _is_retryable(e)`, the fallback was skipped, the request was retried with the same rejected dims, then gave up -- and `_embed` / `_embed_batch` swallowed the error to `None`. Net effect: embeddings silently off, no signal, keyword-only results masquerading as a working semantic index.

## Fix (root cause)

- `embedder._is_retryable` now classifies on **message semantics**, not the exception class or synthetic status code: a `_PERMANENT_PATTERNS` set (invalid param, unsupported capability, auth, 4xx, `output_dimension`) is checked **before** the retryable set. Permanent -> not retryable.
- The dimensions fallback in `_embed_batch_inner` now fires on `_is_unsupported_param(e, "dimensions")` alone (the `and not _is_retryable(e)` gate is removed), so a litellm-wrapped 422 recovers: retry without dims -> native vector -> truncate locally to the requested size.
- `server._embed` and `server._embed_batch` no longer blanket-swallow to `None`: genuine transient errors degrade this call to `None` (`logger.warning`); permanent config/capability errors re-raise **loudly** (`logger.error`) instead of hiding a broken semantic layer.
- The startup `check_available()` probe (no-dims) is intentionally left unchanged -- it correctly reports a working model once the fallback exists.

## Tests (TDD, RED -> GREEN)

New `tests/test_embedder_silent_dims.py` reproduces the exact shape (real litellm exceptions + a dims-**aware** mock that rejects every dims-bearing call, so a naive mock can't recover by luck):
- a litellm-wrapped 422 is **not** retryable; genuine connection/timeout/429 **are**; wrapped auth error is **not**.
- the wrapped 422 triggers the dims-fallback and truncates (2 provider calls: dims -> None), and is **not** retried with the same dims.

Existing `_embed`/`_embed_batch` error tests updated to the new contract (transient -> None; permanent -> raises).

## Verification

- Full suite: **2086 passed, 33 skipped**, 0 failed (ruff + ty + pytest green via pre-commit).
- **Live** against real `cohere/embed-v4.0` @ 768 dims through the CF AI gateway: the provider returned the real 422 (`768 is not a valid output_dimension ... [256 512 1024 1536] is supported`), the fallback fired (`rejected dimensions=768; retrying without it and truncating locally`), and the embed **recovered** to a 768-dim vector -- no silent degrade.