### PR TITLE
fix: unblock Tier 1 docs indexing (seed stamp, ingest gate, page shape)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,9 @@ jobs:
         run: uv run python scripts/build_tier1_index.py
 
       - name: Upload metrics artifact
+        # Runs even when the build step exits non-zero: a failing index run
+        # is exactly when the metrics file is worth reading.
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tier1-index-metrics

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -195,6 +195,11 @@ Alembic migration chain:
   content_hash, token_count}` + `idx_doc_chunks_lib_ver_topic`.
 * `docs_003_project_context` — Cabinets `project_context` table with
   `project_path` PK + `locked_libraries` JSON + LRU index.
+* `docs_004_chunk_summaries` — `doc_chunks.summary` + its index.
+* `docs_005_metadata_seeded_at` — adds `libraries.metadata_seeded_at`
+  (Tier 1 warmup freshness anchor) and moves seed-only
+  `last_indexed_at` stamps into it, so "metadata seeded" and "chunks
+  landed" stop being the same column.
 
 `run_migrations_on_startup()` (in `wet_mcp.migrations`) is invoked by
 the FastMCP lifespan after `DocsDB.__init__`. The runner copies
@@ -206,10 +211,13 @@ Failures are logged and swallowed so server startup never blocks.
 ```text
 First docs_query for library X
     |
-    +-- (a) Tier 1 metadata seeded? (data/tier1_libraries.json -> upsert_library)
+    +-- (a) Does X resolve AND hold a status='indexed' version?
     |       |
     |       +-- yes: resolve library_id, run hybrid search
     |       +-- no:  trigger ingest_tier2 in background, return progress hint
+    |               (Tier 1 warmup seeds metadata only — curated names
+    |                always resolve, with latest_version = None until
+    |                chunks land, so resolution alone is not the gate)
     |
     +-- ingest_tier2 reuses discover_library + fetch_docs_pages
             (delegates to web_core.scraper.ScrapingAgent strategy chain)
