### PR TITLE
fix: stop .gitignore from silently dropping new .jules bot ledgers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,6 @@ wrangler.deploy.jsonc
 .wrangler-deploy-*.jsonc
 
 # AI Agent
-.jules/
-JULES.md
 
 # Code review knowledge graph
 .code-review-graph/

--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,6 @@ tests/benchmark_results.jsonl
 wrangler.deploy.jsonc
 .wrangler-deploy-*.jsonc
 
-# AI Agent
-
 # Code review knowledge graph
 .code-review-graph/
 


### PR DESCRIPTION
## Defect

`.gitignore` still had `.jules/` (line 66) and `JULES.md` (line 67) after
`.jules/bolt.md` and `.jules/sentinel.md` were already tracked on `main`.
`.gitignore` only governs *untracked* paths, so this is latent, not inert:
the first time a new bot writes its first ledger (e.g. `.jules/palette.md`,
which does not exist yet in this repo), `git add` drops the new file
silently — exit code 0, no error — and the resulting PR ships `+0/-0`.

This is not hypothetical. `n24q02m/claude-plugins` hit exactly this: PR #544
was `+0/-0` for this reason, fixed in PR #591 (merged) by removing the same
ignore lines (`.jules/`, `.jules`, `.Jules/`) from that repo's `.gitignore`.
claude-plugins never had a `JULES.md` line to begin with, so there is no
literal precedent for it there — this repo's `JULES.md` line was added in
the same original commit as `.jules/` (`Add .jules/ and JULES.md to
gitignore`, see CHANGELOG.md), was never used (no `JULES.md` ever existed
in this repo's history), and sits in the identical "# AI Agent" block
subject to the identical silent-drop bug, so it is removed here too.

## Fix

Removed the two ignore lines. No other change.

```diff
 # AI Agent
-.jules/
-JULES.md

 # Code review knowledge graph
```

## Proof (run in a clean worktree off origin/main, before the fix)

```
$ echo "# Palette bot ledger (test)" > .jules/palette.md
$ git add -A .
exit code: 0
$ git status --short
(nothing — file NOT staged)
$ git check-ignore -v .jules/palette.md
.gitignore:66:.jules/	.jules/palette.md
```

## Proof (same test, after the fix)

```
$ echo "# Palette bot ledger (test, after fix)" > .jules/palette.md
$ git add -A .
exit code: 0
$ git status --short
M  .gitignore
A  .jules/palette.md
$ git check-ignore -v .jules/palette.md
(no match, exit 1)
```

Test file was removed before committing; the diff contains only `.gitignore`.

Not merging this myself — opened for review.