### PR TITLE
fix: checkpoint sqlite wal into docs.db before sync push

### DIFF
--- a/src/wet_mcp/sync/__init__.py
+++ b/src/wet_mcp/sync/__init__.py
@@ -36,7 +36,7 @@ import sys
 from types import ModuleType
 
 from wet_mcp.sync import gdrive as _gdrive_module
-from wet_mcp.sync.base import SyncBackend
+from wet_mcp.sync.base import SyncBackend, checkpoint_wal
 from wet_mcp.sync.gdrive import GDriveBackend
 
 # Mirror every public + private name exported by gdrive.py into this
@@ -244,6 +244,9 @@ async def _s3_auto_sync_loop(db) -> None:  # type: ignore[no-untyped-def]
     while True:
         try:
             await asyncio.sleep(interval)
+            # Flush WAL into docs.db first: the backend only ships the
+            # main file, so an un-checkpointed sidecar means an empty push.
+            await checkpoint_wal(db_path)
             await backend.push(db_path)
         except asyncio.CancelledError:
             logger.info("S3 auto-sync stopped")

--- a/src/wet_mcp/sync/base.py
+++ b/src/wet_mcp/sync/base.py
@@ -13,8 +13,59 @@ Spec reference: parity refactor with ``mnemo-mcp/sync/base.py``.
 
 from __future__ import annotations
 
+import asyncio
+import sqlite3
 from abc import ABC, abstractmethod
 from pathlib import Path
+
+from loguru import logger
+
+
+async def checkpoint_wal(db_path: Path) -> None:
+    """Fold the ``-wal`` sidecar back into ``db_path`` before an upload.
+
+    :class:`~wet_mcp.db.DocsDB` opens SQLite with ``PRAGMA journal_mode =
+    WAL``, so recent commits -- and, on a young database, the whole schema
+    -- live in ``<db_path>-wal`` until SQLite checkpoints. Every backend
+    uploads the main ``.db`` file only (that is the contract below: all
+    sync state lives in the local SQLite file on disk), so skipping this
+    step can publish a valid-but-EMPTY database to the remote.
+
+    ``TRUNCATE`` is the right level here. ``PASSIVE`` gives up as soon as
+    any reader is active and can transfer nothing; ``FULL`` transfers all
+    frames but leaves the sidecar in place, so a partially-reclaimed WAL
+    keeps growing across ticks. ``TRUNCATE`` transfers every frame AND
+    resets the sidecar to zero length, which is exactly the "main file is
+    complete" invariant the upload needs.
+
+    Failures are logged, never raised: the main ``.db`` file is always a
+    self-consistent SQLite database, so pushing a slightly stale snapshot
+    is strictly better than crashing the background sync loop.
+    """
+    if not db_path.exists():
+        return
+
+    def _checkpoint() -> tuple | None:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("PRAGMA busy_timeout = 5000")
+            return conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        finally:
+            conn.close()
+
+    try:
+        row = await asyncio.to_thread(_checkpoint)
+    except sqlite3.Error as e:
+        logger.warning(f"WAL checkpoint failed for {db_path}: {e}")
+        return
+
+    # Row is (busy, wal_pages, checkpointed_pages); busy != 0 means another
+    # connection held a lock and some frames stayed behind.
+    if row is not None and row[0] != 0:
+        logger.warning(
+            f"WAL checkpoint busy for {db_path} (result={tuple(row)}); "
+            "the uploaded snapshot may lag the newest commits"
+        )
 
 
 class SyncBackend(ABC):

--- a/src/wet_mcp/sync/gdrive.py
+++ b/src/wet_mcp/sync/gdrive.py
@@ -31,6 +31,7 @@ from loguru import logger
 from mcp_core.auth import token_client_mismatch
 
 from wet_mcp.config import settings
+from wet_mcp.sync.base import checkpoint_wal
 
 if TYPE_CHECKING:
     from wet_mcp.db import DocsDB
@@ -446,6 +447,11 @@ async def sync_push(db_path: Path, folder_name: str) -> bool:
 
     existing = await _find_file_in_folder(token, folder_id, db_path.name)
     existing_id = existing["id"] if existing else None
