### PR TITLE
fix: match ReadTheDocs hosts by suffix instead of substring

### DIFF
--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -1584,6 +1584,28 @@ _WELL_KNOWN_DOCS: dict[str, dict[str, str]] = {
 }
 
 
+_READTHEDOCS_HOSTS = (
+    "readthedocs.io",
+    "readthedocs.org",
+    "rtfd.io",
+    # Projects on ReadTheDocs for Business are served from this host instead;
+    # the substring check this replaces matched them, so keep them eligible.
+    "readthedocs-hosted.com",
+)
+
+
+def _is_readthedocs_host(netloc: str) -> bool:
+    """True when netloc is a ReadTheDocs host or a subdomain of one.
+
+    Matching on the host suffix rather than a substring: "readthedocs" appearing
+    anywhere in the netloc also matches an attacker-controlled parent domain such
+    as "turbo.readthedocs.evil.com", whose first label would then pass the
+    subdomain check below and collect the bonus.
+    """
+    host = netloc.lower().partition(":")[0].rstrip(".")
+    return any(host == h or host.endswith(f".{h}") for h in _READTHEDOCS_HOSTS)
+
+
 def _score_discovery_result(r: dict, name: str) -> int:
     """Score a discovery result for relevance to the library name."""
     score = 0
@@ -1610,7 +1632,7 @@ def _score_discovery_result(r: dict, name: str) -> int:
                     score += 3
             # ReadTheDocs bonus: only when subdomain exactly matches lib name
             # Prevents e.g. "app-turbo.readthedocs.org" scoring for "turbo"
-            if any(p in parsed_hp.netloc for p in ("readthedocs", "rtfd.io")):
+            if _is_readthedocs_host(parsed_hp.netloc):
                 subdomain = parsed_hp.netloc.split(".")[0].lower().replace("-", "")
                 if subdomain == lib_norm:
                     score += 2

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -29,6 +29,7 @@ from wet_mcp.sources.docs import (
     _fetch_github_readme,
     _get_github_homepage,
     _github_headers,
+    _is_readthedocs_host,
     _is_toc_only,
     _normalize_docs_url,
     _parse_objects_inv,
@@ -3492,3 +3493,49 @@ def test_sort_urls_by_query_empty_cases():
 
     # Empty URLs returns empty list
     assert _sort_urls_by_query([], "query") == []
+
+
+# ============================================================================
+# _is_readthedocs_host
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "netloc",
+    [
+        "readthedocs.io",
+        "readthedocs.org",
+        "rtfd.io",
+        "turbo.readthedocs.io",
+        "app-turbo.readthedocs.org",
+        "TURBO.ReadTheDocs.IO",
+        "turbo.readthedocs.io:8443",
+        "turbo.rtfd.io",
+        "turbo.readthedocs-hosted.com",
+    ],
+)
+def test_is_readthedocs_host_accepts_real_hosts(netloc):
+    """The ReadTheDocs hosts themselves and their subdomains."""
+    assert _is_readthedocs_host(netloc) is True
+
+
+@pytest.mark.parametrize(
+    "netloc",
+    [
+        # An attacker-controlled parent domain: a substring check matches these,
+        # and the first label would then pass the subdomain test and win the bonus.
+        "turbo.readthedocs.evil.com",
+        "turbo.rtfd.io.evil.com",
+        "readthedocs.evil.com",
+        # Lookalikes that merely contain the name.
+        "notreadthedocs.com",
+        "readthedocs.com.attacker.net",
+        "myrtfd.iodocs.net",
+        "turbo.readthedocs-hosted.com.evil.net",
+        "example.com",
+        "",
+    ],
+)
+def test_is_readthedocs_host_rejects_impostors(netloc):
+    """Anything that only *contains* the name is not a ReadTheDocs host."""
+    assert _is_readthedocs_host(netloc) is False


### PR DESCRIPTION
`_score_discovery_result` awarded its ReadTheDocs bonus after testing
`"readthedocs" in netloc` / `"rtfd.io" in netloc`. A substring test also matches
a host that merely *contains* the name, so a homepage on
`turbo.readthedocs.evil.com` or `turbo.rtfd.io.evil.com` passed the check and its
first label then satisfied the `subdomain == lib_norm` comparison, collecting the
relevance bonus for an attacker-controlled domain. CodeQL flags the `rtfd.io` half
as `py/incomplete-url-substring-sanitization` (high).

`_is_readthedocs_host` matches on the host suffix instead: the netloc must equal
one of the ReadTheDocs hosts or be a subdomain of one, after normalising port,
case and a trailing dot. `readthedocs-hosted.com` is included so that ReadTheDocs
for Business projects, which the substring test accepted, stay eligible.

16 parametrised cases cover the real hosts and the lookalikes.

Supersedes #1556, which proposed rewriting the same `any()` as explicit `or`
conditions for speed.