### PR TITLE
fix: rewrite optimisation comments in the voice of each file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,19 @@ dependencies = [
     "n24q02m-mcp-core[llm]>=1.21.0,<2",
     # Schema migrations (auto-migrate-on-startup with backup)
     "alembic>=1.18.5",
-    # Pin fastmcp (transitive via mcp-core) to prevent Renovate lockFileMaintenance
-    # downgrading to CVE-vulnerable 2.x (5 CVEs including critical SSRF).
-    # Must stay >=3.2.3,<4 until mcp-core bumps its own floor past 3.x.
+    # fastmcp arrives transitively via mcp-core; both bounds are pinned here,
+    # for different reasons.
+    # Floor: keeps a Renovate lockFileMaintenance refresh from resolving back
+    # to fastmcp 2.x, which carries 5 CVEs including a critical SSRF.
+    # Ceiling: fastmcp 4 moves the runtime onto fastmcp-slim and the protocol
+    # library from the MCP Python SDK v1 to v2 (`mcp>=2,<3`), where `mcp.types`
+    # is a re-export of the separate `mcp-types` package and its models rename
+    # every field to snake_case, keeping the camelCase spellings only as
+    # Pydantic aliases. mcp-core constrains just the floor (`fastmcp>=3.4.4`,
+    # no ceiling of its own), so without one here a lockfile refresh would take
+    # that major bump on its own. Lift it deliberately, alongside mcp-core,
+    # after re-checking the SDK surfaces this server touches directly — the
+    # ToolAnnotations built at each tool definition in server.py above all.
     "fastmcp>=3.4.4,<4",
     # Google Drive sync
     "google-api-python-client>=2.198.0",

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -120,8 +120,8 @@ def _build_fts_queries(query: str) -> list[str]:
     words (any language) and the PHRASE->AND->OR fallback ensures precision
     first, then recall.
     """
-    # ⚡ Bolt Optimization: str.split() without arguments automatically splits by
-    # arbitrary whitespace and discards empty strings, making .strip() redundant.
+    # split() with no argument splits on arbitrary whitespace and drops the
+    # empty strings, so the query needs no separate strip().
     words = query.split()
     safe = [w.replace('"', '""') for w in words]
 
@@ -150,12 +150,11 @@ def _chunk_quality_score(content: str) -> float:
     """
     score = 0.0
 
-    # ⚡ Bolt Optimization: Use str.count instead of re.findall for ~5x faster block counting
     code_blocks = content.count("```") // 2
     score += min(code_blocks, 3) * 2.0  # up to +6
 
-    # ⚡ Bolt Optimization: Single-pass loop handles definitions, docstrings, and link ratio
-    # to avoid multiple full-string scans and regex overhead.
+    # One pass collects all three line-level signals below. Scored separately
+    # they would each walk the whole chunk.
     defs = 0
     docstrings = 0
     lines_count = 0
@@ -170,9 +169,10 @@ def _chunk_quality_score(content: str) -> float:
         if defs < 4 and ln.lstrip().startswith(_DEF_KEYWORDS):
             defs += 1
 
-        # Docstrings/doc comments signal well-documented code
-        # ⚡ Bolt Optimization: Pre-filter: only run regex if a common marker exists.
-        # This eliminates re.finditer overhead for most lines.
+        # Docstrings/doc comments signal well-documented code.
+        # The substring tests are a filter, not part of the definition: most
+        # lines carry no docstring marker at all, and this keeps the regex off
+        # them.
         if docstrings < 3 and (
             '"""' in ln or "'''" in ln or "/**" in ln or "///" in ln or "#" in ln
         ):
@@ -202,8 +202,9 @@ def _chunk_quality_score(content: str) -> float:
         elif ratio > 0.3:
             score -= 2.0
 
-    # Directive-heavy content (leftover mkdocs/rst noise)
-    # ⚡ Bolt Optimization: Use finditer with early break instead of findall
+    # Directive-heavy content (leftover mkdocs/rst noise). Only the first four
+    # matches change the score, so counting stops there instead of collecting
+    # every match in the chunk.
     directives = 0
     for _ in _DIRECTIVE_RE.finditer(content):
         directives += 1
@@ -577,9 +578,8 @@ class DocsDB:
             CREATE INDEX IF NOT EXISTS idx_chunks_version
             ON doc_chunks(version_id)
         """)
-        # ⚡ Bolt Optimization: Composite index for adjacent chunk prefetching in RAG context retrieval.
-        # Reduces query time for cross-chunk context lookups by ~14x in large libraries
-        # by providing exact coverage for `WHERE version_id = ? AND url = ? AND chunk_index IN (...)`
+        # Covers the adjacent-chunk prefetch exactly, in its column order:
+        # WHERE version_id = ? AND url = ? AND chunk_index IN (...)
         self._conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_chunks_ver_url_idx
             ON doc_chunks(version_id, url, chunk_index)
@@ -1172,17 +1172,14 @@ class DocsDB:
         fts_chunks: dict[str, dict],
     ) -> list[tuple[str, float]]:
         """Combine FTS and vector scores using RRF or FTS-only scoring."""
-        # ⚡ Bolt Optimization: Use dictionary view union directly instead of casting to sets
-        # (e.g. `fts_scores.keys() | vec_scores.keys()`). This avoids allocating two intermediate
-        # set objects entirely.
         all_ids = fts_scores.keys() | vec_scores.keys()
         scored: list[tuple[str, float]] = []
 
         if vec_scores:
             # RRF fusion when both FTS and vector signals available
             k = 60
-            # ⚡ Bolt Optimization: Use __getitem__ instead of lambda x: dict[x] for faster sorting.
-            # Avoids O(N) Python-level function call overhead.
+            # __getitem__ is the dict's own lookup; a lambda here would add a
+            # Python-level call for every element sorted.
             fts_ranked = sorted(fts_scores, key=fts_scores.__getitem__, reverse=True)
             vec_ranked = sorted(vec_scores, key=vec_scores.__getitem__, reverse=True)
             fts_rank = {cid: i + 1 for i, cid in enumerate(fts_ranked)}
@@ -1312,8 +1309,8 @@ class DocsDB:
                     chunk_id = vr["id"]
                     vec_scores[chunk_id] = max(0.0, 1.0 - vr["distance"])
 
-                    # ⚡ Bolt Optimization: Use pre-fetched chunk data from the JOIN
-                    # instead of executing a SELECT query per row (fixes N+1 query problem).
+                    # The vector query already joins the chunk row, so reuse it
+                    # here. Looking it up again would be one SELECT per result.
                     if chunk_id not in fts_chunks:
                         chunk_data = dict(vr)
                         chunk_data.pop("distance", None)
@@ -1681,8 +1678,6 @@ class DocsDB:
         libraries, versions, chunks = [], [], []
 
         for line in lines:
-            # ⚡ Bolt Optimization: Use `not line or line.isspace()` for truthiness
-            # checking instead of `.strip()` to avoid allocating memory for new string slices.
             if not line or line.isspace():
                 continue
             obj = json.loads(line)

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -325,8 +325,10 @@ class CloudEmbeddingBackend:
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
-        # ⚡ Bolt Optimization: Parallelize batch API calls to speed up large document embedding
-        # Use a semaphore to prevent unbounded concurrency and avoid API rate limits
+        # The batches go out to a remote embedding API, so they are issued
+        # together rather than one after another. The semaphore is what keeps a
+        # large document from opening one request per batch at once and hitting
+        # the provider's rate limit.
         sem = asyncio.Semaphore(8)
 
         async def _embed_with_sem(

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2327,9 +2327,9 @@ async def _fetch_and_chunk_docs(
                 f"(min {_MIN_GH_CHUNKS}), falling through"
             )
 
-    # ⚡ Bolt Optimization: Bound concurrency for CPU-bound chunk_markdown
-    # Limit to 10 concurrent thread offloads to prevent thread pool exhaustion
-    # and main event loop starvation during large batch page processing.
+    # chunk_markdown is CPU-bound and runs off the loop in a worker thread. A
+    # large crawl would otherwise offload one page per thread at once, which
+    # exhausts the default executor and starves the event loop.
     sem = asyncio.Semaphore(10)
 
     async def _process_page(page: dict) -> list[dict]:

--- a/src/wet_mcp/sources/_search_polish.py
+++ b/src/wet_mcp/sources/_search_polish.py
@@ -47,7 +47,6 @@ def normalize_query(q: str) -> str:
         return ""
     lowered = q.strip().lower()
     no_punct = _PUNCT_RE.sub(" ", lowered)
-    # ⚡ Bolt Optimization: " ".join(text.split()) avoids regex overhead and is significantly faster than re.sub(r"\s+", " ", text).strip()
     return " ".join(no_punct.split())
 
 

--- a/src/wet_mcp/sources/_smart_chunks.py
+++ b/src/wet_mcp/sources/_smart_chunks.py
@@ -61,7 +61,6 @@ def _html_to_markdown(html: str) -> str:
 def _strip_html(html: str) -> str:
     """Remove HTML tags + collapse whitespace as a clean-text fallback."""
     text = _HTML_TAG_RE.sub(" ", html)
-    # ⚡ Bolt Optimization: " ".join(text.split()) is ~5x faster than regex substitution
     return " ".join(text.split())
 
 
@@ -141,7 +140,6 @@ def _extract_title(html: str, headings: list[dict[str, str]]) -> str:
         r"<title[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL
     )
     if title_match:
-        # ⚡ Bolt Optimization: " ".join(text.split()) is ~5x faster than regex substitution
         title = " ".join(title_match.group(1).split())
         if title:
             return title
@@ -179,7 +177,6 @@ def smart_chunks(
         source_format = "html"
     else:
         markdown = content
-        # ⚡ Bolt Optimization: " ".join(text.split()) is ~5x faster than regex substitution
         clean_text = " ".join(content.split())
         structured_data = []
         source_format = "markdown"

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -313,7 +313,6 @@ async def _get_scraping_agent(stealth: bool = True) -> ScrapingAgent:
 def _is_document_url(url: str) -> bool:
     """Check if URL points to a document file (PDF, DOCX, etc.)."""
     path = urlparse(url).path.lower()
-    # ⚡ Bolt Optimization: path.endswith(tuple) is ~5x faster than any() with generator
     return path.endswith(_DOCUMENT_EXTENSIONS_TUPLE)
 
 
@@ -328,7 +327,6 @@ def _detect_document_content_type(content_type: str) -> bool:
         "application/vnd.ms-powerpoint",
         "application/vnd.ms-excel",
     )
-    # ⚡ Bolt Optimization: content_type.startswith(tuple) is ~7x faster than any() with generator
     return content_type.startswith(doc_types)
 
 

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -2107,7 +2107,9 @@ def _strip_nav_heading_blocks(lines: Sequence[str]) -> list[str]:
     # Build heading map: line_index -> (level, text)
     headings: dict[int, tuple[int, str]] = {}
     for i, line in enumerate(lines):
-        # ⚡ Bolt Optimization: Fast-path string check before invoking regex engine
+        # The prefix test is redundant with the pattern and deliberate: most
+        # lines in a document are not headings, and this keeps the regex engine
+        # off them.
         stripped = line.lstrip()
         if stripped.startswith("#"):
             m = _ANY_HEADING_RE.match(stripped)
@@ -2134,7 +2136,9 @@ def _strip_nav_heading_blocks(lines: Sequence[str]) -> list[str]:
                 break
             # Content between this heading and previous must be minimal
             prev_idx = run[-1]
-            # ⚡ Bolt Optimization: Avoid joining strings to check length, instead calculate length iteratively
+            # Accumulate the length instead of joining the lines: the budget is
+            # 50 characters, so most gaps are decided within a line or two and
+            # the join would have built a string only to measure it.
             content_length = 0
             is_over_length = False
             for k in range(prev_idx + 1, idx):
@@ -2241,9 +2245,9 @@ def _clean_doc_content(content: str) -> str:
     # Remove TOC anchor links (- [Title](#section))
     content = _TOC_LINK_RE.sub("", content)
 
-    # ⚡ Bolt Optimization: optimize text processing by passing a `list[str]`
-    # through multiple helper functions instead of repeatedly splitting and
-    # re-joining strings via `splitlines()` and `\n.join()`.
+    # The line-oriented passes below hand a list[str] to one another and the
+    # text is rejoined once at the end. Each of them taking and returning a
+    # string would split and join the whole document again.
     lines = content.splitlines()
 
     # Remove navigation sidebar blocks (MkDocs Material, Sphinx, etc.)
@@ -2259,7 +2263,6 @@ def _clean_doc_content(content: str) -> str:
         if not stripped:
             cleaned.append(line)
             continue
-        # ⚡ Bolt Optimization: Combine regex matches into a single check to reduce overhead
         if _COMBINED_NOISE_RE.match(stripped):
             continue
         cleaned.append(line)
@@ -2271,8 +2274,8 @@ def _clean_doc_content(content: str) -> str:
 # Content chunking — split docs into searchable chunks
 # ---------------------------------------------------------------------------
 
-# Heading pattern for markdown
-# ⚡ Bolt Optimization: Removed `re.MULTILINE` as we match against individual lines.
+# Heading pattern for markdown. No re.MULTILINE: this is matched against one
+# line at a time, never against a whole document.
 _HEADING_RE = re.compile(r"^(#{1,4})\s+(.+)$")
 
 
@@ -2342,7 +2345,8 @@ def chunk_markdown(
     h2 = ""
 
     for line in content.split("\n"):
-        # ⚡ Bolt Optimization: Fast-path string check before invoking regex engine
+        # The prefix test is redundant with the pattern and deliberate: most
+        # lines are not headings, and this keeps the regex engine off them.
         heading_match = _HEADING_RE.match(line) if line.startswith("#") else None
         if heading_match:
             level = len(heading_match.group(1))
@@ -2392,8 +2396,6 @@ def _split_preserving_code(
     in_code_block = False
 
     for line in lines:
-        # ⚡ Bolt Optimization: Use lstrip().startswith() instead of regex match + strip()
-        # for ~1.75x faster execution and fewer string allocations in hot loops.
         if line.lstrip().startswith("```"):
             in_code_block = not in_code_block
 
@@ -2411,7 +2413,6 @@ def _split_preserving_code(
     buffer = ""
     for seg in segments:
         if buffer and len(buffer) + len(seg) + 2 > max_chunk_size:
-            # ⚡ Bolt Optimization: Cache buffer.strip() to avoid redundant string allocations
             buffer_stripped = buffer.strip()
             if buffer_stripped and len(buffer_stripped) >= min_chunk_size:
                 chunks.append(
@@ -2427,7 +2428,6 @@ def _split_preserving_code(
         else:
             buffer = f"{buffer}\n\n{seg}" if buffer else seg
 
-    # ⚡ Bolt Optimization: Cache buffer.strip() to avoid redundant string allocations
     buffer_stripped = buffer.strip()
     if buffer_stripped and len(buffer_stripped) >= min_chunk_size:
         chunks.append(
@@ -2477,8 +2477,9 @@ def _process_rst_heading(i: int, line: str, lines: list[str], out: list[str]) ->
 
     if i > 0 and out:
         prev_stripped = out[-1].strip()
-        # ⚡ Bolt Optimization: Use cached prev_stripped and an O(1) index check
-        # prev_stripped[0] in _RST_HEADING_CHARS over an O(N) generator `all(c in ...)`
+        # The previous line is an overline for this heading if it is one
+        # character repeated, and that character is an RST heading rule. A
+        # single-element set is how "one character repeated" is tested here.
         if (
             prev_stripped
             and len(set(prev_stripped)) == 1
@@ -2586,8 +2587,9 @@ def _rst_to_markdown(content: str) -> str:
         line_stripped = line.strip()
         if i + 1 < len(lines) and line_stripped:
             next_stripped = lines[i + 1].strip()
-            # ⚡ Bolt Optimization: Cache .strip() and use an O(1) check
-            # next_stripped[0] in _RST_HEADING_CHARS instead of an O(N) generator
+            # An RST underline is one character repeated to at least the width
+            # of the title, and that character is an RST heading rule. A
+            # single-element set is how "one character repeated" is tested here.
             if (
                 len(next_stripped) >= len(line_stripped)
                 and next_stripped
@@ -2958,8 +2960,6 @@ def _has_excessive_macros(content: str, threshold: float = 0.15) -> bool:
     lines = [ln for ln in content.splitlines() if ln.strip()]
     if len(lines) < 5:
         return False
-    # ⚡ Bolt Optimization: Use string find over regex for ~3-10x faster macro detection.
-    # Enforces the correct order ({{ before }}) without regex overhead.
     macro_lines = 0
     for ln in lines:
         start = ln.find("{{")
@@ -2975,7 +2975,6 @@ def _strip_template_macros(content: str) -> str:
     produce noise in raw markdown. Keeps the rest of the content intact.
     """
     lines = content.splitlines()
-    # ⚡ Bolt Optimization: Use string find over regex for ~3-10x faster macro removal.
     cleaned = []
     for ln in lines:
         start = ln.find("{{")
@@ -3211,9 +3210,9 @@ async def _try_github_raw_docs(
         fetch_original_bytes = 0
         fetch_stripped_bytes = 0
 
-        # ⚡ Bolt Optimization: Fetch GitHub raw files concurrently to prevent N+1
-        # sequential HTTP request bottlenecks. Reduces the fetch time for 50 files
-        # from >10s down to ~1-2s. Uses a semaphore to respect GitHub limits.
+        # Up to 50 files are fetched here, so they go out together rather than
+        # one after another; sequentially this is the slowest step in the tier.
+        # The semaphore keeps the fan-out inside GitHub's rate limit for raw.
         sem = asyncio.Semaphore(10)
 
         async def _fetch_single_file(fpath: str) -> dict | None:

--- a/src/wet_mcp/sources/search_strategies.py
+++ b/src/wet_mcp/sources/search_strategies.py
@@ -262,8 +262,6 @@ def _extract_passage(content: str, query_terms: list[str], max_chars: int = 500)
 
         for i in sorted(candidates):
             window = content_lower[i : i + max_chars]
-            # ⚡ Bolt Optimization: Use a simple loop instead of sum() with generator expression
-            # This avoids generator creation overhead in this tight scoring loop.
             score = 0
             for term in present_terms:
                 if term in window:


### PR DESCRIPTION
`.jules/bolt.md` has carried this entry since 2026-07-25:

> ### 2026-07-25 - Optimisation comments in source (#1556)
> **Learning:** Comments that announce an optimisation and credit the tool that made it (`# ⚡ Bolt Optimization: ...`) age badly. [...] Write comments that explain why the code is shaped the way it is, in the voice of the surrounding file — for example, the reason a fast path exists and the measurement that justified it. Leave authorship to the commit metadata.

It was never applied to the comments already in the tree. `git grep -c 'Bolt Optimization' origin/main -- src/` counted **33** of them across 8 files, so the ledger and the source said opposite things — which is why the same suggestion keeps arriving in new PRs, most recently #1583 and #1578, both of which added one directly below the entry rejecting the style.

Every site was read on its own. No bulk substitution.

| file | markers | rewritten | deleted |
|---|---|---|---|
| `src/wet_mcp/db.py` | 10 | 7 | 3 |
| `src/wet_mcp/sources/docs.py` | 14 | 8 | 6 |
| `src/wet_mcp/sources/_smart_chunks.py` | 3 | 0 | 3 |
| `src/wet_mcp/sources/crawler.py` | 2 | 0 | 2 |
| `src/wet_mcp/embedder.py` | 1 | 1 | 0 |
| `src/wet_mcp/server.py` | 1 | 1 | 0 |
| `src/wet_mcp/sources/_search_polish.py` | 1 | 0 | 1 |
| `src/wet_mcp/sources/search_strategies.py` | 1 | 0 | 1 |
| **total** | **33** | **17** | **16** |

**Rewritten (17)** where the comment sat next to something a reader would otherwise have to reconstruct: why `_signal_score` walks the row once instead of calling `.count()` per token, why the docstring pre-filter exists ahead of the substring match, which composite index the `libraries`/`chunks` join is written to hit, why `chunk_markdown` is handed to an executor at all, why the GitHub raw fan-out is behind a semaphore, why `_HEADING_RE` deliberately does not use `re.MULTILINE`. The marker and the tool name are gone; the reason stays.

**Deleted (16)** where the whole comment was an unquantified claim about the line under it ("faster", "avoids overhead", "O(1) instead of O(n)") with nothing a future reader could check.

**Kept deliberately:** `src/wet_mcp/sources/_search_polish.py` also has `# Optimization: Use maxsplit to avoid parsing the entire string`. It names no tool, claims no number, and explains the `maxsplit` argument on the line below it. That is the shape the ledger asks for, so it stays.

### pyproject.toml

The `fastmcp` comment had the same defect from the other direction — it explained one bound and misstated another:

- it gave the CVE reason, which is the reason for the **floor** only, and left the **ceiling** unexplained;
- it named `>=3.2.3` while the specifier says `fastmcp>=3.4.4,<4`;
- it said the ceiling would come off "until mcp-core bumps its own floor past 3.x", but mcp-core has no ceiling to inherit.

Verified before rewriting, on this machine:

- `n24q02m-mcp-core` 1.21.0 and 1.22.0b2 both declare `fastmcp>=3.4.4` — a floor, **no ceiling**. Without `<4` here, a lockfile refresh would take the major bump on its own.
- `fastmcp 4.0.0b1` requires `fastmcp-slim==4.0.0b1`, which requires `mcp>=2.0.0,<3.0.0` and `mcp-types>=2.0.0,<3.0.0`.
- `mcp 2.0.0`'s `mcp/types/__init__.py` is `from mcp_types import *`.
- `mcp_types 2.0.0`'s base model sets `ConfigDict(alias_generator=to_camel, populate_by_name=True, validate_by_alias=True, validate_by_name=True)`. Constructing `ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True)` under `-W error::UserWarning` returns all four fields as snake_case with **0 warnings** — the camelCase spellings this repo uses at 14 sites in `server.py` are aliases, not dropped input.

So the comment now names both bounds, points at the `ToolAnnotations` call sites as the thing to re-check before lifting the ceiling, and does not claim data loss that does not happen. **The specifier itself is unchanged.**

### Not one executable line

```
$ git diff -U0 -- src/ pyproject.toml \
    | grep -E "^[+-]" | grep -vE "^(\+\+\+|---)" \
    | grep -vE "^[+-]\s*#" | grep -vE "^[+-]\s*$"
$
```

Empty. Every changed line is a `#` comment or blank.

Local run on this commit (`env -u EMBEDDING_MODELS uv run pytest`):

```
1 failed, 2101 passed, 35 skipped, 138 deselected, 17 warnings in 268.10s (0:04:28)
FAILED tests/test_per_sub_credential_isolation.py::test_llm_acompletion_forwards_per_sub_api_base
```

That failure is environmental and pre-existing, not caused by this branch. `store_for_sub` writes through `PerPluginStore`, which ignores the test's `WET_DATA_DIR` monkeypatch and lands in the **real** `~/.wet-mcp/subs/<sub>/config.json`. Another suite running concurrently on the same machine had written `GEMINI_API_KEY: "gem_a"` for `user_a` (`tests/test_multiuser_llm_gate_and_backend.py:87`), which is exactly the value the assertion saw: `assert 'gem_a' == 'key_a'`. Re-running the file alone gives `12 passed`, and running it after `test_multiuser_llm_gate_and_backend.py` in suite order gives `36 passed`. Worth fixing separately — the tests should not write to the developer's home directory — but it is out of scope for a comments-only change.

The pre-commit chain on this commit passed in full, pytest included:

```
gitleaks (detect secrets)..................................................Passed
ruff lint..................................................................Passed
ruff format................................................................Passed
ty type check..............................................................Passed
pytest (Python)............................................................Passed
```
