### PR TITLE
fix: add bot PR governance workflow

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -1,0 +1,90 @@
+name: Bot PR Governance
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  governance:
+    name: Bot PR Rate Limit & Duplicate Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect and govern bot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.head_ref }}
+          ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          # Detect if this is a bot-created PR by branch name pattern.
+          # Two signals:
+          #   1. Explicit bot-tool prefixes (Bolt, Palette, Jules, fix/web-scraper)
+          #   2. Any branch ending with a long numeric task/trace ID (-[0-9]{14,})
+          IS_BOT_PR=false
+          if echo "$BRANCH" | grep -qE \
+              '^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])'; then
+            IS_BOT_PR=true
+          elif echo "$BRANCH" | grep -qE -- \
+              '-[0-9]{14,}$'; then
+            IS_BOT_PR=true
+          fi
+
+          if [ "$IS_BOT_PR" = "false" ]; then
+            echo "Not a bot PR ($BRANCH), skipping governance checks."
+            exit 0
+          fi
+
+          echo "Bot PR detected on branch: $BRANCH"
+          gh pr edit "$PR_NUMBER" --add-label "bot-generated" --repo "$REPO" || true
+
+          # --- Rate limit: max 5 bot PRs/actor/day ---
+          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+                  date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
+          COUNT=$(gh pr list --repo "$REPO" --state open \
+                   --json createdAt,headRefName,author \
+                   --jq "[.[] |
+                          select(.author.login == \"$ACTOR\") |
+                          select(.createdAt > \"$SINCE\") |
+                          select(.headRefName | test(
+                            \"^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])\" +
+                            \"|-[0-9]{14,}$\"
+                          ))] | length" 2>/dev/null || echo 0)
+
+          echo "Bot PRs by $ACTOR in last 24h: $COUNT"
+
+          if [ "${COUNT:-0}" -gt 5 ]; then
+            gh pr close "$PR_NUMBER" --repo "$REPO" \
+              --comment "**Bot rate limit exceeded**: $COUNT PRs created in the last 24 hours (limit: 5/day). This PR has been automatically closed to reduce PR backlog and CI resource waste. Please consolidate related fixes."
+            echo "PR #$PR_NUMBER closed: rate limit exceeded ($COUNT/5 today)"
+            exit 0
+          fi
+
+          # --- Duplicate detection by title keyword ---
+          KEYWORD=$(echo "$PR_TITLE" | sed 's/[^a-zA-Z0-9 _-]//g' | \
+                    tr '[:upper:]' '[:lower:]' | cut -c1-50 | xargs)
+          if [ -z "$KEYWORD" ]; then
+            echo "No keyword extracted, skipping duplicate check."
+            exit 0
+          fi
+
+          DUPES=$(gh pr list --repo "$REPO" --state open --search "$KEYWORD" \
+                   --json number \
+                   --jq "[.[] | select(.number != $PR_NUMBER)] | length" \
+                   2>/dev/null || echo 0)
+
+          echo "Similar open PRs for '$KEYWORD': $DUPES"
+          if [ "${DUPES:-0}" -ge 1 ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" \
+              --add-label "possible-duplicate" || true
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "**Possible duplicate**: found ${DUPES} open PR(s) with similar title ('${KEYWORD}'). Check before merging: \`gh pr list --search '${KEYWORD}' --state open\`"
+          fi


### PR DESCRIPTION
Bot tools open pull requests faster than review absorbs them. **140 of the 269
pull-request branches this repository has ever had** carry a bot task-trace
suffix, and #1556 was a proposal the `bolt.md` ledger had already ruled out in
its "avoid micro-optimizing cold paths" entry.

Two limits, applied only to branches that look bot-authored:

- **Rate limit** — more than 5 open bot pull requests from the same actor in 24
  hours and the new one is closed with the reason stated.
- **Duplicate hint** — a `possible-duplicate` label and a comment when another
  open pull request has a similar title. Advisory only; nothing is closed.

Copied from the workflow already running in Aiora, with **one change**: its
runner is `[self-hosted, linux, arm64]`. This repository is public, where
self-hosted runners are not appropriate and Actions minutes are free, so it runs
on `ubuntu-latest`. `diff` against the source shows that single hunk.

## Detection was checked, not assumed

Both rules were run against every branch this repository has seen (269, via
`gh pr list --state all --limit 300`):

| | result |
|---|---|
| matched | 140 |
| false positives | **0** |
| `renovate/*` matched | **none** |
| `dependabot/*` matched | **none** |

Every match carries the long numeric trace suffix (`-[0-9]{14,}$`) that no
hand-written branch here uses — `bolt-*`, `bolt/*`, `sentinel-*`, `sentinel/*`,
`palette-no-op-*`, plus the older `fix-*` / `test-*` / `perf-*` / `security-*`
bot branches that predate the prefixed naming. Everything unmatched is either a
human branch (`feat/*`, `fix/*`, `docs/*`, `chore/*`) or a dependency bot.
`dependabot/uv/uv-65b5720ae7` ends in hex, not 14+ digits, so it does not match
either.

The prefix rule (`^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])`) catches
less here than at Aiora — `palette-ux-` and `fix/web-scraper-` never appear, and
`sentinel` has no prefix clause — but the trace-suffix rule covers all of them,
so the patterns are kept as-is rather than tuned per repository.

## Labels

`bot-generated` and `possible-duplicate` did not exist here and have been created
with the same colour and description as Aiora's. Both `--add-label` calls end in
`|| true`, so without the labels the job would have kept passing while silently
labelling nothing.