### PR TITLE
fix: cf-d1 index path drops docs_url and four doc_chunks columns

### DIFF
--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -59,22 +59,42 @@ class DocsDBCfBackend:
     def get_library(self, name: str) -> dict | None:
         return self._d1.fetchone("SELECT * FROM libraries WHERE name = ?", [name])
 
-    def upsert_version(self, library_id: str, version: str) -> str:
+    def upsert_version(
+        self,
+        library_id: str,
+        version: str = "latest",
+        docs_url: str | None = None,
+    ) -> str:
+        """Create or get version. Returns version ID.
+
+        Signature and docs_url handling mirror wet_mcp.db.DocsDB.upsert_version:
+        both production index call sites pass ``docs_url=``, and an existing row
+        gets the new ``docs_url`` written back onto it (a missing one leaves the
+        stored value alone).
+        """
         existing = self.get_best_version(library_id, version)
         if existing:
-            return existing["id"]
+            ver_id = existing["id"]
+            if docs_url:
+                self._d1.execute(
+                    "UPDATE versions SET docs_url = ? WHERE id = ?",
+                    [docs_url, ver_id],
+                )
+            return ver_id
         ver_id = str(uuid.uuid4())
         self._d1.execute(
-            "INSERT INTO versions (id, library_id, version) VALUES (?,?,?)",
-            [ver_id, library_id, version],
+            "INSERT INTO versions (id, library_id, version, docs_url) VALUES (?,?,?,?)",
+            [ver_id, library_id, version, docs_url],
         )
         return ver_id
 
-    def get_best_version(self, library_id: str, version: str | None) -> dict | None:
-        if version:
+    def get_best_version(
+        self, library_id: str, target: str | None = None
+    ) -> dict | None:
+        if target:
             return self._d1.fetchone(
                 "SELECT * FROM versions WHERE library_id = ? AND version = ?",
-                [library_id, version],
+                [library_id, target],
             )
         return self._d1.fetchone(
             "SELECT * FROM versions WHERE library_id = ? ORDER BY indexed_at DESC LIMIT 1",
@@ -99,13 +119,20 @@ class DocsDBCfBackend:
                 c.get("chunk_index", 0),
                 c["content"],
                 c.get("heading_path"),
+                c.get("section"),
+                c.get("topic"),
+                c.get("content_hash"),
+                c.get("token_count"),
                 now,
             ]
             for c in chunks
         ]
+        # section/topic/content_hash/token_count exist in migrations/0001_init_wet.sql
+        # and search() reads them back, so persist them like DocsDB.add_chunks does.
         self._d1.executemany(
             "INSERT INTO doc_chunks (id, version_id, library_id, url, title, chunk_index,"
-            " content, heading_path, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            " content, heading_path, section, topic, content_hash, token_count,"
+            " created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
             rows,
         )
         if embeddings:

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -1,9 +1,12 @@
+import inspect
 from pathlib import Path
 
+import pytest
 from conftest_cf import FakeD1Http, FakeVectorizeHttp
 
 from wet_mcp.backends.d1 import D1Backend
 from wet_mcp.backends.vectorize import VectorizeBackend
+from wet_mcp.db import DocsDB
 from wet_mcp.db_cf import DocsDBCfBackend
 
 DDL = Path("migrations/0001_init_wet.sql").read_text(encoding="utf-8")
