### PR TITLE
fix: match registry host checks on the host suffix, not a URL substring

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2760,7 +2760,12 @@ async def _do_docs_search(
         # When no docs URL found but we have a GitHub repo URL,
         # use it as the docs source — _fetch_and_chunk_docs will
         # try GitHub raw docs (Tier 1) which often has good docs/.
-        if repo_url and "github.com" in repo_url:
+        # The host check is a suffix match, not a substring one: `repo_url`
+        # came from publisher-controlled registry metadata and is about to
+        # become a URL this server fetches.
+        from wet_mcp.sources.docs import _is_github_url
+
+        if _is_github_url(repo_url):
             docs_url = repo_url
             logger.info(f"No docs URL for '{library}', using GitHub repo: {repo_url}")
         else:

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -138,15 +138,15 @@ async def _discover_from_pypi(name: str) -> dict | None:
             # Fallback: extract GitHub URL from any project_urls value
             # Many PyPI packages list GitHub under "Homepage", "Bug Tracker",
             # "Changelog", etc. without a dedicated "Repository" key.
-            if not repo_url or "github.com" not in repo_url:
+            if not _is_github_url(repo_url):
                 for _key, url_val in project_urls_lower.items():
-                    if url_val and "github.com" in url_val:
+                    if _is_github_url(url_val):
                         repo_url = url_val
                         break
             # Last resort: check top-level home_page field
-            if not repo_url or "github.com" not in repo_url:
+            if not _is_github_url(repo_url):
                 hp = info.get("home_page") or ""
-                if "github.com" in hp:
+                if _is_github_url(hp):
                     repo_url = hp
             return {
                 "name": info.get("name", name),
@@ -174,7 +174,7 @@ async def _discover_from_crates(name: str) -> dict | None:
             docs_url = crate.get("documentation") or ""
             hp_url = crate.get("homepage") or ""
             # Filter self-referencing crates.io URLs (listing page, not docs)
-            if hp_url and "crates.io" in hp_url:
+            if _is_crates_url(hp_url):
                 hp_url = ""
             # Prefer homepage over docs.rs auto-generated documentation
             if hp_url:
@@ -253,7 +253,7 @@ async def _discover_from_go(name: str) -> dict | None:
                 description = item.get("description") or ""
                 repo_url = item.get("html_url") or ""
                 # Use homepage if it's a real docs domain (not github.com itself)
-                if homepage and "github.com" not in homepage.lower():
+                if homepage and not _is_github_url(homepage):
                     docs_url = homepage
                 else:
                     docs_url = f"https://pkg.go.dev/github.com/{full_name}"
@@ -425,10 +425,10 @@ async def _discover_from_rubygems(name: str) -> dict | None:
             docs_url = data.get("documentation_uri") or data.get("homepage_uri") or ""
             repo_url = data.get("source_code_uri") or ""
             # Fallback: extract GitHub URL from any URI field
-            if not repo_url or "github.com" not in repo_url:
+            if not _is_github_url(repo_url):
                 for key in ("homepage_uri", "bug_tracker_uri", "changelog_uri"):
                     val = data.get(key) or ""
-                    if "github.com" in val:
+                    if _is_github_url(val):
                         repo_url = val
                         break
             return {
@@ -475,7 +475,7 @@ async def _discover_from_nuget(name: str) -> dict | None:
             project_url = latest.get("projectUrl") or ""
             repo_url = ""
             # Extract GitHub repo from project URL if available
-            if project_url and "github.com" in project_url:
+            if _is_github_url(project_url):
                 repo_url = project_url
             return {
                 "name": latest.get("id", name),
@@ -684,11 +684,7 @@ async def _discover_from_github_search(name: str, language: str) -> dict | None:
         homepage = item.get("homepage") or ""
         repo_url = item.get("html_url") or ""
         stars = item.get("stargazers_count", 0)
-        docs_url = (
-            homepage
-            if (homepage and "github.com" not in homepage.lower())
-            else repo_url
-        )
+        docs_url = homepage if (homepage and not _is_github_url(homepage)) else repo_url
         logger.info(
             f"GitHub search {match_type} {name} ({language}): "
             f"{repo_url} ({stars} stars)"
@@ -789,7 +785,7 @@ async def _get_github_homepage(url: str) -> str | None:
                 return None
             data = resp.json()
             gh_homepage = data.get("homepage", "")
-            if gh_homepage and "github.com" not in gh_homepage.lower():
+            if gh_homepage and not _is_github_url(gh_homepage):
                 # Filter registry listing pages (uninformative, not docs)
                 gh_lower = gh_homepage.lower()
                 if any(
@@ -1142,15 +1138,58 @@ def _normalize_language(language: str) -> str:
     return _LANGUAGE_ALIASES.get(lang, lang)
 
 
-def _is_github_url(url: str) -> bool:
-    """Check if a URL points to GitHub using robust domain verification."""
+def _url_host(url: str | None) -> str:
+    """Lowercase host of a registry-supplied URL, or "" when there is none.
+
+    The value is whatever a package publisher typed into npm / PyPI / crates.io
+    / RubyGems / NuGet metadata, so one field arrives in several shapes:
+    "https://github.com/o/r", "git+https://github.com/o/r.git",
+    "git@github.com:o/r.git" and a bare "github.com/o/r". ``urlparse`` only
+    fills ``netloc`` when a scheme is present, so the last two land entirely in
+    ``path``; recover the host from ``path`` rather than reporting "no host",
+    which would drop URLs the substring checks being replaced accepted and
+    packages in the wild still publish.
+    """
     if not url:
-        return False
+        return ""
     try:
-        netloc = urlparse(url).netloc.lower()
-        return netloc == "github.com" or netloc.endswith(".github.com")
-    except Exception:
-        return False
+        parsed = urlparse(url.strip())
+    except ValueError:
+        return ""
+    netloc = parsed.netloc or parsed.path.partition("/")[0]
+    host = netloc.rpartition("@")[2]  # drop any userinfo
+    host = host.partition(":")[0]  # drop the port, or the scp-style path
+    return host.lower().rstrip(".")
+
+
+def _is_github_url(url: str | None) -> bool:
+    """True when url points at github.com or a host GitHub owns beneath it.
+
+    The registry discovery helpers used to ask ``"github.com" in url``, which
+    also accepts "https://evil.example/?x=github.com" (needle in the query) and
+    "https://github.com.evil.example/a/b" (needle is the first label of someone
+    else's domain) -- CodeQL's ``py/incomplete-url-substring-sanitization``.
+    That mattered because a repo URL clearing this gate is stored as the
+    library's trusted ``github_url`` and, when discovery found no docs URL, is
+    promoted to ``docs_url`` and then fetched.
+
+    Subdomains stay eligible: every host under github.com is GitHub's, so
+    allowing them does not widen the trust boundary the way a substring does,
+    and "www.github.com" is a spelling real metadata uses.
+    """
+    host = _url_host(url)
+    return host == "github.com" or host.endswith(".github.com")
+
+
+def _is_crates_url(url: str | None) -> bool:
+    """True when url points at crates.io or a subdomain of it.
+
+    Used to drop a homepage that only points back at the crate's own listing
+    page. A substring match also drops an unrelated homepage that merely
+    mentions crates.io in a query string, losing docs that do exist.
+    """
+    host = _url_host(url)
+    return host == "crates.io" or host.endswith(".crates.io")
 
 
 # ---------------------------------------------------------------------------
@@ -3604,7 +3643,7 @@ async def fetch_docs_pages(
 
     # For GitHub URLs, restrict crawl to the same repo path
     docs_parsed = urlparse(docs_url)
-    _is_github = "github.com" in docs_parsed.netloc
+    _is_github = _is_github_url(docs_url)
     _gh_path_prefix = "/".join(docs_parsed.path.strip("/").split("/")[:2])
     _gh_skip_paths = {
         "features",
@@ -4062,7 +4101,7 @@ async def ingest_tier2(db: Any, library_name: str) -> dict:
         tier=existing.get("tier") or 2,
         package_managers=package_managers or None,
         homepage=homepage,
-        github_url=repo_url if repo_url and "github.com" in (repo_url or "") else None,
+        github_url=repo_url if _is_github_url(repo_url) else None,
         canonical_name=existing.get("canonical_name") or library_name,
     )
     ver_id = db.upsert_version(

--- a/tests/test_host_suffix_checks.py
+++ b/tests/test_host_suffix_checks.py
@@ -1,0 +1,240 @@
+"""Registry host checks must match the host suffix, not a URL substring.
+
+CodeQL raised ``py/incomplete-url-substring-sanitization`` on the
+``github_url=`` sink in ``_index_library_docs``, but the substring test it
+flagged was the same one every registry discovery helper used. The values
+being tested are publisher-controlled: ``repository`` / ``projectUrl`` /
+``source_code_uri`` come straight out of npm, PyPI, crates.io, RubyGems and
+NuGet metadata, so anyone who can publish a package can choose them.
+
+``"github.com" in url`` accepts two shapes it should not:
+
+* ``https://evil.example/?x=github.com`` -- the needle sits in the query.
+* ``https://github.com.evil.example/a/b`` -- the needle is a *prefix* of an
+  attacker-owned parent domain.
+
+Neither is cosmetic. ``server.py`` promotes a "GitHub" repo URL straight into
+``docs_url`` when discovery found no docs URL, so the crawler then fetches it;
+the rest store it as the library's trusted ``github_url``.
+
+The tests below drive the real discovery helpers with mocked registry
+responses, so they fail on the substring implementation and pass on the
+host-suffix one. ``test_legitimate_*`` pins the shapes that must keep working
+-- notably bare ``github.com/o/r`` and ``git+https://github.com/o/r.git``,
+which the substring check accepted and packages in the wild still publish.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wet_mcp.sources.docs import (
+    _discover_from_crates,
+    _discover_from_nuget,
+    _discover_from_pypi,
+    _discover_from_rubygems,
+    _is_crates_url,
+    _is_github_url,
+    _url_host,
+)
+
+# URLs an attacker can publish that a substring check wrongly accepts.
+HOSTILE_URLS = [
+    "https://evil.example/?x=github.com",
+    "https://github.com.evil.example/a/b",
+    "https://notgithub.com/a/b",
+    "https://evil.example/github.com/a/b",
+    "https://evil.example#github.com",
+]
+
+# URLs that really are GitHub and must survive the tightening.
+LEGITIMATE_URLS = [
+    "https://github.com/psf/requests",
+    "git+https://github.com/psf/requests.git",
+    "https://www.github.com/psf/requests",
+    "http://github.com/psf/requests",
+    "github.com/psf/requests",
+]
+
+
+@pytest.mark.parametrize("url", HOSTILE_URLS)
+def test_is_github_url_rejects_hostile(url):
+    assert _is_github_url(url) is False
+
+
+@pytest.mark.parametrize("url", LEGITIMATE_URLS)
+def test_is_github_url_accepts_legitimate(url):
+    assert _is_github_url(url) is True
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("", ""),
+        ("https://github.com/o/r", "github.com"),
+        ("git+https://github.com/o/r.git", "github.com"),
+        ("git@github.com:o/r.git", "github.com"),
+        ("github.com/o/r", "github.com"),
+        ("https://GitHub.COM/o/r", "github.com"),
+        ("https://github.com.:443/o/r", "github.com"),
+        ("https://user:pw@github.com/o/r", "github.com"),
+        ("https://github.com.evil.example/o/r", "github.com.evil.example"),
+    ],
+)
+def test_url_host_shapes(url, expected):
+    assert _url_host(url) == expected
+
+
+def test_is_crates_url_distinguishes_lookalikes():
+    assert _is_crates_url("https://crates.io/crates/serde") is True
+    assert _is_crates_url("https://crates.io.evil.example/x") is False
+    assert _is_crates_url("https://evil.example/?ref=crates.io") is False
+
+
+def _client(route_map):
+    """Mock ``safe_httpx_client`` routing GETs by URL substring."""
+    client = AsyncMock()
+    missing = MagicMock()
+    missing.status_code = 404
+
+    async def _get(url, **kwargs):
+        for key, resp in route_map.items():
+            if key in str(url):
+                return resp
+        return missing
+
+    client.get = AsyncMock(side_effect=_get)
+    client.head = AsyncMock(side_effect=_get)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _json_response(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    return resp
+
+
+def _pypi_payload(url):
+    # No "repository"/"source" key, so the helper falls back to scanning every
+    # project_urls value -- the path that decides whether `url` becomes the repo.
+    return {
+        "info": {
+            "name": "victim",
+            "summary": "",
+            "project_urls": {"Homepage": url},
+            "home_page": "",
+            "docs_url": "",
+        }
+    }
+
+
+def _rubygems_payload(url):
+    return {
+        "name": "victim",
+        "info": "",
+        "documentation_uri": "",
+        "homepage_uri": url,
+        "source_code_uri": "",
+        "downloads": 1,
+    }
+
+
+def _nuget_payload(url):
+    return {
+        "items": [
+            {
+                "items": [
+                    {
+                        "catalogEntry": {
+                            "id": "victim",
+                            "description": "",
+                            "projectUrl": url,
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("url", HOSTILE_URLS)
+async def test_pypi_rejects_non_github_host(url):
+    client = _client({"pypi.org": _json_response(_pypi_payload(url))})
+    with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=client):
+        result = await _discover_from_pypi("victim")
+    assert result is not None
+    assert result["repository"] != url
+
+
+@pytest.mark.parametrize("url", HOSTILE_URLS)
+async def test_rubygems_rejects_non_github_host(url):
+    client = _client({"rubygems.org": _json_response(_rubygems_payload(url))})
+    with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=client):
+        result = await _discover_from_rubygems("victim")
+    assert result is not None
+    assert result["repository"] != url
+
+
+@pytest.mark.parametrize("url", HOSTILE_URLS)
+async def test_nuget_rejects_non_github_host(url):
+    client = _client({"api.nuget.org": _json_response(_nuget_payload(url))})
+    with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=client):
+        result = await _discover_from_nuget("victim")
+    assert result is not None
+    assert result["repository"] != url
+
+
+@pytest.mark.parametrize("url", LEGITIMATE_URLS)
+async def test_legitimate_github_urls_still_accepted(url):
+    client = _client({"pypi.org": _json_response(_pypi_payload(url))})
+    with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=client):
+        result = await _discover_from_pypi("victim")
+    assert result is not None
+    assert result["repository"] == url
+
+
+async def test_crates_keeps_homepage_on_lookalike_host():
+    """``crates.io.evil.example`` is not crates.io, so it is not self-referencing.
+
+    The filter drops a homepage that merely points back at the crate's own
+    listing page. A substring match also drops an unrelated third-party
+    homepage whose URL happens to mention crates.io, losing real docs.
+    """
+    payload = {
+        "crate": {
+            "name": "victim",
+            "description": "",
+            "documentation": "",
+            "homepage": "https://evil.example/?ref=crates.io",
+            "repository": "",
+            "downloads": 1,
+        }
+    }
+    client = _client({"crates.io/api": _json_response(payload)})
+    with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=client):
+        result = await _discover_from_crates("victim")
+    assert result is not None
+    assert result["homepage"] == "https://evil.example/?ref=crates.io"
+
+
+async def test_crates_still_drops_real_self_reference():
+    payload = {
+        "crate": {
+            "name": "victim",
+            "description": "",
+            "documentation": "https://docs.rs/victim",
+            "homepage": "https://crates.io/crates/victim",
+            "repository": "",
+            "downloads": 1,
+        }
+    }
+    client = _client({"crates.io/api": _json_response(payload)})
+    with patch("wet_mcp.sources.docs._safe_httpx_client", return_value=client):
+        result = await _discover_from_crates("victim")
+    assert result is not None
+    assert result["homepage"] != "https://crates.io/crates/victim"


### PR DESCRIPTION
Closes CodeQL alert #129 (`py/incomplete-url-substring-sanitization`, `src/wet_mcp/sources/docs.py:4065`).

## The defect

Registry metadata — `repository`, `projectUrl`, `source_code_uri`, `homepage` — is
publisher-controlled free text. Eleven call sites tested it with
`"github.com" in url` / `"crates.io" in url`, which also accepts:

| Shape | Why it passes |
|---|---|
| `https://evil.example/?x=github.com` | needle sits in the query string |
| `https://github.com.evil.example/a/b` | needle is the first label of someone else's domain |
| `https://notgithub.com/a/b` | needle is a suffix of a different registrable domain |

This is not only a storage concern. When discovery finds no docs URL,
`server.py` promotes the repo URL straight into `docs_url` and the crawler
then fetches it, so a hostile value reaches the network layer.

## The fix

`_is_github_url` **already existed** in `docs.py` and already did correct suffix
matching — it was simply never used by the discovery helpers. Rather than adding
a second rule, this reuses it and extends it through a new `_url_host`, so the
shapes registries really publish keep resolving to a host instead of being
silently dropped:

- `https://github.com/o/r`
- `git+https://github.com/o/r.git`
- `git@github.com:o/r.git` (scp-style)
- `github.com/o/r` (scheme-less — `urlparse` leaves this entirely in `path`)
- userinfo and ports (`https://user:pw@github.com/o/r`, `github.com.:443`)

`_is_crates_url` is added for the crates.io self-reference filter.

Subdomains stay eligible (`host == h or host.endswith("." + h)`, the same rule
`_is_readthedocs_host` uses). Every host under `github.com` is GitHub's, so
allowing them does not widen the trust boundary the way a substring does, and
`www.github.com` is a spelling real metadata uses.

## Sites changed (11)

Security-relevant — value becomes a trusted `github_url` and/or a crawled `docs_url`:

- `server.py:2768` — repo URL promoted to `docs_url` (strictest path)
- `docs.py:141,143,147,149` — PyPI `project_urls` / `home_page` fallback
- `docs.py:428,431` — RubyGems URI fallback
- `docs.py:478` — NuGet `projectUrl`
- `docs.py:3646` — GitHub same-repo crawl restriction
- `docs.py:4104` — the `github_url=` sink CodeQL flagged
- `docs.py:177` — crates.io self-reference filter

Correctness-only (inverse direction — "is this homepage GitHub itself?"), found by a
wider grep that catches the `.lower()` variant the original sweep missed. No security
impact, since both branches already use a registry-supplied URL; the substring form
was discarding legitimate docs at hosts like `notgithub.com`:

- `docs.py:256`, `docs.py:687`, `docs.py:788`

**Considered and deliberately left alone:** `docs.py:57` and `docs.py:182`
(`"docs.rs" in url`) and `docs.py:54` (`"readthedocs" in url`). These pick a regex
substitution or a display preference among values that are equally trusted at that
point — not sanitization — so tightening them would be scope creep with no benefit.

## Evidence

New `tests/test_host_suffix_checks.py` drives the real discovery helpers with mocked
registry responses, so it fails on the substring implementation and passes on this one.

Red — before, on unpatched `src/`:

```
16 failed, 6 passed in 87.87s (0:01:27)
FAILED test_pypi_rejects_non_github_host[https://evil.example/?x=github.com]
FAILED test_pypi_rejects_non_github_host[https://github.com.evil.example/a/b]
FAILED test_pypi_rejects_non_github_host[https://notgithub.com/a/b]
... (same 5 shapes x pypi / rubygems / nuget) ...
FAILED test_crates_keeps_homepage_on_lookalike_host
```

The 6 that already passed are the `test_legitimate_*` cases — they pin the URL shapes
the substring check accepted, so the tightening is proven not to regress them.

Green — after:

```
2188 passed, 33 skipped, 140 deselected, 17 warnings in 241.48s (0:04:01)
```

`ruff check`, `ruff format --check` and `ty check` all clean; `ty` was clean on
`origin/main` before and after, with no new diagnostics.