### PR TITLE
fix: drop the code_quality rule from the main ruleset

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -40,12 +40,6 @@
       "type": "update"
     },
     {
-      "type": "code_quality",
-      "parameters": {
-        "severity": "errors"
-      }
-    },
-    {
       "type": "code_scanning",
       "parameters": {
         "code_scanning_tools": [


### PR DESCRIPTION
## The rule waits for a result that never arrives

`code_quality` is a rule for **GitHub Code Quality**, a separate product from
CodeQL. It waits for a check named `CodeQL - Code Quality`. That product has
never been enabled on this repository:

- `GET /repos/n24q02m/wet-mcp/code-quality` → **404**
- every entry in `code-scanning/analyses` has tool `CodeQL`; no Code Quality
  analysis has ever been recorded

So no pull request can satisfy the rule, and GitHub's own documentation warns
about exactly this shape — confirm the workflow reports results, *"otherwise the
ruleset could block the merging of all pull requests."*

## Removing it makes the gate stronger, not weaker

Today's evidence: #1559, #1560, #1562, #1563, #1564 and #1565 all had a green
`CodeQL` check and all still reported `BLOCKED`. Each was merged with an
administrator bypass — and a bypass skips the **entire** ruleset, `code_scanning`
included. So a rule that protects nothing was forcing every merge to step around
the rule that protects something.

#1564 (running CodeQL on bot pull requests) was a real fix and necessary, but it
was not sufficient: it addressed `code_scanning`, while this rule was blocking
independently.

`code_scanning` and every other rule are unchanged.

## What was touched

Applied to the live ruleset (12512515) first with a surgical `PUT` — the payload
was the current live ruleset minus this one rule — then mirrored into this file.
Verified after: rules are now `deletion, non_fast_forward,
required_linear_history, pull_request, update, code_scanning`; the three
bypass actors are intact; `code_scanning` still requires CodeQL at
`errors`/`high_or_higher`.

**Not touched, deliberately:** this file declares
`required_approving_review_count: 1` and `require_code_owner_review: true`, while
the live ruleset has `0` and `false`. That drift predates this change, and which
side is correct is the repository owner's call — so both sides keep their current
values here and the difference is reported rather than quietly resolved.

Not enabling GitHub Code Quality: it needs a Team/Enterprise plan and bills per
active committer, which is a separate decision.