@@ -125,3 +128,184 @@ def test_cf_search_matches_sqlite_golden(cf_corpus, cf_golden_topk):
         assert overlap >= 2, (
             f"top-3 rank parity failed for {q!r}: {cf_top[:3]} vs {golden[:3]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: cf-d1 index path died before a single row reached doc_chunks
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_version_accepts_docs_url_kwarg():
+    """Both production index call sites pass ``docs_url=``: ``server.py`` (docs
+    auto-index) and ``sources/docs.py`` (tier-2 lazy index). ``DocsDB.upsert_version``
+    accepts it; ``DocsDBCfBackend.upsert_version`` did not, so under
+    ``DOCS_DB_BACKEND=cf-d1`` every index run raised TypeError *after*
+    ``upsert_library`` had already committed -- ``libraries`` kept growing while
+    ``doc_chunks`` stayed at 0.
+    """
+    db = _backend()
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    ver_id = db.upsert_version(
+        library_id=lib_id, version="1.0", docs_url="https://a/docs"
+    )
+    row = db.get_best_version(lib_id, "1.0")
+    assert row["id"] == ver_id
+    assert row["docs_url"] == "https://a/docs"
+
+
+def test_upsert_version_updates_docs_url_on_existing_row():
+    """Mirror ``DocsDB.upsert_version``: an existing row is reused, a non-empty
+    ``docs_url`` is written back onto it, and a missing one leaves it untouched.
+    """
+    db = _backend()
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+
+    first = db.upsert_version(lib_id, "1.0")
+    assert db.get_best_version(lib_id, "1.0")["docs_url"] is None
+
+    again = db.upsert_version(lib_id, "1.0", docs_url="https://a/docs")
+    assert again == first
+    assert db.get_best_version(lib_id, "1.0")["docs_url"] == "https://a/docs"
+
+    db.upsert_version(lib_id, "1.0")
+    assert db.get_best_version(lib_id, "1.0")["docs_url"] == "https://a/docs"
+
+
+def test_upsert_version_defaults_to_latest():
+    """``DocsDB.upsert_version`` defaults ``version`` to ``"latest"``; the CF
+    backend made it required, so the two backends were not interchangeable."""
+    db = _backend()
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    ver_id = db.upsert_version(lib_id)
+    assert db.get_best_version(lib_id, "latest")["id"] == ver_id
+
+
+def test_get_best_version_target_is_optional():
+    """``config(action="clear")`` and ``cli.py`` call ``get_best_version(lib_id)``
+    with no target. ``DocsDB`` defaults it to ``None``; the CF backend required a
+    second argument and named it ``version``, so the same call raised TypeError."""
+    db = _backend()
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    ver_id = db.upsert_version(lib_id, "1.0")
+    assert db.get_best_version(lib_id)["id"] == ver_id
+    assert db.get_best_version(lib_id, target="1.0")["id"] == ver_id
+
+
+def test_add_chunks_persists_every_column_the_sqlite_backend_writes():
+    """``doc_chunks`` in ``migrations/0001_init_wet.sql`` carries ``section``,
+    ``topic``, ``content_hash`` and ``token_count``, and ``search()`` reads three of
+    them back into its results. The CF writer only ever INSERTed the nine base
+    columns, so those four were silently NULL on every cf-d1 row."""
+    db = _backend()
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    ver_id = db.upsert_version(lib_id, "1.0", docs_url="https://a/docs")
+    db.add_chunks(
+        ver_id,
+        lib_id,
+        [
+            {
+                "id": "c1",
+                "url": "https://a/p1",
+                "title": "Routing",
+                "chunk_index": 0,
+                "content": "async function handler with error handling",
+                "heading_path": "Guide > Routing",
+                "section": "guide",
+                "topic": "routing",
+                "content_hash": "deadbeef",
+                "token_count": 7,
+            },
+        ],
+        embeddings=None,
+    )
+
+    stored = db._d1.fetchone("SELECT * FROM doc_chunks WHERE id = ?", ["c1"])
+    assert stored["section"] == "guide"
+    assert stored["topic"] == "routing"
+    assert stored["content_hash"] == "deadbeef"
+    assert stored["token_count"] == 7
+
+    result = db.search("function", limit=5)[0]
+    assert result["section"] == "guide"
+    assert result["topic"] == "routing"
+    assert result["token_count"] == 7
+
+
+def test_add_chunks_leaves_optional_columns_null_when_absent():
+    """The optional keys stay optional: a v1-shaped chunk still inserts cleanly."""
+    db = _backend()
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    ver_id = db.upsert_version(lib_id, "1.0")
+    db.add_chunks(
+        ver_id,
+        lib_id,
+        [{"id": "c1", "content": "hello world", "url": "https://a/p1"}],
+        embeddings=None,
+    )
+    stored = db._d1.fetchone("SELECT * FROM doc_chunks WHERE id = ?", ["c1"])
+    assert stored["section"] is None
+    assert stored["topic"] is None
+    assert stored["content_hash"] is None
+    assert stored["token_count"] is None
+
+
+# ---------------------------------------------------------------------------
+# Signature parity gate: db_cf.py claims to mirror db.py, so prove it
+# ---------------------------------------------------------------------------
+
+MIRRORED_METHODS = sorted(
+    name
+    for name, _member in inspect.getmembers(DocsDBCfBackend, inspect.isfunction)
+    if not name.startswith("_") and callable(getattr(DocsDB, name, None))
+)
+
+
+def _required(param):
+    return param.default is inspect.Parameter.empty
+
+
+@pytest.mark.parametrize("method_name", MIRRORED_METHODS)
+def test_cf_backend_signature_mirrors_sqlite_backend(method_name):
+    """``db_cf.py``'s module docstring states its public interface mirrors
+    ``wet_mcp.db.DocsDB``, and ``server.py`` depends on that: it stores either
+    backend in the same ``_docs_db`` global and calls it with keyword arguments.
+    So every parameter ``DocsDB`` accepts must also be accepted by
+    ``DocsDBCfBackend``, in the same order and with the same required/optional
+    status.
+
+    This is the gate that was missing when ``db_cf.py`` was first added: the new
+    ``upsert_version`` silently dropped ``docs_url`` and no test compared the two
+    signatures, so the drift shipped and broke every cf-d1 index run.
+    """
+    sqlite_params = inspect.signature(getattr(DocsDB, method_name)).parameters
+    cf_params = inspect.signature(getattr(DocsDBCfBackend, method_name)).parameters
+    cf_takes_kwargs = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in cf_params.values()
+    )
+
+    for name, sqlite_param in sqlite_params.items():
+        if sqlite_param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        cf_param = cf_params.get(name)
+        if cf_param is None:
+            assert cf_takes_kwargs, (
+                f"DocsDBCfBackend.{method_name}() does not accept {name!r}, "
+                f"but DocsDB.{method_name}() does -- a call that works on the "
+                f"sqlite backend raises TypeError on cf-d1"
+            )
+            continue
+        assert _required(cf_param) == _required(sqlite_param), (
+            f"DocsDBCfBackend.{method_name}() makes {name!r} "
+            f"{'required' if _required(cf_param) else 'optional'} while "
+            f"DocsDB.{method_name}() makes it "
+            f"{'required' if _required(sqlite_param) else 'optional'}"
+        )
+
+    shared = [name for name in sqlite_params if name in cf_params]
+    assert [name for name in cf_params if name in sqlite_params] == shared, (
+        f"DocsDBCfBackend.{method_name}() reorders parameters relative to "
+        f"DocsDB.{method_name}(), so positional calls bind different values"
+    )