+
+    # This is the single funnel for GDrive uploads (``sync_full`` and
+    # ``GDriveBackend.push`` both land here) and ``_upload_file`` reads the
+    # main .db file only, so the WAL has to be folded in first.
+    await checkpoint_wal(db_path)
 
     success = await _upload_file(token, db_path, folder_id, existing_id)
     if success:

--- a/tests/test_sync_wal_checkpoint.py
+++ b/tests/test_sync_wal_checkpoint.py
@@ -1,0 +1,154 @@
+"""Regression tests: the bytes a sync backend uploads must contain the data.
+
+``DocsDB`` opens SQLite with ``PRAGMA journal_mode = WAL`` (db.py), so freshly
+committed rows -- and, on a young database, the schema itself -- live in the
+``docs.db-wal`` sidecar, not in ``docs.db``. Both upload paths read the main
+``.db`` file only, so without an explicit checkpoint the remote copy is a
+valid-but-empty SQLite database (no tables, no rows).
+
+Two independent upload paths exist and both are covered here:
+
+* S3 operator mode: ``_s3_auto_sync_loop`` -> ``backend.push(db_path)``.
+* GDrive uvx mode: ``_auto_sync_loop`` -> ``sync_full`` -> ``sync_push`` ->
+  ``_upload_file`` (never routed through ``SyncBackend.push``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from wet_mcp.db import DocsDB
+
+_CHUNK_COUNT = 3
+
+
+def _seed_wal_db(db_path: Path) -> DocsDB:
+    """Create a WAL-mode docs.db with real rows, leaving the writer open."""
+    db = DocsDB(db_path, embedding_dims=0)
+    lib_id = db.upsert_library("walcheck", docs_url="https://example.invalid/docs")
+    ver_id = db.upsert_version(lib_id, "1.0.0")
+    db.add_chunks(
+        ver_id,
+        lib_id,
+        [{"content": f"wal checkpoint probe chunk {i}"} for i in range(_CHUNK_COUNT)],
+    )
+
+    mode = db._conn.execute("PRAGMA journal_mode").fetchone()[0]
+    assert mode == "wal", f"expected WAL journal mode, got {mode!r}"
+    assert db_path.with_name(db_path.name + "-wal").exists(), (
+        "no -wal sidecar: this test cannot prove the bug without WAL"
+    )
+    return db
+
+
+def _chunks_in_uploaded_bytes(payload: bytes, tmp_path: Path) -> int:
+    """Open the exact bytes that were uploaded and count doc_chunks rows."""
+    replica = tmp_path / "uploaded_replica.db"
+    replica.write_bytes(payload)
+    conn = sqlite3.connect(str(replica))
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        assert "doc_chunks" in tables, (
+            f"uploaded docs.db has no doc_chunks table (tables={sorted(tables)}); "
+            "the WAL was never checkpointed into the main file"
+        )
+        return conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[0]
+    finally:
+        conn.close()
+
+
+async def test_s3_push_uploads_wal_checkpointed_bytes(monkeypatch, tmp_path) -> None:
+    """The S3 auto-sync loop must hand the backend a checkpointed docs.db."""
+    from wet_mcp.config import settings
+
+    db_path = tmp_path / "docs.db"
+    db = _seed_wal_db(db_path)
+
+    uploaded: list[bytes] = []
+
+    async def _capture_push(path: Path) -> bool:
+        uploaded.append(Path(path).read_bytes())
+        return True
+
+    fake_backend = MagicMock()
+    fake_backend.pull = AsyncMock(return_value=None)
+    fake_backend.push = AsyncMock(side_effect=_capture_push)
+
+    monkeypatch.setattr("wet_mcp.config.settings.sync_interval", 0.05)
+    monkeypatch.setattr("wet_mcp.config.settings.sync_s3_bucket", "b")
+    monkeypatch.setattr(type(settings), "get_db_path", lambda self: db_path)
+    monkeypatch.setattr("wet_mcp.sync.get", lambda name: fake_backend)
+
+    from wet_mcp.sync import _s3_auto_sync_loop
+
+    task = asyncio.create_task(_s3_auto_sync_loop(db=db))
+    try:
+        for _ in range(60):
+            await asyncio.sleep(0.05)
+            if uploaded:
+                break
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert uploaded, "auto-sync loop never pushed"
+    assert _chunks_in_uploaded_bytes(uploaded[0], tmp_path) == _CHUNK_COUNT
+    db.close()
+
+
+async def test_gdrive_sync_push_uploads_wal_checkpointed_bytes(
+    monkeypatch, tmp_path
+) -> None:
+    """The GDrive push path must upload a checkpointed docs.db too."""
+    from wet_mcp.sync import gdrive
+
+    db_path = tmp_path / "docs.db"
+    db = _seed_wal_db(db_path)
+
+    uploaded: list[bytes] = []
+
+    async def _fake_drive_request(
+        method: str,
+        url: str,
+        token: dict,
+        *,
+        params: dict | None = None,
+        json_data: dict | None = None,
+        content: bytes | None = None,
+        headers: dict | None = None,
+        timeout: float = 120.0,
+    ) -> MagicMock:
+        if content is not None:
+            uploaded.append(content)
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"id": "remote-file-id"}
+        return response
+
+    monkeypatch.setattr(
+        gdrive, "_get_valid_token", AsyncMock(return_value={"access_token": "t"})
+    )
+    monkeypatch.setattr(
+        gdrive, "_find_or_create_folder", AsyncMock(return_value="folder-id")
+    )
+    monkeypatch.setattr(
+        gdrive,
+        "_find_file_in_folder",
+        AsyncMock(return_value={"id": "remote-file-id"}),
+    )
+    monkeypatch.setattr(gdrive, "_drive_request", _fake_drive_request)
+
+    assert await gdrive.sync_push(db_path, "wet-mcp") is True
+
+    assert uploaded, "sync_push never uploaded content"
+    assert _chunks_in_uploaded_bytes(uploaded[0], tmp_path) == _CHUNK_COUNT
+    db.close()


### PR DESCRIPTION
## Triệu chứng

Bản `docs.db` đẩy lên remote (Google Drive hoặc S3/R2/B2) có thể là một database SQLite **hợp lệ nhưng rỗng ruột**: file có kích thước bình thường, mở được, nhưng `sqlite_master` không có bảng nào — mất toàn bộ libraries/versions/chunks đã index. Cùng lớp lỗi với sự cố mnemo-mcp ngày 2026-07-31.

## Vì sao WAL gây ra chuyện đó

`DocsDB.__init__` (`src/wet_mcp/db.py:250`) mở SQLite với `PRAGMA journal_mode = WAL`. Ở chế độ WAL, mọi commit được ghi vào file sidecar `docs.db-wal` trước, và chỉ được dồn vào file `docs.db` chính khi có checkpoint. SQLite tự động checkpoint khi WAL vượt ~1000 trang (~4 MB) — nghĩa là với một database còn non, **kể cả schema** (`CREATE TABLE` do `_create_tables` chạy) vẫn nằm nguyên trong `-wal`, còn `docs.db` chỉ là một database rỗng hợp lệ.

Cả hai đường upload đều đọc thẳng file `.db` chính, không checkpoint, không kèm sidecar:

- `src/wet_mcp/sync/s3.py:79` — `body = await asyncio.to_thread(db_path.read_bytes)`
- `src/wet_mcp/sync/gdrive.py:351` — `file_content = await asyncio.to_thread(file_path.read_bytes)`

`git grep wal_checkpoint` trên `origin/main` không ra kết quả nào — repo chưa từng checkpoint.

## Vì sao đặt checkpoint ở chỗ nối chung

Hợp đồng ở `sync/base.py` nói rõ backend chỉ nhận `db_path` và mọi trạng thái nằm trong file trên đĩa, nên checkpoint thuộc về lớp điều phối chứ không nhân đôi trong từng backend. Helper `checkpoint_wal()` được viết **một lần** trong `sync/base.py` — ngay cạnh chính cái hợp đồng mà nó bảo đảm.

Có **hai** đường upload độc lập, và chỉ một trong hai đi qua `SyncBackend.push`:

| Chế độ | Đường gọi |
|---|---|
| S3 (operator/HTTP/Docker) | `server.py:364` -> `start_s3_auto_sync` -> `_s3_auto_sync_loop` -> `backend.push(db_path)` |
| GDrive (uvx local, mặc định) | `server.py:369` -> `start_auto_sync` -> `_auto_sync_loop` -> `sync_full` -> `sync_push` -> `_upload_file` |

Đường GDrive **không bao giờ** đi qua `SyncBackend.push` (`GDriveBackend.push` không có caller production nào). Vì thế `git grep '\.push('` chỉ thấy đúng một dòng 247, nhưng vá riêng dòng 247 sẽ bỏ lọt hẳn chế độ mặc định. Nên checkpoint được gọi ở hai chỗ nối:

- `sync/__init__.py` — ngay trước `await backend.push(db_path)` (chỗ nối điều phối của S3).
- `gdrive.sync_push` — ngay trước `_upload_file`. Chọn `sync_push` thay vì `sync_full` vì đây là phễu duy nhất mà **cả** `sync_full` **lẫn** `GDriveBackend.push` đều chảy qua, nên phủ hết bằng một call site thay vì hai.

Thứ tự trong `sync_full` cũng đúng luôn: pull -> merge vào DB local -> `sync_push` (checkpoint) -> upload, nên các hàng vừa merge từ remote nằm ngay trong lần push đó.

## Vì sao `TRUNCATE` chứ không phải `PASSIVE`/`FULL`

- `PASSIVE` bỏ cuộc ngay khi có reader đang hoạt động và có thể chuyển được **không** frame nào — đúng kịch bản lỗi thì vẫn lỗi.
- `FULL` chuyển hết frame vào file chính nhưng **giữ nguyên** sidecar, nên WAL cứ phình dần qua từng tick sync.
- `TRUNCATE` chuyển hết frame **và** reset sidecar về 0 byte. Đó chính xác là bất biến "file chính đã đầy đủ" mà bước upload cần, và nó khiến mỗi lần push tiếp theo không bao giờ đua với một WAL đầy dở.

Lỗi checkpoint chỉ được log, không raise: file `.db` chính luôn là một database SQLite tự nhất quán, nên đẩy một snapshot hơi cũ vẫn tốt hơn là làm sập vòng lặp sync nền. Trường hợp `busy != 0` (connection khác đang giữ lock) được log warning riêng để chẩn đoán.

## Kết luận về đường `pull`

**Không cần checkpoint ở đường pull.** Lý do:

1. File temp mà `backend.pull` trả về được ghi bằng một lần `write_bytes` duy nhất, không có sidecar `-wal` đi kèm.
2. `DocsDB(remote_db_path)` mở file temp đó chỉ để **đọc** (`export_jsonl`), rồi `close()`. Không có byte nào từ file temp được upload đi đâu cả — nó bị `unlink` ngay sau khi merge.
3. Dữ liệu merge được ghi vào DB local qua `db.import_jsonl(...)`, tức là rơi vào `-wal` của DB **local** — và đó đúng là thứ mà checkpoint phía push trong PR này đã lo.

## Test

`tests/test_sync_wal_checkpoint.py` phủ cả hai đường: mở `DocsDB` thật ở chế độ WAL (có assert `journal_mode == 'wal'` và assert sidecar `-wal` tồn tại, để test không thể "xanh giả" khi không còn WAL), ghi 3 chunk, giữ connection writer mở như server thật, rồi chạy đường push với backend giả / `_drive_request` giả và mở **chính những byte đã được đẩy đi** để đếm hàng `doc_chunks`.

Trước khi vá, cả hai đều đỏ với đúng triệu chứng gốc:

```
E   AssertionError: uploaded docs.db has no doc_chunks table (tables=[]); the WAL was never checkpointed into the main file
```
