### PR TITLE
fix: date the bot ledgers from git history and record rejections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,30 +1,64 @@
-## 2025-02-18 - Optimized String Window Scanning
+Dates below are the dates the change landed on `main`, taken from `git log`.
+Each entry carries the commit holding it, so an entry can be located in the
+repository history before the same change is proposed again.
+
+## 2026-07-05 - Optimized String Window Scanning
+**Commit:** 5d04261
 **Learning:** Sliding windows using string slicing (`string[i : i+N]`) combined with `O(M * N)` substring matching operations within a loop traversing a full document causes exponential slowdowns on larger blocks of text.
 **Action:** Always pre-calculate exact match indices via C-optimized `str.find()` first, then evaluate windows conditionally limited only to relevant indices/buckets rather than traversing blindly across the entire string length.
-## 2024-03-24 - Avoid string joining for length checks in tight loops
+
+## 2026-07-10 - Avoid string joining for length checks in tight loops
+**Commit:** 153b70c
 **Learning:** In `_strip_nav_heading_blocks` (a hot path in markdown chunking), joining multiple string lines into a single string (`"\n".join(...)`) just to check if the combined length exceeds a small limit (50 chars) causes unnecessary memory allocation overhead and slows down processing.
 **Action:** Replace `"\n".join` with an iterative loop that calculates the cumulative length (`content_length += len(line.strip())`), and exit early once the limit is reached.
-## 2024-07-06 - Optimize string length checks in loops
+
+## 2026-07-10 - Optimize string length checks in loops
+**Commit:** 729bf0c
 **Learning:** Checking the length of accumulated string lists via `len("\n".join(lines))` inside a loop is O(N^2) time complexity and causes repeated memory allocations.
 **Action:** Instead of joining strings purely to measure length, track length incrementally with an integer variable (e.g. `current_length += len(line) + (1 if lines else 0)`) to reduce time complexity to O(1) per iteration.
 
-## 2024-07-06 - Fixing `ty` typchecker issues with `ty: ignore`
+## 2026-07-10 - Fixing `ty` typechecker issues with `ty: ignore`
+**Commit:** 729bf0c
 **Learning:** The typechecker used in this project is `ty`, not `mypy`. Ignore pragmas must take the form of `# ty: ignore[<rule>]`. For example, `type: ignore` and `ty: ignore` alone don't work, we need `# ty: ignore[unsupported-base]`. Additionally, we also have to clean up unused ignore pragmas or `ty check` fails with unused ignore comments.
 **Action:** Always run `uv run ty check` as part of CI checks. Only add `# ty: ignore[<error>]` after verifying what the exact error name is, and remove obsolete `# ty: ignore` lines if they trigger `warning[unused-ignore-comment]`.
 
-## 2023-11-20 - Fast String Suffix/Prefix matching with tuples
+## 2026-07-11 - Fast String Suffix/Prefix matching with tuples
+**Commit:** 23b5b55
 **Learning:** Python generator expressions inside `any()` for checking multiple prefixes/suffixes (e.g. `any(path.endswith(ext) for ext in EXTENSIONS)`) are slow due to Python-level iteration overhead.
 **Action:** Always prefer passing a tuple of strings directly to `str.startswith()` and `str.endswith()` (e.g., `path.endswith(tuple(EXTENSIONS))`). This pushes the iteration down into optimized C code, yielding roughly ~5-7x speedup for prefix/suffix matching. Ensure the tuple is defined at the module level if used repeatedly.
-## 2024-05-24 - Avoid micro-optimizing cold paths
 
+## 2026-07-17 - Avoid micro-optimizing cold paths
+**Commit:** 1d9b8dd
 **Learning:** Replacing idiomatic Python generator expressions (like `sum(1 for ...)`) with manual `for` loops in cold paths (like project locking logic) sacrifices code readability for negligible performance gains, and is considered a negative micro-optimization.
 **Action:** When searching for performance improvements, verify that the targeted code is actually in a hot path or tight loop before applying optimizations that reduce readability.
 
-## 2024-05-24 - Use short-circuiting in threshold checks
-
+## 2026-07-17 - Use short-circuiting in threshold checks
+**Commit:** 1d9b8dd
 **Learning:** When checking for a threshold (e.g., detecting if a page is blocked by checking if `hits >= 2`), iterating over the full list of markers using `sum(1 for ...)` wastes cycles. An inline `for` loop with a `break` statement can short-circuit the evaluation as soon as the threshold is met.
 **Action:** Apply early exits (`break` or `return`) when counting matches if a fixed threshold defines success or failure.
 