### PR DESCRIPTION
## Triệu chứng

Trên backend `cf-d1` (`DOCS_DB_BACKEND=cf-d1`), mọi lần index tài liệu đều chết giữa chừng:
bảng `libraries` cứ tăng thêm hàng sau mỗi lần thử, còn `versions` và `doc_chunks` đứng yên ở 0.
`config(action="status")` vì thế luôn báo `chunks: 0` dù đã index nhiều lần.

## Root cause

`DocsDBCfBackend.upsert_version` có chữ ký `(self, library_id, version)` — thiếu tham số
`docs_url` mà `DocsDB.upsert_version` (bản SQLite) nhận. Cả hai call site trong production
đều truyền `docs_url=`:

- `src/wet_mcp/server.py` — nhánh docs auto-index
- `src/wet_mcp/sources/docs.py` — nhánh tier-2 lazy index

Nên mỗi lần index, `upsert_library` chạy trước và commit thành công (D1 không có transaction
bao quanh, mỗi statement là một request riêng), rồi `upsert_version` ném
`TypeError: upsert_version() got an unexpected keyword argument 'docs_url'`. Đó chính là lý do
`libraries` tăng còn `doc_chunks` không bao giờ có hàng nào.

Commit gây lệch: `7d8a194` (15/06/2026, "feat: Cloudflare serverless deployment (Phase 2 pilot)")
— commit tạo mới `src/wet_mcp/db_cf.py`, viết lại một giao diện đã ổn định từ trước mà không
có test nào so hai chữ ký với nhau.

