### PR TITLE
fix: skip bot governance on pull requests from forks

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -12,6 +12,10 @@ permissions:
 jobs:
   governance:
     name: Bot PR Rate Limit & Duplicate Check
+    # A pull_request run from a fork gets a read-only GITHUB_TOKEN whatever the
+    # permissions block above asks for, so every write below would fail. The bot
+    # tools this governs push their branches into this repository, never a fork.
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Detect and govern bot PRs


### PR DESCRIPTION
A `pull_request` run from a fork gets a read-only `GITHUB_TOKEN` no matter what
the `permissions` block asks for. Two of the writes in this job are unguarded
under `set -e`:

| line | command | guarded |
|---|---|---|
| 47 | `gh pr edit --add-label "bot-generated"` | `\|\| true` |
| 65 | `gh pr close` | **no** |
| 87 | `gh pr edit --add-label "possible-duplicate"` | `\|\| true` |
| 88 | `gh pr comment` | **no** |

So a fork pull request whose branch happened to end in a long numeric suffix
would fail the job — and the red check is the mild half. The job's actual
purpose in that situation would be to automatically close a stranger's pull
request.

This never showed at Aiora because that repository is private; this one is
public.

## Job-level rather than first line of the script

The proposal on the table was a guard at the top of the `run:` block. This does
it as a job condition instead:

```yaml
if: github.event.pull_request.head.repo.fork == false
```

The script form only works while it stays first, and the bug being fixed is
precisely that kind of ordering assumption — the missing `|| true` is easy to
miss for the same reason. A later edit that adds a `gh` call above the guard
would reinstate the problem with nothing to catch it. A job condition cannot be
stepped over, skips the runner entirely instead of starting one to exit 0, and
matches how the jobs in `ci.yml` are gated.

`|| true` on the two writes was the other option and is weaker: it hides the
failure rather than preventing the action, and it would leave the auto-close
attempt in place for fork pull requests.

## Unchanged

Branch patterns, the rate limit and the duplicate check are all untouched. Every
bot this governs (Bolt, Sentinel, Palette, Jules) pushes its branch into this
repository, so none of them are affected.

## Verification

`if` parses as a job-level condition; the workflow still has one job with one
step and the same `permissions`. The workflow runs on this pull request — a
non-fork branch — and takes the "Not a bot PR" path, so the guard does not
block the normal path.

The fork path cannot be exercised without opening a pull request from a fork,
which is not something to manufacture here; it is unverified end-to-end and
rests on the documented token behaviour.