-## 2024-05-27 - Use str.split() for multi-whitespace replacement
+## 2026-07-18 - Use str.split() for multi-whitespace replacement
+**Commit:** 7cbab2e
 **Learning:** `re.sub(r"\s+", " ", text).strip()` is generally slower than `" ".join(text.split())` for collapsing multiple whitespace characters into single spaces, as the latter avoids regex engine overhead and is executed entirely in optimized C code.
 **Action:** Use `" ".join(text.split())` instead of regex substitution when the goal is simply to replace continuous whitespace characters with a single space.
+
+## 2026-07-25 - Match host suffixes, not substrings
+**Commit:** efdf601
+**Learning:** `"rtfd.io" in netloc` is also true for `turbo.rtfd.io.evil.com`, whose first label then passes the `subdomain == lib_norm` comparison in `_score_discovery_result` and collects the ReadTheDocs relevance bonus for an attacker-controlled domain. CodeQL reports this shape as `py/incomplete-url-substring-sanitization` whenever the searched string contains a dot.
+**Action:** Compare hosts against a module-level tuple of known hosts with `host == h or host.endswith(f".{h}")`, after lowercasing and stripping the port and any trailing dot. Keep every host the previous substring test accepted: dropping `readthedocs-hosted.com` would have silently lost the bonus for ReadTheDocs for Business projects.
+
+## Rejected
+
+Proposals that were reviewed and turned down, with the reason. They are recorded
+here so the reason travels with the repository instead of staying behind in a
+closed pull request.
+
+### 2026-07-25 - Expanding a two-element `any()` into explicit `or` (#1556)
+**Proposed:** rewrite `any(p in parsed_hp.netloc for p in ("readthedocs", "rtfd.io"))` and `any(p in all_urls for p in ("deprecate-holder", "placeholder"))` in `_score_discovery_result` as explicit `or` chains, claimed at "~3.5x faster".
+**Why rejected:** the call site is not hot. `_score_discovery_result` runs once per registry result at `sources/docs.py:1826` — a handful of dicts per lookup — and only after `asyncio.gather` has queried the package registries over HTTP and `_pre_upgrade_discovery_results` has made its GitHub API calls. A saving on the order of 100 ns sits against hundreds of milliseconds of network work, and no measurement accompanied the claim. The 2026-07-17 entry above already covers this. The proposal also arrived under a title about `_DOC_DIRS`, which its diff never touched.
+**Action:** Before proposing a membership-test rewrite, trace the call site to a loop that runs often enough for the saving to be observable, and quote a measurement taken on this repository. Where the surrounding work is I/O, prefer proposals that remove a request or a round-trip. The hostname half of that proposal was the part worth having, and it landed as efdf601.
+
+### 2026-07-25 - Optimisation comments in source (#1556)
+**Proposed:** annotate the rewritten conditions with a comment naming the optimisation and its expected impact.
+**Why rejected:** this repository is public. A comment that names the tool which wrote it, and asserts an unmeasured speedup, is noise for every later reader of the file.
+**Action:** Write comments that explain why the code is shaped the way it is, in the voice of the surrounding file — for example, the reason a fast path exists and the measurement that justified it. Leave authorship to the commit metadata.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,16 +1,37 @@
-## 2024-05-24 - Path Traversal in Token Storage
+Dates below are the dates the fix landed on `main`, taken from `git log`. Each
+entry carries the commit holding it, so an entry can be located in the
+repository history before the same finding is raised again.
+
+## 2026-05-16 - Path Traversal in Token Storage
+**Commit:** 031a146 (#1091)
 **Vulnerability:** The `token_store.py` module constructed file paths by directly concatenating user-controlled inputs (`provider`, `sub`) via `pathlib.Path` without validation. This allowed path traversal (e.g., using `../` or absolute paths) to read or write arbitrary files on the system with the application's permissions.
 **Learning:** Even when using higher-level path abstractions like `pathlib`, string concatenation or `/` division with unvalidated user input is unsafe because the underlying OS resolution still respects traversal sequences.
 **Prevention:** Always explicitly validate path components for dangerous characters (like `/`, `\`, and `..`) using an explicit string validation helper before passing them to file I/O operations or path constructors.
-## 2026-06-20 - Unsafe Dynamic SQL in SQLite PRAGMA calls
+
+## 2026-06-21 - Unsafe Dynamic SQL in SQLite PRAGMA calls
+**Commit:** 4357e1a (#1399)
 **Vulnerability:** Raw `PRAGMA table_info({table})` and `PRAGMA index_list({table})` using f-strings allows for SQL injection if the table identifier is unsanitized user input. SQLite DDL does not allow standard SQL bound parameters for table names.
 **Learning:** SQLite introduced table-valued functions for introspection (`pragma_table_info(?)` and `pragma_index_list(?)`) which do support safe parameterization using bound variables.
 **Prevention:** Always use parameterized `SELECT name FROM pragma_table_info(?)` or `SELECT name FROM pragma_index_list(?)` instead of using raw dynamic `PRAGMA` queries using string concatenation or f-strings. Note that when migrating from raw `PRAGMA` to `SELECT name FROM pragma_...`, the target column is returned at index 0 rather than index 1 (or by "name" dict lookup).
-## 2026-07-05 - Path Hijacking in subprocess.run
+
+## 2026-07-10 - Path Hijacking in subprocess.run
+**Commit:** 879ca76
 **Vulnerability:** The `subprocess.run` call in `src/wet_mcp/server.py` used a partial executable name (`"gh"`) instead of an absolute path. This is susceptible to path hijacking (where an attacker controls the PATH environment variable to execute a malicious binary).
 **Learning:** Even though `shutil.which` was used to check for the existence of an executable, the result was discarded, and the partial name was still passed to `subprocess.run`.
 **Prevention:** Always use the absolute path returned by `shutil.which` (or hardcode the absolute path if known) when passing the executable name to `subprocess.run`.
-## 2024-07-22 - Hardcoded Bind Interface
+
+## 2026-07-24 - Hardcoded Bind Interface
+**Commit:** fd3f437 (#1557)
 **Vulnerability:** The application was hardcoded to bind to `0.0.0.0` in multi-user mode. This could expose the service on all network interfaces unconditionally, which may not be desirable in environments where it should only be accessible through specific interfaces or VPNs.
 **Learning:** Security scanners like Bandit often flag hardcoded `0.0.0.0` bindings (B104) because it's safer to let administrators control the listen interface.
 **Prevention:** Allow configuration of the bind host via an environment variable (e.g., `MCP_HOST`) with `0.0.0.0` as the fallback default for backward compatibility. Add a `# nosec B104` pragma to suppress false positives where the default behavior is intentional and validated.
+
+## Rejected
+
+Findings that were reviewed and turned down, with the reason. They are recorded
+here so the reason travels with the repository instead of staying behind in a
+closed pull request.
+
+No security finding has been rejected in this repository yet. When one is,
+record what was proposed, why it was turned down, and what the correct shape
+looks like, so the next scan starts from the answer rather than the question.


### PR DESCRIPTION
`.jules/bolt.md` and `.jules/sentinel.md` are what the bots read to know what
has already landed here, so a wrong date is not cosmetic — an entry that cannot
be located in the history reads as absent, and the same change gets proposed
again.

**Dates.** Every entry in `bolt.md` was stamped before the repository existed:
2023-11-20 through 2025-02-18, for changes that landed 2026-07-05 to 2026-07-18.
The first commit here is 2026-02-03. `sentinel.md` was wrong on all four
entries, including two that were merely off by days. Both files are re-dated
from `git log -S` on each entry's distinctive symbol, and each entry now carries
its commit so the next lookup has an anchor.

The effect is not hypothetical: #1556 proposed a cold-path micro-optimisation
that the "avoid micro-optimizing cold paths" entry — dated 2024-05-24 for a
change that landed 2026-07-17 — already ruled out.

**Rejected sections.** Closing a proposal with a comment leaves the reason in
the pull request, outside the file the bots read. Both ledgers now carry one.
The first entries record the two halves of #1556: the `any()` → `or` rewrite,
and the tool-branded optimisation comments it placed in the source of a public
repository.

Both are written as positive guidance — what to verify before proposing, and
how a comment should read — rather than as prohibitions, which give the next
proposal nothing to aim at.