@@ -217,9 +225,12 @@ First docs_query for library X
             -> mark_library_indexed updates last_indexed_at
 ```
 
-Tier 1 freshness window: 7 days. The `refresh-tier1` cron job in
+Tier 1 freshness window: 7 days. `maybe_warm` measures that window
+against `metadata_seeded_at`; `last_indexed_at` is written only by
+`mark_library_indexed`. The `refresh-tier1` cron job in
 `.github/workflows/ci.yml` re-runs `scripts/build_tier1_index.py`
-weekly to keep curated chunks fresh.
+weekly to keep curated chunks fresh; that script exits non-zero when
+fewer than `--min-success-rate` of the libraries produce chunks.
 
 ### Cabinets project isolation
 

--- a/scripts/build_tier1_index.py
+++ b/scripts/build_tier1_index.py
@@ -7,10 +7,14 @@ Walks every entry in src/wet_mcp/data/tier1_libraries.json, calls
 README), and writes a ``tier1_index_metrics.json`` summary alongside
 ``docs.db``.
 
+Exits non-zero when fewer than ``--min-success-rate`` of the curated
+libraries end up with at least one chunk, so a run that indexes nothing
+fails its job instead of reporting success with an empty database.
+
 Usage:
 
     uv run python scripts/build_tier1_index.py
-    uv run python scripts/build_tier1_index.py --upload-snapshot
+    uv run python scripts/build_tier1_index.py --min-success-rate 0.5
 """
 
 from __future__ import annotations
@@ -21,6 +25,7 @@ import json
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 
 async def _amain() -> int:
@@ -32,9 +37,13 @@ async def _amain() -> int:
         help="Path to docs.db (default ~/.wet-mcp/docs.db)",
     )
     parser.add_argument(
-        "--upload-snapshot",
-        action="store_true",
-        help="Upload tier1_index_metrics.json to GitHub Releases (CI-only).",
+        "--min-success-rate",
+        type=float,
+        default=0.8,
+        help=(
+            "Fraction of libraries that must yield at least one chunk for "
+            "the run to succeed (default 0.8). Use 0 to never fail."
+        ),
     )
     args = parser.parse_args()
 
@@ -54,7 +63,7 @@ async def _amain() -> int:
     libraries = payload.get("libraries", [])
     print(f"Eager-ingesting {len(libraries)} Tier 1 libraries...")
 
-    metrics = []
+    metrics: list[dict[str, Any]] = []
     started = time.time()
     for entry in libraries:
         name = entry["id"]
@@ -79,21 +88,44 @@ async def _amain() -> int:
             metrics.append({"library": name, "status": "error", "error": str(exc)})
             print(f"  {name}: ERROR {exc}")
 
+    indexed = [m for m in metrics if (m.get("chunk_count") or 0) > 0]
+    total_chunks = sum(m.get("chunk_count") or 0 for m in metrics)
+    total_pages = sum(m.get("page_count") or 0 for m in metrics)
+    success_rate = len(indexed) / len(libraries) if libraries else 0.0
+
     summary = {
         "timestamp": time.time(),
         "total_libraries": len(libraries),
+        "libraries_with_chunks": len(indexed),
+        "success_rate": round(success_rate, 4),
+        "min_success_rate": args.min_success_rate,
+        "total_pages": total_pages,
+        "total_chunks": total_chunks,
         "duration_seconds": round(time.time() - started, 2),
         "metrics": metrics,
     }
     out_path = args.db_path.parent / "tier1_index_metrics.json"
     out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
-    print(f"\nWrote metrics to {out_path}")
 
-    if args.upload_snapshot:
-        # Best-effort: only used by CI. Local users can ignore.
-        print("Snapshot upload requested (CI-only); see workflow for handler.")
+    print("\n" + "=" * 60)
+    print(
+        f"Tier 1 index: {len(indexed)}/{len(libraries)} libraries with chunks "
+        f"({success_rate:.0%}), {total_pages} pages, {total_chunks} chunks"
+    )
+    print(f"Metrics written to {out_path}")
+    print("=" * 60)
 
     db.close()
+
+    if success_rate < args.min_success_rate:
+        # A run that indexes nothing used to exit 0 and paint CI green for
+        # weeks while the database stayed empty.
+        print(
+            f"FAILED: success rate {success_rate:.0%} is below the "
+            f"{args.min_success_rate:.0%} threshold",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/src/wet_mcp/alembic/versions/docs_005_metadata_seeded_at.py
+++ b/src/wet_mcp/alembic/versions/docs_005_metadata_seeded_at.py
@@ -1,0 +1,79 @@
+"""Separate "metadata seeded" from "docs indexed" on ``libraries``.
+
+Adds the nullable ``libraries.metadata_seeded_at`` column and repairs the
+rows that the previous behaviour mislabelled.
+
+Before this revision ``DocsDB.upsert_library`` stamped ``last_indexed_at``
+on every write, including the metadata-only Tier 1 warmup seed, which
+indexes nothing. A database could therefore claim 50 freshly indexed
+libraries while holding zero versions and zero chunks — and the warmup's
+own 7-day freshness gate read that same column, so it was satisfied by the
+very write it was meant to guard.
+
+The data repair keys off ownership of an indexed version: a library with
+no ``versions`` row at ``status = 'indexed'`` was never indexed, so its
+``last_indexed_at`` can only have come from the old seed stamp (or from the
+``docs_002`` ``last_indexed_at = updated_at`` backfill). Those stamps move
+to ``metadata_seeded_at``; genuinely indexed libraries keep theirs.
+
+Idempotent: the column add is guarded by ``PRAGMA table_info`` and the
+repair matches nothing on a second run (``last_indexed_at`` is already
+NULL for the affected rows).
+
+Revision ID: docs_005_metadata_seeded_at
+Revises: docs_004_chunk_summaries
+Create Date: 2026-08-01
+"""
+
+from __future__ import annotations
+
+import logging
+
+from alembic import op
+
+# Revision identifiers used by Alembic.
+revision = "docs_005_metadata_seeded_at"
+down_revision = "docs_004_chunk_summaries"
+branch_labels = None
+depends_on = None
+
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    """Add ``metadata_seeded_at`` and relabel seed-only index stamps."""
+    existing_cols = {
+        row[0]
+        for row in op.get_bind()
+        .exec_driver_sql("SELECT name FROM pragma_table_info(?)", ("libraries",))
+        .fetchall()
+    }
+    if "metadata_seeded_at" not in existing_cols:
+        op.execute("ALTER TABLE libraries ADD COLUMN metadata_seeded_at REAL")
+
+    op.execute(
+        """
+        UPDATE libraries
+           SET metadata_seeded_at = COALESCE(metadata_seeded_at, last_indexed_at),
+               last_indexed_at = NULL
+         WHERE last_indexed_at IS NOT NULL
+           AND NOT EXISTS (
+               SELECT 1 FROM versions v
+                WHERE v.library_id = libraries.id AND v.status = 'indexed'
+           )
+        """
+    )
+
+
+def downgrade() -> None:
+    """No-op: dropping the column would discard the seed timestamps.
+
+    The relabelled ``last_indexed_at`` values cannot be reconstructed, and
+    the added column is nullable, so leaving it in place is harmless when
+    rolling back to ``docs_004_chunk_summaries``.
+    """
+    logger.warning(
+        "docs_005_metadata_seeded_at downgrade is a no-op; "
+        "libraries.metadata_seeded_at is left in place"
+    )

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -84,6 +84,7 @@ _LIBRARIES_COLUMNS = {
     "package_managers",
     "tier",
     "last_indexed_at",
+    "metadata_seeded_at",
     "total_versions",
     "discovery_version",
     "created_at",
@@ -240,6 +241,7 @@ class DocsDB:
         self._model_identity = model_identity
         self._reindex_on_model_change = reindex_on_model_change
         self._vec_enabled = False
+        self._seed_stamp_migration_pending = False
 
         db_path.parent.mkdir(parents=True, exist_ok=True)
         # check_same_thread=False allows the connection to be used from
@@ -279,7 +281,39 @@ class DocsDB:
         self._create_vector_table()
         self._create_project_context_table()
         self._create_store_meta_table()
+        if self._seed_stamp_migration_pending:
+            # Deferred until the versions table exists — the relabel needs it.
+            self._migrate_seed_stamps_off_last_indexed_at()
+            self._seed_stamp_migration_pending = False
         self._conn.commit()
+
+    def _migrate_seed_stamps_off_last_indexed_at(self) -> None:
+        """Move seed-only ``last_indexed_at`` stamps into ``metadata_seeded_at``.
+
+        A library that owns no ``status = 'indexed'`` version was never
+        indexed, so its ``last_indexed_at`` can only have come from the old
+        ``upsert_library`` stamp (or the ``docs_002`` ``updated_at``
+        backfill). Leaving it in place would keep the Tier 1 freshness gate
+        satisfied forever on an empty database. Mirrors the
+        ``docs_005_metadata_seeded_at`` Alembic migration for DBs that reach
+        ``DocsDB`` first.
+        """
+        cur = self._conn.execute("""
+            UPDATE libraries
+               SET metadata_seeded_at = COALESCE(metadata_seeded_at, last_indexed_at),
+                   last_indexed_at = NULL
+             WHERE last_indexed_at IS NOT NULL
+               AND NOT EXISTS (
+                   SELECT 1 FROM versions v
+                    WHERE v.library_id = libraries.id AND v.status = 'indexed'
+               )
+        """)
+        self._conn.commit()
+        if cur.rowcount:
+            logger.info(
+                f"Relabelled {cur.rowcount} metadata-only library seeds "
+                "(last_indexed_at -> metadata_seeded_at)"
+            )
 
     def _create_store_meta_table(self) -> None:
         # Key/value metadata for store-level invariants (B2: embedding-model
@@ -421,6 +455,7 @@ class DocsDB:
                 package_managers TEXT,
                 tier INTEGER NOT NULL DEFAULT 2,
                 last_indexed_at REAL,
+                metadata_seeded_at REAL,
                 total_versions INTEGER NOT NULL DEFAULT 0,
                 discovery_version INTEGER DEFAULT 0,
                 created_at REAL NOT NULL,
@@ -459,11 +494,20 @@ class DocsDB:
                 "ALTER TABLE libraries ADD COLUMN total_versions INTEGER NOT NULL DEFAULT 0",
                 "total_versions",
             ),
+            (
+                "ALTER TABLE libraries ADD COLUMN metadata_seeded_at REAL",
+                "metadata_seeded_at",
+            ),
         ):
             try:
                 self._conn.execute(sql)
                 self._conn.commit()
                 logger.debug(f"Migrated libraries table: added {col_name}")
+                if col_name == "metadata_seeded_at":
+                    # The column is new here, so this DB was written by a
+                    # build where upsert_library stamped last_indexed_at for
+                    # metadata-only seeds. Relabel those stamps once.
+                    self._seed_stamp_migration_pending = True
             except sqlite3.OperationalError:
                 pass  # Column already exists
 
@@ -676,9 +720,6 @@ class DocsDB:
         if tier is not None and "tier" in existing_cols:
             updates.append("tier = ?")
             params.append(int(tier))
-        if "last_indexed_at" in existing_cols:
-            updates.append("last_indexed_at = ?")
-            params.append(now)
 
         updates.append("discovery_version = ?")
         params.append(DISCOVERY_VERSION)
@@ -741,7 +782,6 @@ class DocsDB:
             ("github_url", github_url, False),
             ("package_managers", pkg_json, False),
             ("tier", tier, False),
-            ("last_indexed_at", now, True),
         ):
             if col_name in existing_cols and (value is not None or include_when_none):
                 cols.append(col_name)
@@ -773,7 +813,11 @@ class DocsDB:
     ) -> str:
         """Create or update a library. Returns library ID.
 
-        Automatically stamps the current ``DISCOVERY_VERSION``.
+        Automatically stamps the current ``DISCOVERY_VERSION``. It does
+        *not* touch ``last_indexed_at``: writing metadata says nothing about
+        whether chunks landed, and ``mark_library_indexed`` is the only
+        writer that knows. Metadata-only seeding records its own progress
+        via ``mark_metadata_seeded``.
 
         Phase 2 (spec §5.4) adds optional metadata: ``tier`` (1 curated /
         2 on-demand), ``package_managers`` (JSON list), ``homepage``,
@@ -867,6 +911,21 @@ class DocsDB:
         self._conn.execute(
             "UPDATE libraries SET " + ", ".join(sets) + " WHERE id = ?",
             params,
+        )
+        self._conn.commit()
+
+    def mark_metadata_seeded(self, library_id: str) -> None:
+        """Record a metadata-only seed pass (Tier 1 warmup freshness anchor).
+
+        Separate from ``last_indexed_at`` so a seeded-but-unindexed library
+        is distinguishable from an indexed one. Silently no-ops on legacy
+        databases that lack the column.
+        """
+        if "metadata_seeded_at" not in self._get_table_columns("libraries"):
+            return
+        self._conn.execute(
+            "UPDATE libraries SET metadata_seeded_at = ? WHERE id = ?",
+            (_now_ts(), library_id),
         )
         self._conn.commit()
 

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1300,7 +1300,13 @@ async def search(  # noqa: PLR0913
             # canonical/alias name. We always look up by name first so the
             # caller can pass either form.
             resolved = await asyncio.to_thread(resolve_library, _docs_db, library, 1)
-            if not resolved:
+            # Ingest when the library is unknown OR known-but-empty. Tier 1
+            # warmup seeds 50 curated libraries metadata-only, so those names
+            # always resolve; gating on `not resolved` alone left exactly them
+            # stuck at zero chunks forever. `latest_version` is populated from
+            # get_best_version, i.e. it is None until a version reaches
+            # status='indexed'.
+            if not resolved or resolved[0].get("latest_version") is None:
                 # Tier 2 lazy ingest: fire-and-forget, return progress hint.
                 asyncio.create_task(ingest_tier2(_docs_db, library))
                 return {

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2553,6 +2553,15 @@ async def _background_index_and_search(
             embeddings=embeddings,
         )
         _docs_db.mark_version_indexed(ver_id, page_count, len(all_chunks))
+        # last_indexed_at is now written only by mark_library_indexed; before
+        # the seed/index split upsert_library stamped it as a side effect,
+        # which hid the fact that this path never marked the library. Left
+        # out, a library indexed here would read as permanently stale.
+        # total_versions is deliberately not passed: this path takes a
+        # caller-supplied `version`, so one library can own several rows in
+        # `versions` (the table is UNIQUE(library_id, version)) and a
+        # hardcoded 1 would be wrong.
+        _docs_db.mark_library_indexed(lib_id)
         logger.info(
             f"Background indexing complete for '{library}'. Pages: {page_count}, Chunks: {len(all_chunks)}"
         )

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -3517,6 +3517,35 @@ def _parse_objects_inv(data: bytes, base_url: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+def _page_from_extract_result(result: dict) -> dict | None:
+    """Project one ``crawler.extract`` result into a docs page dict.
+
+    ``extract`` has two result shapes: web pages come back as smart-chunks
+    (``markdown`` / ``clean_text`` / ``metadata``), documents come back from
+    the markitdown branch (``content`` / ``title``). This crawler only ever
+    read the markitdown keys, so every web page failed the truthiness check
+    and was discarded — which is why the Tier 1 index produced zero chunks
+    for every library. Returns ``None`` for errored or empty results.
+    """
+    if result.get("error"):
+        return None
+    content = (
+        result.get("markdown")
+        or result.get("clean_text")
+        or result.get("content")
+        or ""
+    )
+    if not content:
+        return None
+    metadata = result.get("metadata")
+    title = (metadata or {}).get("title") if isinstance(metadata, dict) else None
+    return {
+        "url": result.get("url", ""),
+        "title": title or result.get("title", ""),
+        "content": content,
+    }
+
+
 async def fetch_docs_pages(
     docs_url: str,
     query: str = "",
@@ -3654,18 +3683,14 @@ async def fetch_docs_pages(
     # Process root page results
     blocked_count = 0
     for r in root_results:
-        if r.get("content") and not r.get("error"):
-            if _is_blocked_content(r["content"]):
-                blocked_count += 1
-                continue
-            pages.append(
-                {
-                    "url": r["url"],
-                    "title": r.get("title", ""),
-                    "content": r["content"],
-                }
-            )
-            pending_urls.extend(_collect_links(r))
+        page = _page_from_extract_result(r)
+        if page is None:
+            continue
+        if _is_blocked_content(page["content"]):
+            blocked_count += 1
+            continue
+        pages.append(page)
+        pending_urls.extend(_collect_links(r))
 
     # Early exit: if root page was blocked, all other pages on the same
     # domain will also be blocked — skip expensive crawling and return
@@ -3732,19 +3757,15 @@ async def fetch_docs_pages(
             batch1_results = json.loads(batch1_str)
 
             for br in batch1_results:
-                if br.get("content") and not br.get("error"):
-                    if _is_blocked_content(br["content"]):
-                        blocked_count += 1
-                        continue
-                    pages.append(
-                        {
-                            "url": br["url"],
-                            "title": br.get("title", ""),
-                            "content": br["content"],
-                        }
-                    )
-                    # Depth-2: discover links from fetched pages
-                    pending_urls.extend(_collect_links(br))
+                page = _page_from_extract_result(br)
+                if page is None:
+                    continue
+                if _is_blocked_content(page["content"]):
+                    blocked_count += 1
+                    continue
+                pages.append(page)
+                # Depth-2: discover links from fetched pages
+                pending_urls.extend(_collect_links(br))
         except TimeoutError:
             logger.warning(
                 f"Round 1 crawl timed out after {batch_timeout}s "
@@ -3767,17 +3788,13 @@ async def fetch_docs_pages(
                 )
                 batch2_results = json.loads(batch2_str)
                 for br in batch2_results:
-                    if br.get("content") and not br.get("error"):
-                        if _is_blocked_content(br["content"]):
-                            blocked_count += 1
-                            continue
-                        pages.append(
-                            {
-                                "url": br["url"],
-                                "title": br.get("title", ""),
-                                "content": br["content"],
-                            }
-                        )
+                    page = _page_from_extract_result(br)
+                    if page is None:
+                        continue
+                    if _is_blocked_content(page["content"]):
+                        blocked_count += 1
+                        continue
+                    pages.append(page)
             except TimeoutError:
                 logger.warning(
                     f"Round 2 crawl timed out after {batch_timeout}s "
@@ -4007,7 +4024,13 @@ async def ingest_tier2(db: Any, library_name: str) -> dict:
     if not discovery:
         return {"status": "not_found", "library_name": library_name}
 
-    docs_url = discovery.get("docs_url")
+    # ``discover_library`` publishes the probed docs URL under ``homepage``
+    # (see ``_finalize_discovery_result``); no registry adapter ever emits a
+    # ``docs_url`` key. Reading only ``docs_url`` therefore always missed and
+    # fell through to ``repository``, which npm/PyPI report as a VCS URL
+    # (``git+https://...git``) that the crawler rejects as unsafe — every
+    # library ingested zero pages.
+    docs_url = discovery.get("docs_url") or discovery.get("homepage")
     repo_url = discovery.get("repository") or discovery.get("github_url")
     registry = discovery.get("registry")
     description = discovery.get("description")
@@ -4016,16 +4039,21 @@ async def ingest_tier2(db: Any, library_name: str) -> dict:
     if registry:
         package_managers = [registry]
 
+    # A curated Tier 1 seed can reach this path too: docs_query now fires
+    # ingestion for libraries that resolve but hold no indexed version. Keep
+    # its tier and display label instead of demoting the row to a Tier 2
+    # entry named after the caller's raw query string.
+    existing = db.get_library(library_name) or {}
     lib_id = db.upsert_library(
         name=library_name,
         docs_url=docs_url,
         registry=registry,
         description=description,
-        tier=2,
+        tier=existing.get("tier") or 2,
         package_managers=package_managers or None,
         homepage=homepage,
         github_url=repo_url if repo_url and "github.com" in (repo_url or "") else None,
-        canonical_name=library_name,
+        canonical_name=existing.get("canonical_name") or library_name,
     )
     ver_id = db.upsert_version(
         library_id=lib_id,
@@ -4054,11 +4082,10 @@ async def ingest_tier2(db: Any, library_name: str) -> dict:
     if pages:
         chunks: list[dict] = []
         for page in pages:
-            page_chunks = chunk_markdown(
-                page["content"],
-                page.get("url", ""),
-                page.get("title", ""),
-            )
+            # chunk_markdown's third parameter is max_chunk_size, not title —
+            # passing the page title there raised TypeError. It never fired
+            # because `pages` was always empty (see _page_from_extract_result).
+            page_chunks = chunk_markdown(page["content"], url=page.get("url", ""))
             chunks.extend(page_chunks)
         if chunks:
             db.add_chunks(version_id=ver_id, library_id=lib_id, chunks=chunks)

--- a/src/wet_mcp/sources/tier1_warmup.py
+++ b/src/wet_mcp/sources/tier1_warmup.py
@@ -12,8 +12,11 @@ to:
   via the web-core ``library_docs_strategy`` (Task 10) on a weekly cron.
 
 Freshness: a library is considered "warm" when its
-``last_indexed_at`` is within 7 days (spec section 3 Tier 1 freshness
-target). ``maybe_warm(force=True)`` re-seeds metadata regardless.
+``metadata_seeded_at`` is within 7 days (spec section 3 Tier 1 freshness
+target). ``maybe_warm(force=True)`` re-seeds metadata regardless. The gate
+deliberately does *not* read ``last_indexed_at``: that column means "chunks
+landed", which seeding never does, so keying off it made the warmup's own
+write satisfy its own freshness check.
 """
 
 from __future__ import annotations
@@ -63,14 +66,14 @@ def maybe_warm(db: Any, force: bool = False) -> dict:
         if (
             not force
             and existing
-            and existing.get("last_indexed_at")
-            and (now - existing["last_indexed_at"]) < _FRESHNESS_WINDOW_SECONDS
+            and existing.get("metadata_seeded_at")
+            and (now - existing["metadata_seeded_at"]) < _FRESHNESS_WINDOW_SECONDS
         ):
             skipped_fresh += 1
             continue
 
         try:
-            db.upsert_library(
+            lib_id = db.upsert_library(
                 name=name,
                 canonical_name=entry.get("canonical_name", name),
                 homepage=entry.get("homepage"),
@@ -78,6 +81,7 @@ def maybe_warm(db: Any, force: bool = False) -> dict:
                 package_managers=entry.get("package_managers"),
                 tier=1,
             )
+            db.mark_metadata_seeded(lib_id)
             seeded += 1
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(f"Tier 1 warmup failed for {name}: {exc}")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1840,3 +1840,133 @@ class TestEmbeddingModelIdentityGuard:
             assert vec_count == 0
         finally:
             db2.close()
+
+
+# ---------------------------------------------------------------------------
+# Seed-vs-indexed separation (metadata_seeded_at)
+# ---------------------------------------------------------------------------
+_PRE_FIX_LIBRARIES_DDL = """
+    CREATE TABLE libraries (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        docs_url TEXT,
+        registry TEXT,
+        description TEXT,
+        canonical_name TEXT,
+        homepage TEXT,
+        github_url TEXT,
+        package_managers TEXT,
+        tier INTEGER NOT NULL DEFAULT 2,
+        last_indexed_at REAL,
+        total_versions INTEGER NOT NULL DEFAULT 0,
+        discovery_version INTEGER DEFAULT 0,
+        created_at REAL NOT NULL,
+        updated_at REAL NOT NULL
+    )
+"""
+
+_PRE_FIX_VERSIONS_DDL = """
+    CREATE TABLE versions (
+        id TEXT PRIMARY KEY,
+        library_id TEXT NOT NULL,
+        version TEXT NOT NULL DEFAULT 'latest',
+        docs_url TEXT,
+        indexed_at REAL,
+        page_count INTEGER DEFAULT 0,
+        chunk_count INTEGER DEFAULT 0,
+        status TEXT DEFAULT 'pending',
+        release_date REAL,
+        source_url TEXT,
+        UNIQUE(library_id, version)
+    )
+"""
+
+
+def _make_pre_fix_db(db_path):
+    """Build a docs.db in the shape shipped before metadata_seeded_at existed.
+
+    ``seeded-lib`` reproduces the observed bug: a metadata-only Tier 1 seed
+    that upsert_library stamped as freshly indexed while holding zero
+    versions. ``indexed-lib`` is a genuinely indexed library.
+    """
+    import sqlite3 as _sqlite3
+
+    conn = _sqlite3.connect(str(db_path))
+    conn.execute(_PRE_FIX_LIBRARIES_DDL)
+    conn.execute(_PRE_FIX_VERSIONS_DDL)
+    conn.execute(
+        "INSERT INTO libraries (id, name, tier, last_indexed_at, created_at, "
+        "updated_at) VALUES ('seeded', 'react', 1, 1000.0, 1.0, 1.0)"
+    )
+    conn.execute(
+        "INSERT INTO libraries (id, name, tier, last_indexed_at, created_at, "
+        "updated_at) VALUES ('indexed', 'fastapi', 2, 2000.0, 1.0, 1.0)"
+    )
+    conn.execute(
+        "INSERT INTO versions (id, library_id, version, status, chunk_count) "
+        "VALUES ('v1', 'indexed', 'latest', 'indexed', 382)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_pre_fix_db_moves_seed_stamp_to_metadata_seeded_at(tmp_path):
+    """Opening a pre-fix DB relabels bogus last_indexed_at stamps.
+
+    Libraries with no indexed version were never indexed, so their stamp
+    belongs in metadata_seeded_at; libraries that do have one keep theirs.
+    """
+    db_path = tmp_path / "docs.db"
+    _make_pre_fix_db(db_path)
+
+    db = DocsDB(db_path, embedding_dims=0)
+    try:
+        seeded = db._conn.execute(
+            "SELECT last_indexed_at, metadata_seeded_at FROM libraries "
+            "WHERE id = 'seeded'"
+        ).fetchone()
+        assert seeded["last_indexed_at"] is None
+        assert seeded["metadata_seeded_at"] == 1000.0
+
+        indexed = db._conn.execute(
+            "SELECT last_indexed_at, metadata_seeded_at FROM libraries "
+            "WHERE id = 'indexed'"
+        ).fetchone()
+        assert indexed["last_indexed_at"] == 2000.0
+        assert indexed["metadata_seeded_at"] is None
+    finally:
+        db.close()
+
+
+def test_upsert_library_does_not_stamp_last_indexed_at(tmp_path):
+    """upsert_library writes metadata only; last_indexed_at stays untouched."""
+    db = DocsDB(tmp_path / "docs.db", embedding_dims=0)
+    try:
+        lib_id = db.upsert_library(name="react", tier=1)
+        row = db.get_library("react")
+        assert row["last_indexed_at"] is None
+
+        # A second upsert (metadata refresh) must not resurrect the stamp.
+        db.upsert_library(name="react", homepage="https://react.dev", tier=1)
+        assert db.get_library("react")["last_indexed_at"] is None
+
+        # mark_library_indexed remains the single writer of the column.
+        db.mark_library_indexed(lib_id, total_versions=1)
+        assert db.get_library("react")["last_indexed_at"] is not None
+    finally:
+        db.close()
+
+
+def test_mark_metadata_seeded_records_seed_time(tmp_path):
+    """mark_metadata_seeded stamps metadata_seeded_at without claiming index."""
+    db = DocsDB(tmp_path / "docs.db", embedding_dims=0)
+    try:
+        lib_id = db.upsert_library(name="react", tier=1)
+        assert db.get_library("react")["metadata_seeded_at"] is None
+
+        db.mark_metadata_seeded(lib_id)
+        row = db.get_library("react")
+        assert row["metadata_seeded_at"] is not None
+        assert row["last_indexed_at"] is None
+    finally:
+        db.close()

--- a/tests/test_docs_comprehensive.py
+++ b/tests/test_docs_comprehensive.py
@@ -609,3 +609,44 @@ def test_chunk_markdown_large():
     for c in chunks:
         assert c["url"] == "http://test"
         assert c["title"] in ("Title", "Section 1", "Section 2")
+
+
+@pytest.mark.asyncio
+async def test_fetch_docs_pages_reads_smart_chunks_shape():
+    """Web pages come back as smart-chunks, not the markitdown shape.
+
+    ``crawler.extract`` returns ``markdown`` / ``clean_text`` / ``metadata``
+    for scraped pages; only its document branch emits ``content`` + a
+    top-level ``title``. Reading the document keys alone silently dropped
+    every scraped page, so the Tier 1 index produced zero chunks.
+    """
+    with patch(
+        "wet_mcp.sources.crawler.extract", new_callable=AsyncMock
+    ) as mock_extract:
+        mock_extract.return_value = json.dumps(
+            [
+                {
+                    "url": "https://docs.test/",
+                    "markdown": "## Overview\n\nThe library does things.",
+                    "clean_text": "Overview The library does things.",
+                    "structured_data": [],
+                    "code_blocks": [],
+                    "metadata": {"title": "Overview", "headings": []},
+                }
+            ]
+        )
+        with (
+            patch(
+                "wet_mcp.sources.docs._try_sitemap", new_callable=AsyncMock
+            ) as mock_sitemap,
+            patch(
+                "wet_mcp.sources.docs._try_objects_inv", new_callable=AsyncMock
+            ) as mock_objects,
+        ):
+            mock_sitemap.return_value = []
+            mock_objects.return_value = []
+            res = await fetch_docs_pages("https://docs.test/")
+
+    assert len(res) == 1
+    assert res[0]["title"] == "Overview"
+    assert res[0]["content"].startswith("## Overview")

--- a/tests/test_ingest_tier2.py
+++ b/tests/test_ingest_tier2.py
@@ -174,3 +174,81 @@ async def test_ingest_tier2_uses_repo_url_when_no_docs_url(db: DocsDB) -> None:
     ):
         out = await ingest_tier2(db, "bar")
     assert out["status"] in {"ok", "no_chunks"}
+
+
+async def test_ingest_tier2_reads_homepage_when_discovery_has_no_docs_url(
+    db: DocsDB,
+) -> None:
+    """Registry adapters publish the probed docs URL under ``homepage``.
+
+    No adapter emits a ``docs_url`` key, so reading only that one made the
+    ingester fall through to ``repository`` — which npm reports as a
+    ``git+https://...git`` VCS URL that the crawler rejects as unsafe. Every
+    Tier 1 library therefore fetched zero pages.
+    """
+    fetch = AsyncMock(return_value=[])
+    with (
+        patch.object(
+            _docs_mod,
+            "discover_library",
+            new=AsyncMock(
+                return_value={
+                    "homepage": "https://expressjs.com/",
+                    "repository": "git+https://github.com/expressjs/express.git",
+                    "registry": "npm",
+                }
+            ),
+        ),
+        patch.object(_docs_mod, "fetch_docs_pages", new=fetch),
+    ):
+        await ingest_tier2(db, "express")
+
+    assert fetch.await_args.args[0] == "https://expressjs.com/"
+    assert db.get_library("express")["docs_url"] == "https://expressjs.com/"
+
+
+async def test_ingest_tier2_chunks_pages_with_the_real_chunker(db: DocsDB) -> None:
+    """Pages must survive chunk_markdown and land as rows.
+
+    ``chunk_markdown``'s third positional parameter is ``max_chunk_size``,
+    not a title; passing the page title there raised TypeError as soon as
+    a page actually reached the chunker.
+    """
+    body = "\n\n".join(
+        f"## Section {i}\n\nThe library exposes a helper for section {i}. "
+        f"Call it with the options object to configure behaviour."
+        for i in range(6)
+    )
+    pages = [{"url": "https://example.com/guide", "title": "Guide", "content": body}]
+    with (
+        patch.object(
+            _docs_mod,
+            "discover_library",
+            new=AsyncMock(return_value={"homepage": "https://example.com/"}),
+        ),
+        patch.object(_docs_mod, "fetch_docs_pages", new=AsyncMock(return_value=pages)),
+    ):
+        out = await ingest_tier2(db, "example-lib")
+
+    assert out["status"] == "ok"
+    assert out["chunk_count"] > 0
+    stored = db._conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[0]
+    assert stored == out["chunk_count"]
+
+
+async def test_ingest_tier2_keeps_tier1_curation(db: DocsDB) -> None:
+    """A curated seed reaching this path keeps its tier and display label."""
+    db.upsert_library(name="react", canonical_name="React", tier=1)
+    with (
+        patch.object(
+            _docs_mod,
+            "discover_library",
+            new=AsyncMock(return_value={"homepage": "https://react.dev/"}),
+        ),
+        patch.object(_docs_mod, "fetch_docs_pages", new=AsyncMock(return_value=[])),
+    ):
+        await ingest_tier2(db, "react")
+
+    row = db.get_library("react")
+    assert row["tier"] == 1
+    assert row["canonical_name"] == "React"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -271,7 +271,10 @@ def test_alembic_version_advances_through_chain(tmp_path: Path) -> None:
 
     if _has_revision("docs_004_chunk_summaries"):
         command.upgrade(cfg, "head")
-        assert _read_alembic_version(db_path) == "docs_004_chunk_summaries"
+        assert (
+            _read_alembic_version(db_path)
+            == ScriptDirectory.from_config(cfg).get_current_head()
+        )
 
 
 def test_004_adds_summary_columns(tmp_path: Path) -> None:
@@ -369,7 +372,10 @@ def test_full_v1_to_v2_round_trip(tmp_path: Path) -> None:
     run_migrations_on_startup(db_path)
 
     # Version stamp advanced to head.
-    assert _read_alembic_version(db_path) == "docs_004_chunk_summaries"
+    assert (
+        _read_alembic_version(db_path)
+        == ScriptDirectory.from_config(cfg).get_current_head()
+    )
 
     # Pre-existing rows are preserved across all forward migrations.
     conn = sqlite3.connect(str(db_path))
@@ -446,3 +452,86 @@ def test_db_add_chunks_writes_summary_columns_when_present(tmp_path: Path) -> No
     assert row is not None
     assert row["summary"] == "Short overview"
     assert row["summary_provider"] == "gemini-3-flash-preview"
+
+
+def test_005_moves_seed_stamp_into_metadata_seeded_at(tmp_path: Path) -> None:
+    """docs_005 adds metadata_seeded_at and relabels bogus index stamps.
+
+    Pre-fix ``upsert_library`` stamped ``last_indexed_at`` for metadata-only
+    Tier 1 seeds, so an upgraded DB must not keep claiming those libraries
+    are indexed. Rows that really do own an indexed version are untouched.
+    """
+    if not _has_revision("docs_005_metadata_seeded_at"):
+        pytest.skip("docs_005_metadata_seeded_at not yet created")
+
+    db_path = tmp_path / "docs.db"
+    cfg = _make_alembic_cfg(db_path)
+    command.upgrade(cfg, "docs_004_chunk_summaries")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO libraries (id, name, tier, last_indexed_at, created_at, "
+        "updated_at) VALUES ('seeded', 'react', 1, 1000.0, 1.0, 1.0)"
+    )
+    conn.execute(
+        "INSERT INTO libraries (id, name, tier, last_indexed_at, created_at, "
+        "updated_at) VALUES ('indexed', 'fastapi', 2, 2000.0, 1.0, 1.0)"
+    )
+    conn.execute(
+        "INSERT INTO versions (id, library_id, version, status, chunk_count) "
+        "VALUES ('v1', 'indexed', 'latest', 'indexed', 382)"
+    )
+    conn.commit()
+    conn.close()
+
+    command.upgrade(cfg, "docs_005_metadata_seeded_at")
+
+    assert "metadata_seeded_at" in _table_columns(db_path, "libraries")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    rows = {
+        r["id"]: r
+        for r in conn.execute(
+            "SELECT id, last_indexed_at, metadata_seeded_at FROM libraries"
+        ).fetchall()
+    }
+    conn.close()
+
+    assert rows["seeded"]["last_indexed_at"] is None
+    assert rows["seeded"]["metadata_seeded_at"] == 1000.0
+    assert rows["indexed"]["last_indexed_at"] == 2000.0
+    assert rows["indexed"]["metadata_seeded_at"] is None
+
+
+def test_005_is_idempotent(tmp_path: Path) -> None:
+    """Re-running docs_005 does not disturb an already-corrected DB."""
+    if not _has_revision("docs_005_metadata_seeded_at"):
+        pytest.skip("docs_005_metadata_seeded_at not yet created")
+
+    db_path = tmp_path / "docs.db"
+    cfg = _make_alembic_cfg(db_path)
+    command.upgrade(cfg, "docs_004_chunk_summaries")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO libraries (id, name, tier, last_indexed_at, created_at, "
+        "updated_at) VALUES ('seeded', 'react', 1, 1000.0, 1.0, 1.0)"
+    )
+    conn.commit()
+    conn.close()
+
+    command.upgrade(cfg, "docs_005_metadata_seeded_at")
+    # Rewind only the revision pointer (the column + corrected rows stay) and
+    # replay the migration: it must find nothing left to fix.
+    command.stamp(cfg, "docs_004_chunk_summaries")
+    command.upgrade(cfg, "docs_005_metadata_seeded_at")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT last_indexed_at, metadata_seeded_at FROM libraries WHERE id = 'seeded'"
+    ).fetchone()
+    conn.close()
+    assert row["last_indexed_at"] is None
+    assert row["metadata_seeded_at"] == 1000.0

--- a/tests/test_phase2_dispatch.py
+++ b/tests/test_phase2_dispatch.py
@@ -62,6 +62,39 @@ async def test_docs_query_unknown_library_triggers_indexing_hint(
     assert data["results"] == []
 
 
+async def test_docs_query_seeded_library_without_chunks_triggers_ingest(
+    docs_db, monkeypatch
+) -> None:
+    """A resolvable library holding zero indexed versions must still ingest.
+
+    Tier 1 warmup seeds 50 curated libraries metadata-only, so
+    ``resolve_library`` never returns ``[]`` for them. Gating ingestion on
+    ``not resolved`` therefore left exactly those libraries stuck at zero
+    chunks forever.
+    """
+    import asyncio
+
+    from wet_mcp.sources import docs as docs_mod
+
+    ingested: list[str] = []
+
+    async def _fake_ingest(db, library_name):
+        ingested.append(library_name)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(docs_mod, "ingest_tier2", _fake_ingest)
+    docs_db.upsert_library(name="react", canonical_name="React", tier=1)
+
+    out = await _call_search(action="docs_query", library="react", query="useState")
+    data = payload(out)
+    assert data["status"] == "indexing_in_progress"
+    assert data["library"] == "react"
+    assert data["results"] == []
+
+    await asyncio.sleep(0)
+    assert ingested == ["react"]
+
+
 async def test_docs_query_known_library_returns_results(docs_db) -> None:
     lib_id = docs_db.upsert_library(name="react")
     ver_id = docs_db.upsert_version(library_id=lib_id, version="latest")

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -1650,6 +1650,75 @@ async def test_background_index_fetch_timeout():
 
 
 @pytest.mark.asyncio
+async def test_background_index_marks_library_indexed(tmp_path):
+    """The background index path must stamp libraries.last_indexed_at.
+
+    Before the seed/index split, ``upsert_library`` stamped that column as a
+    side effect of writing metadata, which hid the fact that this path never
+    calls ``mark_library_indexed``. Now that only ``mark_library_indexed``
+    writes it, a library indexed here would stay NULL forever and read as
+    permanently stale (``hooks/SessionStart_check_docs_freshness.sh``).
+    """
+    from wet_mcp.db import DocsDB
+
+    db = DocsDB(tmp_path / "docs.db", embedding_dims=0)
+    lib_id = db.upsert_library(name="testlib", docs_url="http://docs")
+    ver_id = db.upsert_version(
+        library_id=lib_id, version="latest", docs_url="http://docs"
+    )
+    before = db.get_library("testlib")
+    assert before is not None
+    assert before["last_indexed_at"] is None
+
+    chunks = [
+        {
+            "url": "http://docs",
+            "title": "Guide",
+            "content": f"chunk {i}",
+            "heading_path": "Guide",
+            "chunk_index": i,
+        }
+        for i in range(3)
+    ]
+    previous_db = server._docs_db
+    server._docs_db = db
+    try:
+        with (
+            patch(
+                "wet_mcp.sources.docs._normalize_docs_url", return_value="http://docs"
+            ),
+            patch(
+                "wet_mcp.server._fetch_and_chunk_docs",
+                new_callable=AsyncMock,
+                return_value=(chunks, 5),
+            ),
+            patch(
+                "wet_mcp.embedder.resolve_embed_backend_for_request",
+                return_value=None,
+            ),
+        ):
+            await server._background_index_and_search(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id=lib_id,
+                ver_id=ver_id,
+            )
+
+        after = db.get_library("testlib")
+        assert after is not None
+        assert after["last_indexed_at"] is not None
+        assert db.get_best_version(lib_id, None) is not None
+    finally:
+        server._docs_db = previous_db
+        db.close()
+
+
+@pytest.mark.asyncio
 @_skip_win_iocp
 async def test_background_index_with_searxng_fallback():
     """Test background indexing SearXNG fallback (lines 1185-1207)."""

--- a/tests/test_tier1_warmup.py
+++ b/tests/test_tier1_warmup.py
@@ -101,19 +101,66 @@ def test_tier1_warmup_force_reseeds(db: DocsDB) -> None:
 
 
 def test_tier1_warmup_re_seeds_when_stale(db: DocsDB) -> None:
-    """Library with last_indexed_at older than 7 days is re-seeded."""
+    """Library with metadata_seeded_at older than 7 days is re-seeded."""
     maybe_warm(db)
 
-    # Manually back-date react's last_indexed_at by 10 days.
+    # Manually back-date react's metadata_seeded_at by 10 days.
     stale_ts = time.time() - (10 * 24 * 60 * 60)
     db._conn.execute(
-        "UPDATE libraries SET last_indexed_at = ? WHERE name = ?",
+        "UPDATE libraries SET metadata_seeded_at = ? WHERE name = ?",
         (stale_ts, "react"),
     )
     db._conn.commit()
 
     summary = maybe_warm(db)
     assert summary["seeded"] >= 1
+
+
+def test_tier1_warmup_does_not_stamp_last_indexed_at(db: DocsDB) -> None:
+    """Metadata-only seeding must not claim the libraries are indexed.
+
+    ``last_indexed_at`` belongs to ``mark_library_indexed`` — the only
+    writer that knows chunks actually landed. The warmup records its own
+    progress in ``metadata_seeded_at`` instead, so a seeded-but-unindexed
+    DB is distinguishable from an indexed one.
+    """
+    maybe_warm(db)
+
+    assert (
+        db._conn.execute(
+            "SELECT COUNT(*) FROM libraries WHERE last_indexed_at IS NOT NULL"
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        db._conn.execute(
+            "SELECT COUNT(*) FROM libraries WHERE metadata_seeded_at IS NOT NULL"
+        ).fetchone()[0]
+        >= 50
+    )
+    # The seed writes no versions and no chunks — that is the point.
+    assert db._conn.execute("SELECT COUNT(*) FROM versions").fetchone()[0] == 0
+    assert db._conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[0] == 0
+
+
+def test_tier1_warmup_freshness_gate_ignores_last_indexed_at(db: DocsDB) -> None:
+    """A fresh last_indexed_at must not satisfy the seed freshness gate.
+
+    Pre-fix the warmup's own ``upsert_library`` write stamped
+    ``last_indexed_at``, so the gate was satisfied by the very write it was
+    supposed to guard.
+    """
+    maybe_warm(db)
+
+    stale_ts = time.time() - (10 * 24 * 60 * 60)
+    db._conn.execute(
+        "UPDATE libraries SET metadata_seeded_at = ?, last_indexed_at = ? "
+        "WHERE name = ?",
+        (stale_ts, time.time(), "react"),
+    )
+    db._conn.commit()
+
+    assert maybe_warm(db)["seeded"] == 1
 
 
 def test_tier1_warmup_total_matches_fixture(db: DocsDB) -> None:


### PR DESCRIPTION
## Hiện trạng quan sát được

`docs.db` sau nhiều tuần chạy: **50 libraries / 0 versions / 0 doc_chunks**. Con số 50
đúng bằng số entry trong `src/wet_mcp/data/tier1_libraries.json`, nghĩa là toàn bộ nội
dung DB đến từ Tier 1 warmup seed metadata; `versions = 0` chứng minh `upsert_version`
chưa từng chạy.

Song song, job `refresh-tier1` (cron chủ nhật, `.github/workflows/ci.yml`) chạy
`scripts/build_tier1_index.py` 12 lần và báo 12/12 `success`, nhưng artifact metrics của
lần đầu (2026-05-10) và lần mới nhất (2026-07-26) giống hệt nhau sau 11 tuần:
`total_libraries 50 / no_chunks 49 / no_docs 1 (qwik) / sum page_count 0 /
sum chunk_count 0`.

## Bốn cơ chế khoá

**1. Seed tự đóng dấu "đã index".** `DocsDB.upsert_library` stamp `last_indexed_at = now`
ở cả nhánh update lẫn insert, kể cả khi chỉ ghi metadata. `tier1_warmup.maybe_warm` lại
lấy chính cột đó làm cổng freshness 7 ngày, nên lần seed đầu tiên tự thoả mãn cổng của
chính nó. Lần gọi thứ hai trả `{'total': 50, 'skipped_fresh': 50, 'seeded': 0}` vĩnh viễn.

**2. Điều kiện ingest ở server sai.** `server.py` `case "docs_query"` chỉ bắn
`ingest_tier2` khi `not resolved`. 50 thư viện đã seed thì luôn resolve được, nên
`query_docs` trả `[]` im lặng và không ghi gì. Đúng 50 thư viện curated bị kẹt.

**3. Đường ingest chết ở ba điểm** (làm chết cả nhánh cron lẫn nhánh lazy):

- `fetch_docs_pages` đọc `r["content"]` / `r["title"]`, nhưng `crawler.extract` trả về
  smart-chunks (`markdown` / `clean_text` / `metadata.title`) cho trang web — chỉ nhánh
  markitdown (tài liệu) mới có `content` + `title` ở cấp cao nhất. Mọi trang web rớt ở
  kiểm tra truthiness, nên `page_count = 0` với tất cả thư viện.
- `ingest_tier2` đọc `discovery.get("docs_url")`, nhưng `discover_library` publish URL
  docs dưới khoá `homepage` (xem `_finalize_discovery_result`); không adapter registry
  nào phát khoá `docs_url`. Nó rơi xuống `repository`, thứ npm/PyPI trả về dạng
  `git+https://...git` và bị crawler từ chối vì unsafe.
