### PR TITLE
fix: stop tests writing credentials into the developer's real home

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,31 @@ pytest_plugins = ["conftest_e2e", "conftest_cf"]
 
 
 @pytest.fixture(autouse=True)
+def _isolate_per_plugin_home(tmp_path_factory, monkeypatch):
+    """Point ``Path.home()`` at a throwaway directory for every test.
+
+    ``mcp_core.storage.per_plugin_store`` derives every credential path from
+    ``Path.home()`` and exposes no override seam, so each test that reaches
+    ``store_for_sub`` writes the developer's real
+    ``~/.wet-mcp/subs/<sub>/config.json``. The sub names are fixed constants
+    (``user_a`` / ``user_b`` / ``empty_user``), which turns that shared path
+    into a cross-process mutex nobody holds: two pytest processes running at
+    once -- two agents on one machine, or a ``-n`` worker pair in CI -- write
+    the same blob and read back each other's values. A run has already been
+    seen asserting ``key_a`` and reading ``jina_a`` (stored by
+    ``test_multiuser_llm_gate_and_backend``), and reading ``None`` moments
+    after its own ``store_for_sub`` because the other process rewrote the file
+    in between.
+
+    ``Path.home()`` resolves ``HOME`` on POSIX and ``USERPROFILE`` on Windows,
+    so both are set; ``monkeypatch`` restores them when the test ends.
+    """
+    fake_home = tmp_path_factory.mktemp("wet_test_home")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+
+@pytest.fixture(autouse=True)
 def _never_open_a_real_browser(monkeypatch):
     """Keep the GDrive device-code path from hijacking the developer's browser.
 


### PR DESCRIPTION
## The defect

`mcp_core.storage.per_plugin_store._cred_path` derives every credential path from
`Path.home()` and offers no override seam. `mcp_core.storage.backends._key_to_path`,
which does the actual write, resolves from `Path.home()` too. So any test reaching
`store_for_sub` writes the developer's **real** `~/.wet-mcp/subs/<sub>/config.json`.

The sub names are fixed constants — `user_a`, `user_b`, `empty_user` — shared by four
test modules:

- `tests/integration/test_multi_user_remote.py`
- `tests/test_credential_state_cf.py`
- `tests/test_multiuser_llm_gate_and_backend.py`
- `tests/test_per_sub_credential_isolation.py`

That turns one on-disk path into a cross-process mutex nobody holds. Two pytest
processes at once — two agents on one machine, or a `-n` worker pair in CI —
overwrite each other's blobs mid-test.

## It already happened

Two runs of the *same command* on unpatched code, minutes apart:

```
$ uv run pytest tests/test_multiuser_llm_gate_and_backend.py \
                tests/test_per_sub_credential_isolation.py -q
3 failed, 33 passed in 105.06s     # run 1
36 passed in 87.14s                # run 2
```

Run 1's failures:

```
FAILED test_per_sub_credential_isolation.py::test_embedder_forwards_per_sub_api_key
E   AssertionError: assert 'jina_a' == 'key_a'
FAILED test_per_sub_credential_isolation.py::test_llm_acompletion_forwards_per_sub_api_key
E   AssertionError: assert None == 'key_a'
FAILED test_per_sub_credential_isolation.py::test_api_base_for_task_resolves_per_sub
E   AssertionError: assert None == 'https://gw-a/cohere/v2/embed'
```

`jina_a` is written by `test_multiuser_llm_gate_and_backend.py:177`. Reading `None`
moments after the test's own `store_for_sub` is the other process truncating and
rewriting the file in between.

Worth being precise about the mechanism: this is a **cross-process race, not a
sequential ordering bug**. Nothing caches — every read goes to disk — so a single
pytest process that writes then reads always sees its own value. The same command
passing on the retry is the proof. It only fails when another process is writing
the same path concurrently, which is exactly what CI parallelism would make routine.

## The fix

Redirect `HOME` and `USERPROFILE` to a per-test tmp dir, the same guard `mnemo-mcp`
already carries in its `tests/conftest.py`. `Path.home()` reads `HOME` on POSIX and
`USERPROFILE` on Windows, so both are set; `monkeypatch` restores them at test end.
The fixture is defined first in `conftest.py` so HOME is redirected before any other
autouse fixture runs.

## Evidence

A controlled experiment, immune to whatever else is running on the machine — same
test file, same scratch `HOME`, only the fixture differing:

```
CONTROL (fixture absent):
  12 passed
  $CTL/.wet-mcp/subs/user_a/config.json
  $CTL/.wet-mcp/subs/user_b/config.json

TREATMENT (fixture present):
  12 passed
  no .wet-mcp directory at all
```

Full suite, with the fix, real `HOME`, plus the two failing files together: green.
No test turned out to depend on the real home directory.