### PR TITLE
fix: install a single litellm distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,4 +196,17 @@ fail_under = 92
 show_missing = true
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
 
+[tool.uv]
+# crawl4ai requires `unclecode-litellm==1.81.13`, a fork that ships the same
+# top-level `litellm` package as the upstream litellm this project already
+# depends on through mcp-core[llm]. Installing both writes two different
+# versions into one site-packages/litellm/, and which files survive is decided
+# by install order — CI has already failed on a run where the fork landed last:
+#   ImportError: cannot import name '_redact_string' from 'litellm._logging'
+# Drop the fork so exactly one litellm is installed. crawl4ai imports litellm
+# only inside its LLM helper functions, which this project never calls (it uses
+# AsyncWebCrawler/BrowserConfig/CrawlerRunConfig), and mcp_core.llm needs the
+# upstream 1.9x API (litellm.aresponses backs the x_search transport).
+override-dependencies = ["unclecode-litellm ; sys_platform == 'unreachable'"]
+
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "unclecode-litellm", marker = "sys_platform == 'unreachable'" }]
+
 [[package]]
 name = "aiofile"
 version = "3.11.1"
@@ -497,7 +500,7 @@ dependencies = [
     { name = "rich" },
     { name = "shapely" },
     { name = "snowballstemmer" },
-    { name = "unclecode-litellm" },
+    { name = "unclecode-litellm", marker = "sys_platform == 'unreachable'" },
     { name = "xxhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/95/a307119201f09a5136be1e394282ee4d4d6e3816cbc3c73f370aaa4b5e56/crawl4ai-0.9.1.tar.gz", hash = "sha256:d04251f13ba180107324bb7bbe12029a63d95cc50248f05085743739f38404fc", size = 575249, upload-time = "2026-07-08T14:29:15.247Z" }
@@ -3232,18 +3235,18 @@ name = "unclecode-litellm"
 version = "1.81.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "sys_platform != 'win32'" },
+    { name = "click", marker = "sys_platform != 'win32'" },
+    { name = "fastuuid", marker = "sys_platform != 'win32'" },
+    { name = "httpx", marker = "sys_platform != 'win32'" },
+    { name = "importlib-metadata", marker = "sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform != 'win32'" },
+    { name = "jsonschema", marker = "sys_platform != 'win32'" },
+    { name = "openai", marker = "sys_platform != 'win32'" },
+    { name = "pydantic", marker = "sys_platform != 'win32'" },
+    { name = "python-dotenv", marker = "sys_platform != 'win32'" },
+    { name = "tiktoken", marker = "sys_platform != 'win32'" },
+    { name = "tokenizers", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/c4/93ed52c49c2347184f908c692ebb7c1f06303805910774c3282ac68033db/unclecode_litellm-1.81.13.tar.gz", hash = "sha256:db70e34e3e859c0a07f02cb02eaa644f8fa4b4ecc5e2f3be9a58bd7d1c3feedc", size = 16678208, upload-time = "2026-03-24T14:46:31.915Z" }
 wheels = [


### PR DESCRIPTION
crawl4ai requires `unclecode-litellm==1.81.13`, a fork published under a
different distribution name that ships the same top-level `litellm` package as
the upstream litellm this project already pulls in through `mcp-core[llm]`.
Both unpack into one `site-packages/litellm/`, so the installed module is a mix
of two versions and which files survive is decided by install order.

That is not theoretical. On 2026-07-24 the `Lint & Test (ubuntu-latest)` job on
#1520 failed while installing the identical version pair (`litellm==1.92.0` +
`unclecode-litellm==1.81.13`) that had passed on `main` three minutes earlier:

```
ImportError: cannot import name '_redact_string' from 'litellm._logging'
```

#1520 only changes `package.json` and `bun.lock`, so the failure had nothing to
do with its diff — every job in this repo is one unlucky install ordering away
from the same error.

This overrides the fork away with an unsatisfiable marker so exactly one
litellm is installed. Upstream is the one to keep: `mcp_core.llm` dispatches
through it and the x_search transport needs `litellm.aresponses`, which 1.81
predates. crawl4ai imports litellm only inside its LLM helper functions and
this project calls none of them — it uses `AsyncWebCrawler`, `BrowserConfig`
and `CrawlerRunConfig`.

Verified in a clean `uv sync --group dev --no-sources`: one
`litellm-1.92.0.dist-info`, no unclecode entry, `from litellm.exceptions import
APIConnectionError, RateLimitError` resolves, and
`tests/test_embedder_silent_dims.py` — the module that hit the ImportError —
passes.

Scope note: the override governs installs resolved from this repo (CI, the
Docker images, dev environments). It is not part of the published wheel
metadata, so `uvx wet-mcp` from PyPI still resolves both distributions; fixing
that needs an upstream change in crawl4ai.