- `chunk_markdown(page["content"], url, title)` — tham số vị trí thứ ba là
  `max_chunk_size` chứ không phải title, nên ném `TypeError` ngay khi có trang thật đi
  qua. Bug này ẩn suốt vì `pages` luôn rỗng.

**4. CI xanh giả.** `scripts/build_tier1_index.py` `return 0` vô điều kiện: 50/50 thất
bại vẫn exit 0, nên cron xanh 12 tuần liền trên một database rỗng.

## Cách phá vòng lặp

- Tách "seed metadata" khỏi "đã index": `upsert_library` không còn chạm
  `last_indexed_at` (cột đó thuộc về `mark_library_indexed` — writer duy nhất biết chunk
  đã đáp). Thêm cột `libraries.metadata_seeded_at` + `DocsDB.mark_metadata_seeded`, và
  cổng freshness của `maybe_warm` chuyển sang đọc cột mới.
- `server.py`: bắn ingest khi thư viện **chưa từng thấy HOẶC resolve được nhưng rỗng** —
  `if not resolved or resolved[0].get("latest_version") is None`. `latest_version` lấy từ
  `get_best_version`, chỉ khác `None` khi có version `status='indexed'`, nên tín hiệu này
  đúng cho cả backend SQLite lẫn CF D1 mà không phải sửa `db_cf.py`.
