### PR TITLE
fix: run CodeQL on bot pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,7 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
-    if: >-
-      (github.event_name == 'pull_request' || github.event_name == 'push')
-      && github.actor != 'dependabot[bot]'
-      && github.actor != 'renovate[bot]'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
       security-events: write
       contents: read


### PR DESCRIPTION
The `Main Ruleset` requires a CodeQL result before a pull request can merge
(`alerts_threshold: errors`, `security_alerts_threshold: high_or_higher`), and
this repository has no default code-scanning setup —
`gh api repos/n24q02m/wet-mcp/code-scanning/default-setup` reports
`not-configured`. The `codeql` job in this workflow is therefore the only source
of results.

That job then skipped itself for `dependabot[bot]` and `renovate[bot]`. No
analysis → no result → the rule can never be satisfied → every dependency pull
request is permanently `BLOCKED` for a human merger. All six merges in today's
backlog clear had to bypass the gate with `--admin`.

Requiring a scan and refusing to run it is self-contradictory, and a dependency
change is the kind of diff most worth scanning. Actions minutes are free on a
public repository, so the skip buys nothing.

**Why the sibling repos are not affected:** `mnemo-mcp` and `imagine-mcp` both
report `default-setup: configured`, so GitHub runs CodeQL itself and the actor
condition in their workflow never matters.

**Where it came from:** `502db68` (#528, "add Semgrep SAST scan to CI pipeline",
2026-03-20) introduced the condition as collateral, not as a decision about bot
pull requests.

**On the Dependabot half:** Dependabot-triggered `pull_request` runs are
sometimes given a read-only `GITHUB_TOKEN`, which would fail the SARIF upload.
That is not the case here — on #1404 the `Dependency Review` job in this same
workflow run (27901379237) posted its PR comment as `github-actions[bot]`, which
requires `pull-requests: write`. Worth watching on the first Dependabot pull
request after this lands regardless, since the failure mode would be visible and
the change is a four-line revert.

The ruleset is untouched; the fix is to make the scan run, not to drop the
requirement for one.