## Nội dung sửa

1. `upsert_version` nhận `docs_url: str | None = None`, ghi vào `INSERT INTO versions`, và ghi
   đè lên hàng đã tồn tại khi `docs_url` không rỗng — khớp đúng hành vi của `DocsDB.upsert_version`
   (`docs_url` rỗng thì giữ nguyên giá trị đang lưu).
2. `version` mặc định `"latest"`, và `get_best_version` đổi tham số thứ hai thành `target` với
   mặc định `None` — giống bản SQLite. Trước đó `get_best_version(lib_id)` (dùng ở nhánh
   `config(action="clear")` và ở CLI) ném TypeError trên `cf-d1`.
3. `add_chunks` ghi thêm `section`, `topic`, `content_hash`, `token_count`. Bốn cột này đã có
   sẵn trong `migrations/0001_init_wet.sql` và `search()` đọc ba trong số đó ra kết quả, nhưng
   writer chỉ INSERT 9 cột nền nên chúng luôn NULL. Không cần migration mới.

## Vì sao test parity là phần chống tái phát

Docstring của `db_cf.py` tự nhận "public interface mirrors `wet_mcp.db.DocsDB`", và `server.py`
dựa vào đúng điều đó: nó giữ cả hai backend trong cùng biến `_docs_db` và gọi bằng keyword
argument. Đó là một hợp đồng có thật nhưng chưa có gì kiểm chứng — nên `7d8a194` làm lệch chữ ký
mà CI vẫn xanh, và lỗi sống hơn sáu tuần trước khi lộ ra.

`test_cf_backend_signature_mirrors_sqlite_backend` parametrize trên mọi phương thức công khai mà
cả hai lớp cùng có, và với mỗi tham số của bản SQLite thì kiểm: backend CF có nhận tham số đó
không, có cùng bắt buộc/tuỳ chọn không, và thứ tự tham số có giữ nguyên không. Chạy trên nhánh
`main` nó đỏ ở `upsert_version` và `get_best_version` — tức là nó bắt đúng lỗi mà đáng lẽ nó đã
phải chặn từ `7d8a194`.

## Còn lại trên cùng đường đi (KHÔNG nằm trong PR này)

Đường index trên `cf-d1` vẫn chưa chạy được đến cuối sau PR này. Các điểm sau đã được xác nhận
bằng code nhưng cố ý để ngoài phạm vi:

- `DocsDBCfBackend` thiếu hẳn `clear_version_chunks`, `mark_version_indexed`,
  `mark_library_indexed`, `close`, `get_project_context`, `touch_project_context` — tất cả đều
  được gọi thẳng trên `_docs_db` mà không có `hasattr` guard. Ngay dòng sau `upsert_version`,
  đường index gọi `clear_version_chunks` và sẽ ném `AttributeError`. Bổ sung chúng cần thêm
  endpoint xoá vector cho Vectorize (client hiện chỉ có `upsert`/`query`) và một bảng
  `project_context` trong D1, tức là đụng tới worker + migration.
- `D1Backend.executemany` gom tối đa 100 dòng mỗi INSERT; với 13 cột là 1300 bound parameter
  trong một query, trong khi D1 giới hạn 100 bound parameter mỗi query. Giới hạn này đã bị vượt
  từ trước (9 cột x 100 dòng = 900) nhưng chưa lộ vì INSERT chưa bao giờ chạy tới.
- `DocsDBCfBackend.upsert_library` nuốt `registry`/`description`/`tier`/... qua `**extra` dù D1
  có sẵn các cột đó, và `add_chunks` trả `None` trong khi bản SQLite trả số chunk đã ghi.