- `_page_from_extract_result` chuẩn hoá cả hai hình dạng kết quả của `extract`
  (smart-chunks cho trang web, markitdown cho tài liệu) tại một chỗ, dùng cho cả ba vòng
  thu trang.
- `ingest_tier2` đọc `docs_url` rồi mới tới `homepage`, gọi `chunk_markdown` đúng chữ ký,
  và giữ nguyên `tier` + `canonical_name` của bản ghi curated đã có (vì fix ở server giờ
  đưa cả seed Tier 1 đi qua hàm này, trước đây nó hardcode `tier=2`).
- `scripts/build_tier1_index.py`: bỏ cờ giả `--upload-snapshot` (chỉ in một dòng chữ,
  không upload gì), thêm `--min-success-rate` (mặc định 0.8) và **exit 1** khi tỉ lệ thư
  viện có chunk thấp hơn ngưỡng, kèm khối tóm tắt in ra console thay vì chỉ ghi JSON.
  Bước upload artifact trong workflow thêm `if: always()` để lần chạy hỏng vẫn giữ được
  file metrics mà đọc.

- Đường index nền (`_background_index_and_search`) lưu chunk và gọi
  `mark_version_indexed` nhưng chưa bao giờ gọi `mark_library_indexed` — trước đây không
  lộ vì `upsert_library` đóng dấu hộ, đúng cái dấu sai mà PR này gỡ. Nay gọi
  `mark_library_indexed(lib_id)` ngay sau đó. **Cố ý không truyền `total_versions`**:
  đường này nhận `version` từ caller nên một thư viện có thể sở hữu nhiều hàng trong
  `versions` (bảng khai `UNIQUE(library_id, version)`) — đo thật được 3 hàng cho cùng một
  `library_id`, trong khi hằng số 1 sẽ ghi sai. `ingest_tier2` giữ nguyên
  `total_versions=1` vì nó luôn upsert đúng `version="latest"`.

