### PR TITLE
⚡ Bolt: Optimize whitespace checks in docs chunking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -62,3 +62,7 @@ closed pull request.
 **Proposed:** annotate the rewritten conditions with a comment naming the optimisation and its expected impact.
 **Why rejected:** this repository is public. A comment that names the tool which wrote it, and asserts an unmeasured speedup, is noise for every later reader of the file.
 **Action:** Write comments that explain why the code is shaped the way it is, in the voice of the surrounding file — for example, the reason a fast path exists and the measurement that justified it. Leave authorship to the commit metadata.
+
+## 2024-07-27 - Optimize whitespace checks in tight text parsing loops
+**Learning:** In hot text processing loops (like markdown and reStructuredText parsing), checking for empty or whitespace-only strings using `not string.strip()` or `string.strip() == ""` creates unnecessary string allocations and copies.
+**Action:** Always prefer the non-allocating alternative `not string or string.isspace()` when checking if a string is empty or contains only whitespace in performance-critical code paths.

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -1921,7 +1921,7 @@ async def try_llms_txt(base_url: str) -> str | None:
                 if resp.status_code == 200:
                     content = resp.text
                     # Validate: should be substantial text, not an error page
-                    if len(content) > 200 and not content.strip().startswith(
+                    if len(content) > 200 and not content.lstrip().startswith(
                         "<!DOCTYPE"
                     ):
                         # llms.txt (non-full) is often just a TOC with links.
@@ -2285,12 +2285,12 @@ def chunk_markdown(
     Chunks that are too large are further split by paragraphs,
     but never inside fenced code blocks.
     """
-    if not content or not content.strip():
+    if not content or content.isspace():
         return []
 
     # Clean noise (badges, navigation, footer) before chunking
     content = _clean_doc_content(content)
-    if not content.strip():
+    if not content or content.isspace():
         return []
 
     chunks: list[dict] = []
@@ -2387,7 +2387,7 @@ def _split_preserving_code(
         if line.lstrip().startswith("```"):
             in_code_block = not in_code_block
 
-        if not in_code_block and line.strip() == "" and current_segment:
+        if not in_code_block and (not line or line.isspace()) and current_segment:
             # Paragraph boundary — flush segment
             segments.append("\n".join(current_segment))
             current_segment = []
@@ -2496,7 +2496,7 @@ def _process_rst_directive(
         out.append(f"```{lang}")
         i += 1
         while i < len(lines) and (
-            not lines[i].strip() or lines[i].strip().startswith(":")
+            (not lines[i] or lines[i].isspace()) or lines[i].strip().startswith(":")
         ):
             i += 1
         if i < len(lines):
@@ -2518,12 +2518,16 @@ def _process_rst_directive(
         "deprecated",
     ):
         i += 1
-        while i < len(lines) and (not lines[i].strip() or lines[i].startswith("   ")):
+        while i < len(lines) and (
+            (not lines[i] or lines[i].isspace()) or lines[i].startswith("   ")
+        ):
             i += 1
     elif directive in ("note", "warning", "tip", "important", "seealso"):
         out.append(f"> **{directive.title()}:** {args}")
         i += 1
-        while i < len(lines) and (not lines[i].strip() or lines[i].startswith("   ")):
+        while i < len(lines) and (
+            (not lines[i] or lines[i].isspace()) or lines[i].startswith("   ")
+        ):
             body = lines[i].strip()
             if body:
                 out.append(f"> {body}")
@@ -2600,7 +2604,7 @@ def _rst_to_markdown(content: str) -> str:
             out.append(line.rstrip()[:-2] + ":" if len(line.rstrip()) > 2 else "")
             i += 1
             # Skip blank lines
-            while i < len(lines) and not lines[i].strip():
+            while i < len(lines) and (not lines[i] or lines[i].isspace()):
                 i += 1
             if i < len(lines):
                 code_indent = len(lines[i]) - len(lines[i].lstrip())
@@ -3473,7 +3477,7 @@ def _parse_objects_inv(data: bytes, base_url: str) -> list[str]:
     # Parse entries — only std:doc (pages) and std:label (sections)
     doc_urls: set[str] = set()
     for line in text.splitlines():
-        if not line.strip():
+        if not line or line.isspace():
             continue
         parts = line.split(" ", 4)
         if len(parts) < 4:
@@ -3837,7 +3841,7 @@ def resolve_library(db: Any, name: str, limit: int = 5) -> list[dict]:
     an empty list here is intentional for unknown libraries — callers can
     decide to trigger ingestion or surface "not found" to the user.
     """
-    if not name or not name.strip():
+    if not name or name.isspace():
         return []
     norm = name.lower().strip()
     if not norm:


### PR DESCRIPTION
💡 What: Replaced occurrences of `not string.strip()` or `string.strip() == ""` with `not string or string.isspace()` in tight parsing loops, and used `.lstrip().startswith(...)` instead of `.strip().startswith(...)`.
🎯 Why: Using `strip()` allocates memory and copies the string purely for a length/emptiness check, causing unnecessary overhead in hot paths like markdown and RST chunking.
📊 Impact: Reduces string allocations and overhead during hot text processing loops.
🔬 Measurement: Verify changes in `src/wet_mcp/sources/docs.py` and run tests.

---
*PR created automatically by Jules for task [9459138049647945305](https://jules.google.com/task/9459138049647945305) started by @n24q02m*