### PR TITLE
fix: gate bot governance on the branch living in this repository

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -12,10 +12,22 @@ permissions:
 jobs:
   governance:
     name: Bot PR Rate Limit & Duplicate Check
-    # A pull_request run from a fork gets a read-only GITHUB_TOKEN whatever the
-    # permissions block above asks for, so every write below would fail. The bot
-    # tools this governs push their branches into this repository, never a fork.
-    if: github.event.pull_request.head.repo.fork == false
+    # Only govern pull requests whose branch lives in this repository.
+    #
+    # Technically: a pull_request run from a fork gets a read-only GITHUB_TOKEN
+    # whatever the permissions block above asks for, and `gh pr close` and
+    # `gh pr comment` are both unguarded under `set -e`, so the job would fail.
+    #
+    # More importantly: what it would be trying to do there is close an
+    # outsider's pull request because somebody else's bot spent the day's rate
+    # limit. Every bot this governs pushes its branch into this repository, so
+    # nothing is lost by not running.
+    #
+    # Comparing head.repo.full_name against the repository asks whether the
+    # branch lives here. head.repo.fork answers a different question — whether
+    # the source repository is itself a fork — which would silently disable
+    # governance for internal branches if this repository ever became one.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Detect and govern bot PRs


### PR DESCRIPTION
Follow-up to #1567, adopting the condition imagine-mcp uses.

```diff
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.full_name == github.repository
```

`head.repo.fork` asks whether the repository the branch lives in is itself a fork
of something else. That is not the question. The two answers coincide today only
because this repository is not a fork (`repos/n24q02m/wet-mcp` → `fork: false`).
If it ever became one, `head.repo.fork` would be true for its own branches, and
governance would switch itself off permanently with no failing check to show for
it — the quietest possible way for this to break.

Comparing `head.repo.full_name` against `github.repository` asks whether the
branch lives here, which is what the guard means. It also handles a deleted
source repository, where `head.repo` is null and the comparison simply fails.

The comment now carries both halves of the reason:

- **Technical** — a `pull_request` run from a fork gets a read-only
  `GITHUB_TOKEN` whatever the `permissions` block asks for, and `gh pr close`
  (line 65) and `gh pr comment` (line 88) are both unguarded under `set -e`.
- **Product, and the one that matters more** — what the job would be attempting
  there is closing an outsider's pull request because somebody else's bot spent
  the day's rate limit.

Branch patterns, the rate limit and the duplicate check are untouched.

## Verification

Condition parses as a job-level `if` and is byte-identical to imagine-mcp's. The
workflow runs on this pull request — a branch in this repository — and takes the
"Not a bot PR" path, so the guard does not block the normal path.

The fork path stays unverified end-to-end; exercising it needs a real pull
request from a fork.