## Migration xử lý dữ liệu cũ

DB đang tồn tại có 50 dòng mang `last_indexed_at` sai. Cả hai đường khởi động đều sửa
chúng, idempotent và hội tụ về cùng một kết quả:

- `DocsDB._create_libraries_table` (vòng `ALTER TABLE` sẵn có) chỉ đặt cờ repair khi cột
  `metadata_seeded_at` thật sự vừa được thêm, rồi chạy relabel sau khi bảng `versions`
  đã tồn tại.
- Alembic `docs_005_metadata_seeded_at` chạy đúng câu `UPDATE` đó cho DB đi qua đường
  Alembic trước.

Quy tắc relabel: dòng nào có `last_indexed_at` **và không** sở hữu version
`status='indexed'` thì giá trị đó chuyển sang `metadata_seeded_at`, `last_indexed_at`
đặt về `NULL`. Thư viện đã index thật giữ nguyên. `downgrade()` cố ý no-op: drop cột sẽ
làm mất mốc seed, mà cột thì nullable nên vô hại.

## Kiểm chứng thật (chạy `scripts/build_tier1_index.py` đủ 50 thư viện, không mock)

| | trước | sau |
|---|---|---|
| libraries có chunk | 0/50 | **45/50 (90%)** |
| pages | 0 | **648** |
| chunks | 0 | **9183** |
| versions `status='indexed'` | 0 | **45** |
| `libraries.metadata_seeded_at IS NOT NULL` | (cột chưa có) | 50 |
| `libraries.last_indexed_at IS NOT NULL` | 50 (sai) | 45 (đúng) |
| exit code khi index được 0 chunk | 0 | 1 |

5 thư viện còn lại: `qwik` (`no_docs` — registry không có docs_url lẫn repo_url) và
`flask` / `pytest` / `requests` / `celery` (`no_chunks` — bị chặn hoặc timeout ở tầng
crawler, không phải lỗi của đường ingest).

## Còn thấy nhưng cố ý KHÔNG sửa trong PR này

- `_collect_links` trong `fetch_docs_pages` đọc `result["links"]["internal"]`, khoá mà
  `crawler.extract` không bao giờ phát ra. Depth-crawl coi như chết; số trang hiện chỉ
  đến từ sitemap / `objects.inv`. Thử khôi phục bằng cách parse link trong markdown thì
  react tăng 1 -> 50 trang nhưng fastapi tụt 50 -> 1 trang (một vòng batch bị vứt trọn
  khi `batch_timeout`), nên đã revert để giữ diff hẹp.
- Các điểm nuốt lỗi im lặng: `server.py` 2451-2455, 2509-2516, 2539-2540, 2554-2555,
  2840-2841 và `db.py` 1022-1032.
- Thiết kế job `refresh-tier1`: nó build index trên runner ephemeral rồi chỉ upload
  `tier1_index_metrics.json`, không ai upload DB. Đây là quyết định thiết kế (đẩy sang
  D1? bỏ hẳn?) nên để lại cho chủ repo chốt.
- `tests/test_config.py::test_resolve_embedding_backend_none` đỏ sẵn trên `origin/main`
  (API key thật lọt vào `Settings()` trước khi `mock.patch.dict(..., clear=True)` kịp
  chặn) — không thuộc phạm vi PR này.
