### PR TITLE
fix: surface the errors server.py and db.py were swallowing

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -268,7 +268,16 @@ class DocsDB:
                 self._vec_enabled = True
                 logger.debug("sqlite-vec extension loaded")
             except Exception as e:
-                logger.debug(f"sqlite-vec not available, FTS-only mode: {e}")
+                # sqlite-vec is a hard dependency, and the caller asked for
+                # embedding_dims > 0. Falling back to FTS-only is a whole
+                # capability going away for the life of the process, so it is
+                # not a debug-level event.
+                logger.warning(
+                    f"sqlite-vec unavailable for {db_path} "
+                    f"({type(e).__name__}: {e}); running FTS-only -- vector "
+                    "search is disabled and docs queries answer with keyword "
+                    "matching alone"
+                )
 
         self._create_tables()
         self._guard_embedding_identity()
@@ -1079,7 +1088,16 @@ class DocsDB:
                 try:
                     vec_rows.append((chunk_ids[i], _serialize_f32(emb)))
                 except Exception as e:
-                    logger.debug(f"Failed to serialize embedding: {e}")
+                    # Per-chunk skip is a real degrade (the other chunks keep
+                    # their vectors and this one stays keyword-searchable), but
+                    # it must name the chunk so a systematic producer bug is
+                    # traceable instead of showing up as thin search results.
+                    logger.warning(
+                        f"Dropping the embedding for chunk {chunk_ids[i]}: "
+                        f"cannot serialize {type(emb).__name__} "
+                        f"({type(e).__name__}: {e}); the chunk will be "
+                        "keyword-searchable only"
+                    )
 
         if vec_rows:
             try:
@@ -1088,7 +1106,19 @@ class DocsDB:
                     vec_rows,
                 )
             except Exception as e:
-                logger.debug(f"Failed to batch-insert embeddings: {e}")
+                # Previously logged at debug and swallowed: add_chunks still
+                # returned the full chunk count, so the caller stamped the
+                # version 'indexed' over a database that could not answer a
+                # single semantic query. Roll the whole batch back (the
+                # doc_chunks INSERT above shares this open transaction) and let
+                # the caller see the failure.
+                logger.error(
+                    f"Vector insert failed for {len(vec_rows)} of "
+                    f"{len(chunk_ids)} chunks in {self._db_path} "
+                    f"({type(e).__name__}: {e}); rolling back the chunk batch"
+                )
+                self._conn.rollback()
+                raise
 
     def _prepare_chunk_rows(
         self,
@@ -1259,7 +1289,16 @@ class DocsDB:
                     fts_scores[cid] = score
                     fts_chunks[cid] = chunk
         except Exception as e:
-            logger.debug(f"FTS search error: {e}")
+            # An FTS5 syntax/schema error returns the same empty dict as "no
+            # document matched", and search() then reports an empty result set.
+            # The return shape is deliberately unchanged (a broken keyword tier
+            # must not take down a query the vector tier can still answer), so
+            # this log is the only place the difference is recorded.
+            logger.warning(
+                f"FTS search failed for {fts_queries!r} "
+                f"(library_id={library_id}, version_id={version_id}); "
+                f"returning zero keyword matches: {type(e).__name__}: {e}"
+            )
 
         # Min-max normalize FTS scores to 0-1
         if fts_scores:
@@ -1316,7 +1355,16 @@ class DocsDB:
                         chunk_data.pop("distance", None)
                         fts_chunks[chunk_id] = chunk_data
             except Exception as e:
-                logger.debug(f"Vector search error: {e}")
+                # Same shape as the FTS tier: an empty vec_scores is
+                # indistinguishable from "nothing was semantically close", so a
+                # dims mismatch or a missing doc_chunks_vec table used to read
+                # as a merely disappointing result set.
+                logger.warning(
+                    f"Vector search failed (library_id={library_id}, "
+                    f"version_id={version_id}, dims="
+                    f"{len(query_embedding)}); returning zero semantic "
+                    f"matches: {type(e).__name__}: {e}"
+                )
         return vec_scores
 
     def _prefetch_adjacent_chunks(
@@ -1765,7 +1813,15 @@ class DocsDB:
             if not isinstance(libs, list):
                 libs = []
             result["locked_libraries"] = libs
-        except (TypeError, json.JSONDecodeError):
+        except (TypeError, json.JSONDecodeError) as e:
+            # An unreadable lock silently becomes "no libraries locked", which
+            # is exactly the shape of a project that was never locked -- so
+            # Cabinets isolation switches itself off with no trace.
+            logger.warning(
+                f"project_context row for {project_path!r} has unreadable "
+                f"locked_libraries ({type(e).__name__}: {e}); treating the "
+                "project as unlocked"
+            )
             result["locked_libraries"] = []
         return result
 

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -65,6 +65,22 @@ _docs_db: DocsDB | None = None
 _embedding_dims: int = 0
 
 
+def _missing_docs_db_methods(backend) -> list[str]:
+    """Public ``DocsDB`` methods that ``backend`` (class or instance) lacks.
+
+    ``DocsDB`` itself is the contract, read at runtime rather than copied into
+    a hand-written list, so a method added there cannot quietly become a hole
+    in an alternate backend.
+    """
+    return sorted(
+        name
+        for name, attr in vars(DocsDB).items()
+        if not name.startswith("_")
+        and callable(attr)
+        and not callable(getattr(backend, name, None))
+    )
+
+
 def make_docs_db():
     """Select docs DB backend: sqlite (default) or cf-d1 (D1 + Vectorize).
 
@@ -85,11 +101,29 @@ def make_docs_db():
         from wet_mcp.backends.vectorize import vectorize_backend_from_env
         from wet_mcp.db_cf import DocsDBCfBackend
 
-        return DocsDBCfBackend(
+        cf_db = DocsDBCfBackend(
             d1_backend_from_env(),
             vectorize_backend_from_env(),
             embedding_dims=dims,
         )
+        # A backend that implements only part of DocsDB does not fail at
+        # startup, it fails mid-index: _background_index_and_search writes the
+        # chunks through add_chunks (present) and then raises AttributeError on
+        # mark_version_indexed (absent), inside a broad `except Exception` that
+        # only logs. The version never reaches status='indexed', so the next
+        # request re-indexes it, forever, while the row count keeps growing.
+        # Refuse the object here instead, where the missing names can be named.
+        missing = _missing_docs_db_methods(cf_db)
+        if missing:
+            raise RuntimeError(
+                f"DOCS_DB_BACKEND=cf-d1 built {type(cf_db).__name__}, which is "
+                f"missing {len(missing)} method(s) that callers invoke on a "
+                f"DocsDB: {', '.join(missing)}. Indexing would write chunks and "
+                "then fail on the first missing call, leaving every version "
+                "short of status='indexed' and re-indexed on every request. "
+                "Refusing to start until the backend implements them."
+            )
+        return cf_db
     embed_backend = settings.resolve_embedding_backend()
     if embed_backend == "cloud":
         model_identity = settings.embedding_primary() or ""
@@ -706,7 +740,15 @@ async def _rerank_results(
                     reranked.append(result)
             return reranked
     except Exception as e:
-        logger.debug(f"Reranking failed, using original order: {e}")
+        # A reranker that is configured but permanently broken (bad key, wrong
+        # model id, dead endpoint) silently returns keyword order on EVERY
+        # search. At debug level nobody sees that; warning is the level an
+        # operator actually reads.
+        logger.warning(
+            f"Reranking failed with {type(reranker).__name__} "
+            f"({len(results)} candidates, query {query[:80]!r}), "
+            f"falling back to unranked order: {type(e).__name__}: {e}"
+        )
 
     return results[:top_n]
 
@@ -1117,7 +1159,10 @@ async def search(  # noqa: PLR0913
                                 data["total"] = len(data["results"])
                                 modified = True
                     except Exception as e:
-                        logger.debug(f"Search reranking failed, using original: {e}")
+                        logger.warning(
+                            f"Search reranking step failed for query {query!r}, "
+                            f"returning backend order: {type(e).__name__}: {e}"
+                        )
 
                     # Optional snippet enrichment
                     if enrich:
@@ -1134,7 +1179,15 @@ async def search(  # noqa: PLR0913
                                 data["results"] = enriched
                                 modified = True
                         except Exception as e:
-                            logger.debug(f"Snippet enrichment failed: {e}")
+                            # enrich=True is an explicit opt-in the caller pays
+                            # latency for. Dropping it at debug level returns
+                            # plain snippets that look like a successful
+                            # enrichment.
+                            logger.warning(
+                                f"Snippet enrichment (enrich=True) failed for "
+                                f"query {query!r}; returning unenriched "
+                                f"snippets: {type(e).__name__}: {e}"
+                            )
 
                     # Citation standardization (always on -- cheap pure-python).
                     try:
@@ -1147,7 +1200,13 @@ async def search(  # noqa: PLR0913
                             )
                             modified = True
                     except Exception as e:
-                        logger.debug(f"Citation standardization failed: {e}")
+                        # Pure-python and always on, so a failure here is our
+                        # own bug, not an upstream outage.
+                        logger.warning(
+                            f"Citation standardization failed for query "
+                            f"{query!r}; results ship without freshness / "
+                            f"citation metadata: {type(e).__name__}: {e}"
+                        )
 
                     if modified:
                         result = json.dumps(data, ensure_ascii=False, indent=2)
@@ -2505,6 +2564,10 @@ async def _background_index_and_search(
                     results = await asyncio.gather(*tasks, return_exceptions=True)
                     for i, res in enumerate(results):
                         if isinstance(res, BaseException):
+                            logger.warning(
+                                f"Alternate docs source failed for '{library}' "
+                                f"at {alt_urls[i]}: {type(res).__name__}: {res}"
+                            )
                             continue
                         alt_chunks, alt_pages = res
                         if alt_pages > page_count and len(alt_chunks) > len(all_chunks):
@@ -2513,7 +2576,12 @@ async def _background_index_and_search(
                             page_count = alt_pages
                             break
             except Exception as e:
-                logger.debug(f"SearXNG fallback failed: {e}")
+                logger.warning(
+                    f"SearXNG docs fallback failed for '{library}' "
+                    f"(query {fallback_query!r}); staying with "
+                    f"{len(all_chunks)} chunks from {page_count} pages: "
+                    f"{type(e).__name__}: {e}"
+                )
 
         if not all_chunks:
             logger.error(
@@ -2543,6 +2611,17 @@ async def _background_index_and_search(
                         _embed_batch(embed_texts_list), timeout=_EMBED_TIMEOUT
                     )
                 except TimeoutError:
+                    # Storing the chunks anyway is the intended degrade (they
+                    # stay keyword-searchable), but the version is then stamped
+                    # 'indexed' with a full chunk_count while holding zero
+                    # vectors. Without this line that swap is invisible.
+                    logger.error(
+                        f"Embedding batch timed out after {_EMBED_TIMEOUT}s for "
+                        f"'{library}' ({len(embed_texts_list)} chunks from "
+                        f"{docs_url}); chunks are stored WITHOUT vectors, so "
+                        "this version answers keyword-only until it is "
+                        "re-indexed"
+                    )
                     embeddings = None
 
         # Store chunks
@@ -2567,7 +2646,19 @@ async def _background_index_and_search(
         )
 
     except Exception as e:
-        logger.error(f"Background indexing failed for {library}: {e}")
+        # Fire-and-forget task: nothing ever inspects its result, so this is
+        # the only record that the library was never indexed. A bare `{e}` on
+        # a KeyError/TypeError prints just the attribute name, which is what
+        # made the Tier 1 breakage of #1590 unreadable -- keep the traceback.
+        # Formatted here rather than via ``logger.opt(exception=True)`` because
+        # the stderr sink runs with loguru's default ``diagnose=True``, which
+        # would dump every local (chunk bodies, provider objects) into the log.
+        import traceback
+
+        logger.error(
+            f"Background indexing failed for '{library}' ({docs_url}): "
+            f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
+        )
 
 
 async def _search_cached_index(
@@ -2724,7 +2815,14 @@ async def _discover_docs_url(
         except TimeoutError:
             logger.warning("SearXNG discovery fallback timed out")
         except json.JSONDecodeError:
-            pass
+            # searxng_search reports failure by returning an "Error: ..."
+            # string, which lands here. Swallowing it made a dead SearXNG
+            # indistinguishable from "this library has no docs page".
+            logger.warning(
+                f"SearXNG discovery fallback for '{library}' returned "
+                f"non-JSON output, so no docs URL was found: "
+                f"{search_result[:200]!r}"
+            )
 
     return docs_url, repo_url, registry, description
 
@@ -2858,7 +2956,14 @@ async def _do_immediate_fallback_search(
                 query, fallback_data["results"], top_n=limit
             )
     except Exception as e:
-        logger.debug(f"Immediate fallback search failed: {e}")
+        # The caller ships this as `temporary_results` next to a message
+        # promising web results. An empty list therefore reads as "the web had
+        # nothing" rather than "the fallback search never ran".
+        logger.warning(
+            f"Immediate fallback search failed for '{library}' "
+            f"(query {fallback_search_query!r}); temporary_results will be "
+            f"empty: {type(e).__name__}: {e}"
+        )
     return fallback_data
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -8,6 +8,7 @@ RRF fusion scoring, and tiered FTS fallback.
 
 import importlib.util
 import json
+import sqlite3
 import struct
 import sys
 import types
@@ -863,7 +864,12 @@ class TestAddChunksVec:
             db.close()
 
     def test_add_chunks_vec_batch_insert_error(self, tmp_path):
-        """Batch vec insert error is caught gracefully."""
+        """Batch vec insert error aborts the batch instead of reporting success.
+
+        This used to be swallowed at debug level: ``add_chunks`` returned the
+        full chunk count and the caller stamped the version ``indexed`` over a
+        database that could not answer a single semantic query.
+        """
         db = DocsDB(tmp_path / "add_vec_err.db", embedding_dims=4)
         try:
             lib_id = db.upsert_library(name="emblib3")
@@ -874,14 +880,18 @@ class TestAddChunksVec:
             db._conn.commit()
 
             embeddings = [[1.0, 0.0, 0.0, 0.0]]
-            # Should not raise — error caught in except block
-            count = db.add_chunks(
-                ver_id,
-                lib_id,
-                [{"content": "test"}],
-                embeddings=embeddings,
-            )
-            assert count == 1  # doc chunks still inserted
+            with pytest.raises(sqlite3.Error):
+                db.add_chunks(
+                    ver_id,
+                    lib_id,
+                    [{"content": "test"}],
+                    embeddings=embeddings,
+                )
+            # The doc_chunks rows share the failed transaction.
+            remaining = db._conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[
+                0
+            ]
+            assert remaining == 0
         finally:
             db.close()
 

--- a/tests/test_db_add_chunks_serialization.py
+++ b/tests/test_db_add_chunks_serialization.py
@@ -1,6 +1,8 @@
 import sqlite3
 from typing import Any, cast
 
+import pytest
+
 from wet_mcp.db import DocsDB
 
 
@@ -9,7 +11,15 @@ class TestAddChunksSerialization:
         """Verify add_chunks handles embedding serialization failure and continues."""
         # Initialize DocsDB with vector support enabled
         db = DocsDB(tmp_path / "extra_ser.db", embedding_dims=2)
-        db._vec_enabled = True
+        if not db._vec_enabled:
+            db.close()
+            pytest.skip(
+                "sqlite-vec did not load here (sqlite3 built without "
+                "enable_load_extension, e.g. macOS actions/setup-python), so "
+                "doc_chunks_vec was never created; the batch insert below now "
+                "aborts rather than swallowing, and forcing the flag on would "
+                "fabricate a state the server cannot reach"
+            )
 
         lib_id = db.upsert_library(name="extra_lib")
         ver_id = db.upsert_version(lib_id)

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -12,6 +12,7 @@ import struct
 import sys
 import types
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -334,7 +335,7 @@ class TestClearVersionChunksVec:
 
 class TestAddChunksWithEmbeddings:
     def test_add_chunks_vec_enabled_with_embeddings(self, tmp_path):
-        """Exercise embedding insertion path when vec is enabled (lines 526-540)."""
+        """A failed vector insert aborts the batch instead of reporting success."""
         d = DocsDB(tmp_path / "emb.db", embedding_dims=0)
         lib_id = d.upsert_library(name="emblib")
         ver_id = d.upsert_version(lib_id)
@@ -346,10 +347,12 @@ class TestAddChunksWithEmbeddings:
             {"content": "chunk A"},
             {"content": "chunk B"},
         ]
-        # This will try to insert into doc_chunks_vec which doesn't exist,
-        # exercising the exception handler (lines 534-540)
-        count = d.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
-        assert count == 2
+        # doc_chunks_vec does not exist at dims=0, so the vector INSERT fails.
+        # add_chunks used to swallow that and still return 2, which let the
+        # caller stamp the version 'indexed' over a vector-less batch.
+        with pytest.raises(sqlite3.Error):
+            d.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
+        assert d._conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[0] == 0
         d.close()
 
     def test_add_chunks_vec_empty_embedding_skipped(self, tmp_path):
@@ -365,8 +368,31 @@ class TestAddChunksWithEmbeddings:
             {"content": "chunk X"},
             {"content": "chunk Y"},
         ]
-        count = d.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
+
+        # dims=0 leaves doc_chunks_vec uncreated and a failing vector INSERT now
+        # aborts the batch, so route that one statement to a spy: what this test
+        # asserts is which rows reach it, not that they land.
+        real_conn = d._conn
+        vec_batches: list[list] = []
+
+        class _VecSpyConn:
+            def executemany(self, sql, params):
+                if "doc_chunks_vec" in sql:
+                    vec_batches.append(list(params))
+                    return None
+                return real_conn.executemany(sql, params)
+
+            def __getattr__(self, name):
+                return getattr(real_conn, name)
+
+        d._conn = cast(Any, _VecSpyConn())
+        try:
+            count = d.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
+        finally:
+            d._conn = real_conn
         assert count == 2
+        assert len(vec_batches) == 1
+        assert len(vec_batches[0]) == 1  # only the non-empty embedding
         d.close()
 
 
@@ -804,7 +830,7 @@ class TestAddChunksEdgeCases:
         db.close()
 
     def test_add_chunks_batch_insert_error(self, db):
-        """add_chunks handles batch insert failure for vectors (lines 825-826)."""
+        """A batch vector-insert failure reaches the caller (lines 825-826)."""
         # Force vec_enabled to reach the insert path
         db._vec_enabled = True
         lib_id = db.upsert_library(name="batchlib")
@@ -826,8 +852,8 @@ class TestAddChunksEdgeCases:
 
         mock_conn.executemany.side_effect = mock_executemany
         mock_conn.commit = real_conn.commit
+        mock_conn.rollback = real_conn.rollback
 
-        with patch.object(db, "_conn", mock_conn):
-            # Should not raise
-            count = db.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
-            assert count == 1
+        with patch.object(db, "_conn", mock_conn), pytest.raises(sqlite3.Error):
+            db.add_chunks(ver_id, lib_id, chunks, embeddings=embeddings)
+        assert real_conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[0] == 0

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -803,10 +803,18 @@ class TestProjectContext:
 class TestAddChunksEdgeCases:
     def test_add_chunks_serialization_error(self, tmp_path):
         """add_chunks handles embedding serialization failure (lines 817-818)."""
-        # Use embedding_dims > 0 and force _vec_enabled to ensure serialization loop is hit
-        # Use embedding_dims > 0 to ensure doc_chunks_vec table exists
+        # embedding_dims > 0 both reaches the serialization loop and creates
+        # doc_chunks_vec -- but only where sqlite-vec actually loads.
         db = DocsDB(tmp_path / "ser.db", embedding_dims=2)
-        db._vec_enabled = True
+        if not db._vec_enabled:
+            db.close()
+            pytest.skip(
+                "sqlite-vec did not load here (sqlite3 built without "
+                "enable_load_extension, e.g. macOS actions/setup-python), so "
+                "doc_chunks_vec was never created; the batch insert below now "
+                "aborts rather than swallowing, and forcing the flag on would "
+                "fabricate a state the server cannot reach"
+            )
         lib_id = db.upsert_library(name="serlib")
         ver_id = db.upsert_version(lib_id)
 

--- a/tests/test_server_cf_mode.py
+++ b/tests/test_server_cf_mode.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_docs_db_selection_sqlite(monkeypatch, tmp_path):
     monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
     # Isolate the docs DB to tmp_path so the B2 model-identity guard does not
@@ -18,8 +21,56 @@ def test_docs_db_selection_sqlite(monkeypatch, tmp_path):
 
 
 def test_docs_db_selection_cf_d1(cf_env):
+    """cf-d1 either hands back a complete backend or refuses to start.
+
+    Asserted as the invariant rather than as today's method count so this
+    passes unchanged once DocsDBCfBackend implements the rest of DocsDB.
+    """
     from wet_mcp.db_cf import DocsDBCfBackend
+    from wet_mcp.server import _missing_docs_db_methods, make_docs_db
+
+    missing = _missing_docs_db_methods(DocsDBCfBackend)
+    if not missing:
+        assert isinstance(make_docs_db(), DocsDBCfBackend)
+        return
+
+    with pytest.raises(RuntimeError) as excinfo:
+        make_docs_db()
+    for name in missing:
+        assert name in str(excinfo.value)
+
+
+def test_docs_db_cf_backend_missing_methods_refuses_to_start(cf_env, monkeypatch):
+    """A partial backend must fail at construction, not halfway through indexing.
+
+    ``_background_index_and_search`` calls ``add_chunks`` and then
+    ``mark_version_indexed``; with the second one absent the write lands, the
+    AttributeError is swallowed by the task's ``except Exception`` logger, and
+    the version stays un-indexed forever. Startup is the only place that
+    failure is still cheap and legible.
+    """
+    import wet_mcp.db_cf as db_cf_mod
     from wet_mcp.server import make_docs_db
 
-    db = make_docs_db()
-    assert isinstance(db, DocsDBCfBackend)
+    class _PartialBackend:
+        """Implements add_chunks but not the marks that follow it."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def add_chunks(self, *args, **kwargs) -> int:
+            return 0
+
+        def search(self, *args, **kwargs) -> list:
+            return []
+
+    monkeypatch.setattr(db_cf_mod, "DocsDBCfBackend", _PartialBackend)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        make_docs_db()
+
+    message = str(excinfo.value)
+    assert "_PartialBackend" in message
+    # The point of the guard is that it names what is missing.
+    assert "mark_version_indexed" in message
+    assert "upsert_library" in message

--- a/tests/test_silent_failure_surfacing.py
+++ b/tests/test_silent_failure_surfacing.py
@@ -565,7 +565,15 @@ def test_sqlite_vec_unavailable_is_reported_at_warning(tmp_path):
 def test_embedding_serialization_failure_names_the_chunk(tmp_path):
     """A per-chunk skip is fine; an unattributed per-chunk skip is not."""
     db = DocsDB(tmp_path / "ser.db", embedding_dims=2)
-    db._vec_enabled = True
+    if not db._vec_enabled:
+        db.close()
+        pytest.skip(
+            "sqlite-vec did not load here (macOS CI runs a python whose "
+            "sqlite3 has no enable_load_extension), so doc_chunks_vec was "
+            "never created. This test needs the surviving vector to land, and "
+            "forcing _vec_enabled on without the table is a state the server "
+            "cannot reach."
+        )
     try:
         lib_id = db.upsert_library(name="serlib")
         ver_id = db.upsert_version(lib_id)

--- a/tests/test_silent_failure_surfacing.py
+++ b/tests/test_silent_failure_surfacing.py
@@ -1,0 +1,711 @@
+"""Regressions for failures that used to be swallowed in server.py / db.py.
+
+Every test here pins an *observable* signal: either a WARNING/ERROR log record
+carrying enough context to trace the fault, or an exception that reaches the
+caller. On the pre-fix code each of these paths produced a success-shaped
+result with the cause hidden behind ``logger.debug`` or a bare ``pass`` -- the
+same shape that let ``refresh-tier1`` report success for eleven weeks over an
+empty docs database.
+
+Asserting "the function did not raise" is deliberately NOT what these tests do;
+that is the property that hid the bug.
+"""
+
+import contextlib
+import json
+import sqlite3
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from loguru import logger
+
+from wet_mcp import server
+from wet_mcp.db import DocsDB
+from wet_mcp.server import search
+
+_LEVELS = {
+    "TRACE": 5,
+    "DEBUG": 10,
+    "INFO": 20,
+    "SUCCESS": 25,
+    "WARNING": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+}
+
+
+@contextlib.contextmanager
+def captured_logs(level: str = "DEBUG"):
+    """Collect loguru records emitted inside the block.
+
+    ``logger.add`` is additive, so the module-level stderr sink configured by
+    ``wet_mcp.server`` keeps working and no global logger state is mutated.
+    """
+    records: list[dict] = []
+    sink_id = logger.add(lambda message: records.append(message.record), level=level)
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
+
+
+def at_least(records: list[dict], level: str) -> list[dict]:
+    """Records logged at ``level`` or above."""
+    floor = _LEVELS[level]
+    return [r for r in records if r["level"].no >= floor]
+
+
+def messages(records: list[dict], level: str) -> list[str]:
+    return [r["message"] for r in at_least(records, level)]
+
+
+@pytest.fixture(autouse=True)
+def _single_user_stdio_context():
+    """Keep this module off the real embedder and on the stdio credential path.
+
+    Three order-dependent hazards, all observed under ``pytest-randomly``:
+
+    * ``_background_index_and_search`` resolves the embedding backend lazily,
+      so an unmocked run downloads and loads a local ONNX model -- that turns a
+      failing assertion into a 30s timeout that kills the run. Tests that need
+      a backend patch the same target inside their own ``with`` block, which
+      takes precedence.
+    * ``credential_state._current_sub`` is a ContextVar that some tests set and
+      never clear, and pytest-asyncio copies the ambient context into the test
+      task. A leaked ``sub`` sends ``_require_credentials`` down the HTTP
+      multi-user branch, so the ``search`` tool returns an awaiting_setup
+      payload and never reaches the post-processing under test.
+    * conftest's ``_disable_uvx_tool_venv_detection`` neutralises
+      ``is_uvx_tool_venv`` only on whatever object is registered as
+      ``sys.modules["wet_mcp.server"]``. ``test_serverinfo_version.py`` pops
+      that key and re-imports, so from then on the module object bound at the
+      top of this file is a *different* object, and conftest patches the other
+      one. Measured under a random seed: ``{'uvx': True, 'same_module':
+      False}``; reproduced deterministically with
+      ``pytest tests/test_serverinfo_version.py tests/test_silent_failure_surfacing.py -p no:randomly``.
+      The detector genuinely returns True here -- it keys off a missing
+      ``pip``, which this uv-managed venv has none of -- so the unpatched copy
+      makes ``search`` bail out at the SearXNG gate and return the
+      blocked-error string before any post-processing runs. Pin the name on
+      the object these tests actually call into.
+    """
+    from wet_mcp.credential_state import set_current_sub
+
+    set_current_sub(None)
+    previous_db = server._docs_db
+    with (
+        patch("wet_mcp.embedder.resolve_embed_backend_for_request", return_value=None),
+        patch.object(server, "is_uvx_tool_venv", lambda: False),
+    ):
+        yield
+    server._docs_db = previous_db
+
+
+def _diag() -> dict:
+    """Ambient state that decides whether the search tool even runs its body."""
+    import sys
+
+    from wet_mcp.credential_state import get_current_sub, get_state
+
+    return {
+        "uvx": server.is_uvx_tool_venv(),
+        "same_module": server is sys.modules.get("wet_mcp.server"),
+        "sub": get_current_sub(),
+        "cred_state": get_state(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# server.py -- reranking and search post-processing
+# ---------------------------------------------------------------------------
+
+
+async def test_rerank_failure_is_reported_at_warning():
+    """A broken reranker degrades every search; debug level hid that."""
+    reranker = MagicMock()
+    reranker.rerank.side_effect = RuntimeError("rerank endpoint returned 502")
+    results = [{"content": f"chunk {i}"} for i in range(5)]
+
+    with (
+        patch(
+            "wet_mcp.reranker.resolve_rerank_backend_for_request",
+            return_value=reranker,
+        ),
+        captured_logs() as records,
+    ):
+        out = await server._rerank_results("how to mount a volume", results, top_n=2)
+
+    assert out == results[:2]
+    warned = messages(records, "WARNING")
+    assert any(
+        "Reranking failed" in m and "how to mount a volume" in m for m in warned
+    ), warned
+
+
+async def test_search_rerank_step_failure_is_reported_at_warning():
+    """The search action's rerank block swallowed its own bugs at debug."""
+    backend_results = json.dumps(
+        {
+            "results": [
+                {"url": "https://a.example", "title": "A", "snippet": "S"},
+            ],
+            "total": 1,
+            "query": "test",
+        }
+    )
+
+    chain = AsyncMock(return_value=backend_results)
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.chain_backend_names",
+            return_value=[],
+        ),
+        patch("wet_mcp.sources.search_backends.run_search_chain", new=chain),
+        patch.object(
+            server,
+            "_rerank_results",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("rerank blew up"),
+        ),
+        patch.object(server, "_web_cache", None),
+        captured_logs() as records,
+    ):
+        out = await search(action="search", query="pinned query", max_results=3)
+
+    warned = messages(records, "WARNING")
+    assert any(
+        "Search reranking step failed" in m and "pinned query" in m for m in warned
+    ), (warned, chain.await_count, _diag(), out)
+
+
+async def test_search_enrichment_failure_is_reported_at_warning():
+    """enrich=True is an explicit opt-in; dropping it must not be silent."""
+    backend_results = json.dumps(
+        {
+            "results": [
+                {"url": "https://a.example", "title": "A", "snippet": "S"},
+            ],
+            "total": 1,
+            "query": "test",
+        }
+    )
+
+    chain = AsyncMock(return_value=backend_results)
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.chain_backend_names",
+            return_value=[],
+        ),
+        patch("wet_mcp.sources.search_backends.run_search_chain", new=chain),
+        patch.object(
+            server,
+            "_rerank_results",
+            new_callable=AsyncMock,
+            side_effect=lambda q, r, top_n: r,
+        ),
+        patch(
+            "wet_mcp.sources.search_strategies.enrich_snippets",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("enrichment fetch failed"),
+        ),
+        patch.object(server, "_web_cache", None),
+        captured_logs() as records,
+    ):
+        out = await search(
+            action="search", query="enrich me", max_results=3, enrich=True
+        )
+
+    warned = messages(records, "WARNING")
+    assert any("Snippet enrichment" in m and "enrich me" in m for m in warned), (
+        warned,
+        chain.await_count,
+        _diag(),
+        out,
+    )
+
+
+async def test_search_citation_standardization_failure_is_reported_at_warning():
+    """Citation standardization is our own pure-python step -- a failure is a bug."""
+    backend_results = json.dumps(
+        {
+            "results": [
+                {"url": "https://a.example", "title": "A", "snippet": "S"},
+            ],
+            "total": 1,
+            "query": "test",
+        }
+    )
+
+    chain = AsyncMock(return_value=backend_results)
+    with (
+        patch(
+            "wet_mcp.sources.search_backends.chain_backend_names",
+            return_value=[],
+        ),
+        patch("wet_mcp.sources.search_backends.run_search_chain", new=chain),
+        patch.object(
+            server,
+            "_rerank_results",
+            new_callable=AsyncMock,
+            side_effect=lambda q, r, top_n: r,
+        ),
+        patch(
+            "wet_mcp.sources._search_polish.standardize_results",
+            side_effect=RuntimeError("bad citation shape"),
+        ),
+        patch.object(server, "_web_cache", None),
+        captured_logs() as records,
+    ):
+        out = await search(action="search", query="cite me", max_results=3)
+
+    warned = messages(records, "WARNING")
+    assert any(
+        "Citation standardization failed" in m and "cite me" in m for m in warned
+    ), (warned, chain.await_count, _diag(), out)
+
+
+# ---------------------------------------------------------------------------
+# server.py -- background docs indexing
+# ---------------------------------------------------------------------------
+
+
+def _chunk(i: int) -> dict:
+    return {
+        "url": "http://docs",
+        "title": "Guide",
+        "content": f"chunk {i}",
+        "heading_path": "Guide",
+        "chunk_index": i,
+    }
+
+
+async def test_background_index_alternate_source_failure_is_reported():
+    """Alternate docs URLs failed inside gather() with no record at all."""
+    searx_payload = json.dumps({"results": [{"url": "https://alt.example/docs"}]})
+
+    with (
+        patch("wet_mcp.sources.docs._normalize_docs_url", return_value="http://docs"),
+        patch.object(
+            server,
+            "_fetch_and_chunk_docs",
+            new_callable=AsyncMock,
+            side_effect=[([], 0), RuntimeError("alt source 403")],
+        ),
+        patch.object(
+            server,
+            "ensure_searxng",
+            new_callable=AsyncMock,
+            return_value="http://localhost:41592",
+        ),
+        patch.object(
+            server,
+            "searxng_search",
+            new_callable=AsyncMock,
+            return_value=searx_payload,
+        ),
+        captured_logs() as records,
+    ):
+        await server._background_index_and_search(
+            library="testlib",
+            lib_key="testlib",
+            language=None,
+            docs_url="http://docs",
+            repo_url="",
+            query="test",
+            version=None,
+            lib_id="1",
+            ver_id="1",
+        )
+
+    warned = messages(records, "WARNING")
+    assert any(
+        "Alternate docs source failed" in m
+        and "testlib" in m
+        and "https://alt.example/docs" in m
+        for m in warned
+    ), warned
+
+
+async def test_background_index_searxng_fallback_failure_is_reported():
+    """The last-resort docs fallback logged its own death at debug level."""
+    with (
+        patch("wet_mcp.sources.docs._normalize_docs_url", return_value="http://docs"),
+        patch.object(
+            server,
+            "_fetch_and_chunk_docs",
+            new_callable=AsyncMock,
+            return_value=([], 0),
+        ),
+        patch.object(
+            server,
+            "ensure_searxng",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("searxng container is down"),
+        ),
+        captured_logs() as records,
+    ):
+        await server._background_index_and_search(
+            library="testlib",
+            lib_key="testlib",
+            language="python",
+            docs_url="http://docs",
+            repo_url="",
+            query="test",
+            version=None,
+            lib_id="1",
+            ver_id="1",
+        )
+
+    warned = messages(records, "WARNING")
+    assert any(
+        "SearXNG docs fallback failed" in m
+        and "testlib" in m
+        and "testlib python documentation" in m
+        for m in warned
+    ), warned
+
+
+async def test_background_index_embedding_timeout_is_reported():
+    """Chunks stored with embeddings=None still get stamped 'indexed'."""
+    docs_db = MagicMock()
+    chunks = [_chunk(i) for i in range(3)]
+    previous_db = server._docs_db
+    server._docs_db = docs_db
+    try:
+        with (
+            patch(
+                "wet_mcp.sources.docs._normalize_docs_url", return_value="http://docs"
+            ),
+            patch.object(
+                server,
+                "_fetch_and_chunk_docs",
+                new_callable=AsyncMock,
+                return_value=(chunks, 5),
+            ),
+            patch(
+                "wet_mcp.embedder.resolve_embed_backend_for_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                server,
+                "_embed_batch",
+                new_callable=AsyncMock,
+                side_effect=TimeoutError,
+            ),
+            captured_logs() as records,
+        ):
+            await server._background_index_and_search(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
+    finally:
+        server._docs_db = previous_db
+
+    # The degrade itself is intended -- the chunks are still stored.
+    assert docs_db.add_chunks.call_args.kwargs["embeddings"] is None
+    docs_db.mark_version_indexed.assert_called_once()
+
+    errored = messages(records, "ERROR")
+    assert any(
+        "Embedding batch timed out" in m and "testlib" in m and "3 chunks" in m
+        for m in errored
+    ), errored
+
+
+async def test_background_index_crash_keeps_the_traceback():
+    """`{e}` alone on a KeyError prints one word; the task result is discarded."""
+    docs_db = MagicMock()
+    docs_db.add_chunks.side_effect = KeyError("content")
+    chunks = [_chunk(0)]
+    previous_db = server._docs_db
+    server._docs_db = docs_db
+    try:
+        with (
+            patch(
+                "wet_mcp.sources.docs._normalize_docs_url",
+                return_value="http://docs.example/guide",
+            ),
+            patch.object(
+                server,
+                "_fetch_and_chunk_docs",
+                new_callable=AsyncMock,
+                return_value=(chunks, 5),
+            ),
+            patch(
+                "wet_mcp.embedder.resolve_embed_backend_for_request",
+                return_value=None,
+            ),
+            captured_logs() as records,
+        ):
+            await server._background_index_and_search(
+                library="testlib",
+                lib_key="testlib",
+                language=None,
+                docs_url="http://docs.example/guide",
+                repo_url="",
+                query="test",
+                version=None,
+                lib_id="1",
+                ver_id="1",
+            )
+    finally:
+        server._docs_db = previous_db
+
+    crashes = [
+        r
+        for r in at_least(records, "ERROR")
+        if "Background indexing failed for 'testlib'" in r["message"]
+    ]
+    assert crashes, messages(records, "ERROR")
+    message = crashes[0]["message"]
+    assert "http://docs.example/guide" in message
+    assert "KeyError" in message
+    # The traceback is the part that makes a bare KeyError readable, and it
+    # must not carry loguru's `diagnose` variable dump.
+    assert "Traceback (most recent call last)" in message
+    assert "_background_index_and_search" in message
+
+
+async def test_discover_docs_url_non_json_searxng_is_reported():
+    """searxng_search reports failure as an "Error: ..." string, not an exception."""
+    with (
+        patch(
+            "wet_mcp.sources.docs.discover_library",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            server,
+            "ensure_searxng",
+            new_callable=AsyncMock,
+            return_value="http://localhost:41592",
+        ),
+        patch.object(
+            server,
+            "searxng_search",
+            new_callable=AsyncMock,
+            return_value="Error: SearXNG unreachable",
+        ),
+        captured_logs() as records,
+    ):
+        docs_url, _repo, _registry, _desc = await server._discover_docs_url(
+            "ghostlib", None
+        )
+
+    assert docs_url == ""
+    warned = messages(records, "WARNING")
+    assert any(
+        "SearXNG discovery fallback" in m
+        and "ghostlib" in m
+        and "SearXNG unreachable" in m
+        for m in warned
+    ), warned
+
+
+async def test_immediate_fallback_search_failure_is_reported():
+    """An empty temporary_results read as "the web had nothing"."""
+    with (
+        patch.object(
+            server,
+            "ensure_searxng",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("searxng container is down"),
+        ),
+        captured_logs() as records,
+    ):
+        data = await server._do_immediate_fallback_search(
+            docs_url="https://docs.example/guide",
+            library="testlib",
+            language=None,
+            query="how to install",
+            limit=5,
+        )
+
+    assert data == {"results": []}
+    warned = messages(records, "WARNING")
+    assert any(
+        "Immediate fallback search failed" in m
+        and "testlib" in m
+        and "how to install" in m
+        for m in warned
+    ), warned
+
+
+# ---------------------------------------------------------------------------
+# db.py
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_vec_unavailable_is_reported_at_warning(tmp_path):
+    """Dropping to FTS-only kills semantic search for the whole process."""
+    db_path = tmp_path / "novec.db"
+    with (
+        patch("sqlite_vec.load", side_effect=RuntimeError("no vec0 in this build")),
+        captured_logs() as records,
+    ):
+        db = DocsDB(db_path, embedding_dims=4)
+    try:
+        assert db._vec_enabled is False
+        warned = messages(records, "WARNING")
+        assert any("sqlite-vec unavailable" in m and "novec.db" in m for m in warned), (
+            warned
+        )
+    finally:
+        db.close()
+
+
+def test_embedding_serialization_failure_names_the_chunk(tmp_path):
+    """A per-chunk skip is fine; an unattributed per-chunk skip is not."""
+    db = DocsDB(tmp_path / "ser.db", embedding_dims=2)
+    db._vec_enabled = True
+    try:
+        lib_id = db.upsert_library(name="serlib")
+        ver_id = db.upsert_version(lib_id)
+        embeddings = cast(Any, [[1.0, 2.0], "not-an-embedding"])
+
+        with captured_logs() as records:
+            db.add_chunks(
+                ver_id,
+                lib_id,
+                [{"content": "good"}, {"content": "bad"}],
+                embeddings=embeddings,
+            )
+
+        warned = messages(records, "WARNING")
+        assert any(
+            "Dropping the embedding for chunk" in m and "str" in m for m in warned
+        ), warned
+    finally:
+        db.close()
+
+
+def test_vector_batch_insert_failure_reaches_the_caller(tmp_path):
+    """add_chunks used to report the full chunk count over a vector-less batch."""
+    # embedding_dims=0 leaves doc_chunks_vec uncreated; forcing _vec_enabled
+    # reproduces a live database whose vector table is missing or unwritable.
+    db = DocsDB(tmp_path / "batch.db", embedding_dims=0)
+    db._vec_enabled = True
+    try:
+        lib_id = db.upsert_library(name="batchlib")
+        ver_id = db.upsert_version(lib_id)
+
+        raised: Exception | None = None
+        with captured_logs() as records:
+            try:
+                db.add_chunks(
+                    ver_id,
+                    lib_id,
+                    [{"content": "c1"}, {"content": "c2"}],
+                    embeddings=[[1.0, 2.0], [3.0, 4.0]],
+                )
+            except sqlite3.Error as exc:
+                raised = exc
+
+        assert raised is not None, "vector insert failure never reached the caller"
+
+        errored = messages(records, "ERROR")
+        assert any("Vector insert failed" in m and "batch.db" in m for m in errored), (
+            errored
+        )
+
+        # The doc_chunks rows share the failed transaction and must not survive
+        # as a half-written "indexed" batch.
+        remaining = db._conn.execute("SELECT COUNT(*) FROM doc_chunks").fetchone()[0]
+        assert remaining == 0
+    finally:
+        db.close()
+
+
+def test_fts_search_failure_is_reported_at_warning(tmp_path):
+    """A broken FTS tier returns the same empty dict as "nothing matched"."""
+
+    class _FtsFailingConn:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, params=()):
+            if "doc_chunks_fts" in sql:
+                raise sqlite3.OperationalError("fts5: syntax error near AND")
+            return self._real.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    db = DocsDB(tmp_path / "fts.db", embedding_dims=0)
+    try:
+        lib_id = db.upsert_library(name="ftslib")
+        ver_id = db.upsert_version(lib_id)
+        db.add_chunks(ver_id, lib_id, [{"content": "installing the thing"}])
+        db.mark_version_indexed(ver_id, 1, 1)
+
+        real_conn = db._conn
+        db._conn = cast(Any, _FtsFailingConn(real_conn))
+        try:
+            with captured_logs() as records:
+                results = db.search(query="installing", library_name="ftslib")
+        finally:
+            db._conn = real_conn
+
+        assert results == []
+        warned = messages(records, "WARNING")
+        assert any("FTS search failed" in m and "installing" in m for m in warned), (
+            warned
+        )
+    finally:
+        db.close()
+
+
+def test_vector_search_failure_is_reported_at_warning(tmp_path):
+    """An empty vec_scores read as "nothing was semantically close"."""
+    db = DocsDB(tmp_path / "vecsearch.db", embedding_dims=0)
+    db._vec_enabled = True  # no doc_chunks_vec table exists at dims=0
+    try:
+        lib_id = db.upsert_library(name="veclib")
+        ver_id = db.upsert_version(lib_id)
+        db.add_chunks(ver_id, lib_id, [{"content": "installing the thing"}])
+        db.mark_version_indexed(ver_id, 1, 1)
+
+        with captured_logs() as records:
+            db.search(
+                query="installing",
+                library_name="veclib",
+                query_embedding=[1.0, 2.0],
+            )
+
+        warned = messages(records, "WARNING")
+        assert any("Vector search failed" in m for m in warned), warned
+    finally:
+        db.close()
+
+
+def test_unreadable_project_lock_is_reported_at_warning(tmp_path):
+    """An unreadable lock silently becomes "this project was never locked"."""
+    db = DocsDB(tmp_path / "lock.db", embedding_dims=0)
+    try:
+        db._conn.execute(
+            "INSERT INTO project_context "
+            "(project_path, locked_libraries, created_at, last_used_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("/repo/my-app", "{truncated json", 0.0, 0.0),
+        )
+        db._conn.commit()
+
+        with captured_logs() as records:
+            ctx = db.get_project_context("/repo/my-app")
+
+        assert ctx is not None
+        assert ctx["locked_libraries"] == []
+        warned = messages(records, "WARNING")
+        assert any("locked_libraries" in m and "/repo/my-app" in m for m in warned), (
+            warned
+        )
+    finally:
+        db.close()


### PR DESCRIPTION
## What this is

A pass over `src/wet_mcp/server.py` and `src/wet_mcp/db.py` asking one question at every `except`: **if this breaks, would anyone know?**

The `refresh-tier1` incident is the reference shape - twelve green runs over eleven weeks over an empty index, because three real bugs sat behind `except` / `logger.debug`. Every site below was classified individually; nothing was fixed in bulk.

Scope is exactly those two source files. `src/wet_mcp/sources/docs.py` (nine registry lookups that swallow) and `src/wet_mcp/db_cf.py` are deliberately untouched - they belong to other open work.

## Classification

Group 1 = real swallow, fixed. Group 2 = deliberate and correct, left alone. Group 3 = suspected but not measured, listed only.

### Group 1 - fixed

| Site | Class | What can fail, and who knew before |
|---|---|---|
| `server.py::_rerank_results` catch-all | 1 | reranker key/model/endpoint dead. Nobody - `logger.debug`, and the caller gets keyword order that looks like a ranked list |
| `server.py::search` rerank block | 1 | same, plus our own bug in the score filter. Nobody - `logger.debug` |
| `server.py::search` enrichment block | 1 | `enrich_snippets` fetch failure. Nobody - `logger.debug`; `enrich=True` is a paid-for opt-in that silently degrades to plain snippets |
| `server.py::search` citation standardization | 1 | our own pure-python bug. Nobody - `logger.debug`; results ship without freshness/citation metadata |
| `server.py::_background_index_and_search` gather over alternate docs URLs | 1 | alt source 403/timeout/parse. Nobody - `isinstance(res, BaseException)` then a bare `continue`, no log at any level |
| `server.py` SearXNG docs fallback | 1 | container down, non-JSON body. Nobody - `logger.debug(f"SearXNG fallback failed: {e}")` |
| `server.py` embedding batch timeout | 1 | embedding provider slow or down. Nobody - `except TimeoutError: embeddings = None` with no log at all; chunks are then stored vector-less and the version is stamped `indexed` with a full `chunk_count` |
| `server.py` background task outer catch-all | 1 | anything above. One line, `f"...failed for {library}: {e}"` - on a `KeyError` that prints one word and no traceback, exactly what made #1590 unreadable. The task result is never inspected, so this line is the only record |
| `server.py::_discover_docs_url` non-JSON SearXNG | 1 | SearXNG returns `Error: ...` instead of JSON. Nobody - `except json.JSONDecodeError: pass`; caller reads it as "no docs URL exists" |
| `server.py::_do_immediate_fallback_search` | 1 | SearXNG down. Nobody - `logger.debug`; an empty `temporary_results` reads as "the web had nothing" |
| `server.py::make_docs_db` cf-d1 branch | 1 | backend missing DocsDB methods. Nobody - no check at all; see the section below |
| `db.py::DocsDB.__init__` sqlite-vec load | 1 | extension missing or unloadable. Nobody - `logger.debug`; semantic search is off for the whole process while search still returns FTS hits |
| `db.py::_add_chunk_vectors` per-embedding serialize | 1 | one bad embedding value. Nobody - `logger.debug`, the chunk silently keeps no vector |
| `db.py::_add_chunk_vectors` batch insert | 1 | vec table missing or unwritable, dim mismatch. Nobody - `logger.debug`, and `add_chunks` still returned the full chunk count, so the caller stamped the version `indexed` over a database that cannot answer a single semantic query |
| `db.py::_run_fts_search` | 1 | FTS5 syntax error or corruption. Nobody - `logger.debug`; an empty dict is indistinguishable from "nothing matched" |
| `db.py::_run_vec_search` | 1 | vec table missing, dim mismatch. Nobody - `logger.debug`; same conflation |
| `db.py::get_project_context` | 1 | truncated or renamed `locked_libraries` JSON. Nobody - silent `except (TypeError, json.JSONDecodeError)`; the project reads as never locked, so Cabinets isolation switches itself off |

### Group 2 - deliberate, left untouched

Including the one site from the list I was handed that I did **not** change:

- **`server.py` docs-fetch `except TimeoutError` (pre-#1590 lines 2451-2455).** It already logs `logger.warning(f"Docs fetch timed out after {_FETCH_TIMEOUT}s for '{library}'")`, naming the library and the timeout, and the empty result it produces is either replaced by the SearXNG fallback (logged) or ends at the existing `logger.error("Could not extract content from ...")`. Nothing is hidden, so touching it would be noise. Called out explicitly because it was on the list.
- `_detect_gh_token` `except Exception: pass` - the caller already emits a WARNING naming the remediation, and `shutil.which` covers gh-absent.
- `_warmup_searxng` debug - every search re-calls `ensure_searxng` and returns an explicit error string to the caller.
- `_lifespan_shutdown` warmup-task cancel, and the `_with_timeout` grace-period catch - cleanup paths.
- The three `except json.JSONDecodeError: pass` sites in the `search` cache / post-processing paths - `_payload` re-raises them to the caller as `{"error": ...}`.
- `db.py` `except sqlite3.OperationalError: pass  # Column already exists` - ALTER idempotence.
- `db.py::clear_version_chunks` (already warning), `DocsDB.close()` (cleanup), `upsert_project_context` legacy-table debug no-op.

### Group 3 - suspected, not measured, not touched

1. The `db.py` ALTER-idempotence handler also swallows non-duplicate-column `OperationalError` (for example `database is locked`). Narrowing it needs message matching, and I did not measure which other messages actually occur here.
2. `_maybe_register_custom_embed` / `_maybe_register_custom_rerank` `except ValueError` conflates "already registered" with "invalid BYO spec". Splitting them needs qwen3-embed's exact error texts, which I did not verify.
3. `db.py::_clear_for_import` calls `logger.warning(..., exc_info=True)`. Under loguru `exc_info` is consumed as a format kwarg, so the traceback it claims to log is never emitted. Reported rather than fixed: that is a logging-API misuse, not a swallow, and it is outside the shape this PR changes.

## Two behaviour changes worth pushing back on

**1. `db.py::_add_chunk_vectors` batch insert now re-raises.** It logs at ERROR, calls `self._conn.rollback()` and re-raises. The rollback is required, not decorative: the `doc_chunks` `executemany` above shares the same open implicit transaction, so without it a later `commit()` would flush a half-written batch. `sqlite-vec` is a hard dependency (`pyproject.toml:45`) and `_vec_enabled=True` with `dims>0` guarantees the `doc_chunks_vec` table exists, so a failure here is a defect, not an environment quirk.

Four pre-existing tests encoded the old swallow contract and are updated here: `test_db.py::TestAddChunksVec::test_add_chunks_vec_batch_insert_error`, `test_db_coverage.py::test_add_chunks_vec_enabled_with_embeddings`, `test_add_chunks_batch_insert_error`, and `test_add_chunks_vec_empty_embedding_skipped`. The last one keeps its original intent - empty embeddings are skipped - via a proxy connection that observes the vec batch, instead of depending on the insert landing. Two more (`test_db_add_chunks_serialization.py::test_add_chunks_serialization_error_extra` and `test_db_coverage.py::TestAddChunksEdgeCases::test_add_chunks_serialization_error`) turned out to fabricate a vec-enabled database on platforms where sqlite-vec cannot load; see the last test-hygiene note.

**2. `make_docs_db()` refuses a deficient backend.** Measured on this branch: `DocsDBCfBackend` implements 7 methods, `DocsDB` exposes 17, and `server.py` alone calls 13 of them on `_docs_db`. Six of those 13 are missing: `mark_version_indexed`, `mark_library_indexed`, `clear_version_chunks`, `get_project_context`, `touch_project_context`, `close`.

On cf-d1 the background indexer calls `add_chunks(...)` - present, real rows land in D1 - and then `mark_version_indexed(...)` - absent - one line later, inside the task's `except Exception` that only logs. `versions.status` therefore never becomes `indexed`, and the library is re-indexed on every request while the row count keeps growing. `db_cf.py`'s own module docstring claims the interface "mirrors wet_mcp.db.DocsDB ... so server.py is polymorphic"; this guard enforces that claim at construction and names every missing method in the error, turning a silent hole into a startup failure that says exactly what is absent.

Two notes. `mark_library_indexed` landed today in `ec2a1756`, but it is **not** the cause - the `AttributeError` fires one line earlier on `mark_version_indexed`, which was never there. And the check compares against `DocsDB` at runtime rather than a hand-written list, so it cannot drift and it turns itself off automatically once `db_cf.py` is complete; `test_docs_db_selection_cf_d1` is written as an invariant (raise while methods are missing, `isinstance` once they are not) so the CF work does not have to come back and edit this test.

## Tests

Every group-1 site has a test asserting an **observable** signal: a WARNING-or-above loguru record carrying the context needed to trace the fault, or an exception reaching the caller. None of them assert "the function did not raise" - that is the property that hid the bug. Log capture uses an additive `logger.add` sink, so no global logger state is mutated.

Red was produced by running the new and updated tests against unpatched source (`git stash push -- src/wet_mcp/server.py src/wet_mcp/db.py`), not by argument.

### Red, before the patch

```
$ git stash push -- src/wet_mcp/server.py src/wet_mcp/db.py
$ uv run pytest tests/test_silent_failure_surfacing.py tests/test_server_cf_mode.py \
    tests/test_db.py::TestAddChunksVec::test_add_chunks_vec_batch_insert_error \
    tests/test_db_coverage.py::TestAddChunksWithEmbeddings \
    tests/test_db_coverage.py::TestAddChunksEdgeCases -p no:randomly --tb=line -q --timeout=30

FFFFFFFFFFFFFFFF.FFFF..F                                                 [100%]
=========================== short test summary info ===========================
FAILED tests/test_silent_failure_surfacing.py::test_rerank_failure_is_reported_at_warning
FAILED tests/test_silent_failure_surfacing.py::test_search_rerank_step_failure_is_reported_at_warning
FAILED tests/test_silent_failure_surfacing.py::test_search_enrichment_failure_is_reported_at_warning
FAILED tests/test_silent_failure_surfacing.py::test_search_citation_standardization_failure_is_reported_at_warning
FAILED tests/test_silent_failure_surfacing.py::test_background_index_alternate_source_failure_is_reported
FAILED tests/test_silent_failure_surfacing.py::test_background_index_searxng_fallback_failure_is_reported
FAILED tests/test_silent_failure_surfacing.py::test_background_index_embedding_timeout_is_reported
FAILED tests/test_silent_failure_surfacing.py::test_background_index_crash_keeps_the_traceback
FAILED tests/test_silent_failure_surfacing.py::test_discover_docs_url_non_json_searxng_is_reported
FAILED tests/test_silent_failure_surfacing.py::test_immediate_fallback_search_failure_is_reported
FAILED tests/test_silent_failure_surfacing.py::test_sqlite_vec_unavailable_is_reported_at_warning
FAILED tests/test_silent_failure_surfacing.py::test_embedding_serialization_failure_names_the_chunk
FAILED tests/test_silent_failure_surfacing.py::test_vector_batch_insert_failure_reaches_the_caller
FAILED tests/test_silent_failure_surfacing.py::test_fts_search_failure_is_reported_at_warning
FAILED tests/test_silent_failure_surfacing.py::test_vector_search_failure_is_reported_at_warning
FAILED tests/test_silent_failure_surfacing.py::test_unreadable_project_lock_is_reported_at_warning
FAILED tests/test_server_cf_mode.py::test_docs_db_selection_cf_d1 - ImportErr...
FAILED tests/test_server_cf_mode.py::test_docs_db_cf_backend_missing_methods_refuses_to_start
FAILED tests/test_db.py::TestAddChunksVec::test_add_chunks_vec_batch_insert_error
FAILED tests/test_db_coverage.py::TestAddChunksWithEmbeddings::test_add_chunks_vec_enabled_with_embeddings
FAILED tests/test_db_coverage.py::TestAddChunksEdgeCases::test_add_chunks_batch_insert_error
21 failed, 3 passed in 6.51s
```

Representative failure lines from that same run, showing the assertions are about signal and not about shape:

```
E   AssertionError: []

E   AssertionError: ['Background indexing failed: Could not extract content from http://docs']

E   AssertionError: ["Background indexing failed for testlib: 'content'"]

E   AssertionError: vector insert failure never reached the caller

E   ImportError: cannot import name '_missing_docs_db_methods' from 'wet_mcp.server'

E   Failed: DID NOT RAISE RuntimeError

E   Failed: DID NOT RAISE Error
```

The bare `[]` is the common case: nothing at warning or above was emitted at all. The third line is the point of the traceback change - on unpatched source the entire record of a crashed indexing run is `Background indexing failed for testlib: 'content'`, a `KeyError` rendered as one word.

### Green, after the patch

```
$ git stash pop
$ uv run pytest tests/test_silent_failure_surfacing.py tests/test_server_cf_mode.py \
    tests/test_db.py::TestAddChunksVec::test_add_chunks_vec_batch_insert_error \
    tests/test_db_coverage.py::TestAddChunksWithEmbeddings \
    tests/test_db_coverage.py::TestAddChunksEdgeCases -p no:randomly --tb=short -q --timeout=30

........................                                                 [100%]
24 passed in 5.38s
```

Both runs are on this branch's base, `21ab77c`.

The whole suite, in the random order pytest-randomly picks, on the branch as it stands:

```
$ uv run pytest tests/ -q --timeout=30
2163 passed, 33 skipped, 140 deselected, 17 warnings in 162.95s (0:02:42)
```

The whole suite runs as the pre-commit gate on this commit (gitleaks, ruff lint, ruff format, ty, pytest). Nothing here was committed with `--no-verify`.

Two test-hygiene notes, both found by the pre-commit run rather than by reading:

- The new tests patch `wet_mcp.server` symbols with `patch.object(server, ...)` rather than by dotted string, and an autouse fixture pins `resolve_embed_backend_for_request` to `None`. Under random ordering an unbound patch let `_background_index_and_search` reach the real local ONNX embedder, which turns a failing assertion into a 30-second timeout that kills the run instead of reporting it.
- The same fixture calls `set_current_sub(None)`. `credential_state._current_sub` is a `ContextVar`, `TestLlmProviderDetection::test_multi_user_sub_aware` and `::test_multi_user_no_fallback_to_env` set it to `"user-123"` and never clear it, and pytest-asyncio copies the ambient context into the test task. A leaked `sub` sends `_require_credentials` down the HTTP multi-user branch, so the `search` tool returns an `awaiting_setup` payload and never reaches the block under test. Reproduced deterministically:

  ```
  $ uv run pytest \
      "tests/test_credential_state.py::TestLlmProviderDetection::test_multi_user_no_fallback_to_env" \
      tests/test_silent_failure_surfacing.py -p no:randomly --tb=line -q --timeout=30

  # without the fixture guard
  FAILED tests/test_silent_failure_surfacing.py::test_search_rerank_step_failure_is_reported_at_warning
  FAILED tests/test_silent_failure_surfacing.py::test_search_enrichment_failure_is_reported_at_warning
  FAILED tests/test_silent_failure_surfacing.py::test_search_citation_standardization_failure_is_reported_at_warning
  3 failed, 14 passed in 6.57s

  # with it
  17 passed in 6.46s
  ```

  Fixed defensively in the new module only. The leak itself lives in `tests/test_credential_state.py` and is left alone here - it is unrelated to this PR's subject, and an autouse `set_current_sub(None)` in `conftest.py` would be the real fix for the suite.

- That was a real cause but not the whole one: the same three tests still failed on the next pre-commit run. Rather than guess again I made the assertions print the ambient state that decides whether the `search` tool even runs its body, and a full random-order run answered it: `{'uvx': True, 'same_module': False, 'sub': None, 'cred_state': CONFIGURED}`, with `chain.await_count == 0` - `run_search_chain` was never reached. The tool had returned `uvx_searxng_blocked_error(action)` from the gate at `server.py:1050`.

  `conftest.py::_disable_uvx_tool_venv_detection` neutralises `is_uvx_tool_venv` on whatever object is registered as `sys.modules["wet_mcp.server"]`. `tests/test_serverinfo_version.py` pops that key and re-imports the module, so afterwards the object bound at the top of my test file is a different one and conftest patches the other copy. The detector then runs for real, and it returns True correctly: it keys off a missing `pip`, which this uv-managed `.venv` does not have. Reproduced deterministically, and this is also the red-before for the fixture line:

  ```
  $ uv run pytest tests/test_serverinfo_version.py tests/test_silent_failure_surfacing.py \
      -p no:randomly -q --timeout=30

  # without patch.object(server, "is_uvx_tool_venv", lambda: False)
  FAILED tests/test_silent_failure_surfacing.py::test_search_rerank_step_failure_is_reported_at_warning
  FAILED tests/test_silent_failure_surfacing.py::test_search_enrichment_failure_is_reported_at_warning
  FAILED tests/test_silent_failure_surfacing.py::test_search_citation_standardization_failure_is_reported_at_warning
  3 failed, 14 passed in 9.20s

  # with it
  17 passed in 7.16s
  ```

  Fixed in the new module only, by patching the name on the module object these tests actually call into. Widening conftest's loop to cover stale copies would fix it suite-wide, but that is a shared-fixture change outside this PR's two files.

- The first CI run caught a third one, which is the re-raise doing its job. `Lint & Test (macos-latest)` failed 3 tests that ubuntu and windows passed: `test_db_add_chunks_serialization.py::test_add_chunks_serialization_error_extra`, `test_db_coverage.py::TestAddChunksEdgeCases::test_add_chunks_serialization_error`, and my own `test_embedding_serialization_failure_names_the_chunk`, all with `sqlite3.OperationalError: no such table: doc_chunks_vec`.

  All three build a `DocsDB(..., embedding_dims=2)` and then force `db._vec_enabled = True`. On macOS CI the interpreter's `sqlite3` has no `enable_load_extension`, so `sqlite_vec` never loads, `doc_chunks_vec` is never created, and the forced flag describes a state `DocsDB` cannot produce - `_vec_enabled` is only set True after the extension loads, and the table is created under the same condition. The old swallow is what hid the inconsistency; two of the three even wrapped their vec assertion in `except sqlite3.OperationalError: pass` with the comment "extension not loaded, that's fine".

  They now skip when the extension did not load, keyed on the DocsDB's own `_vec_enabled` rather than a second global probe. `tests/test_db.py` already skips its whole vec suite for the same platform reason (`_requires_sqlite_vec`, reason text: "sqlite3 built without enable_load_extension, e.g. macOS actions/setup-python builds"), which is why those tests were skipped rather than failed on that lane. Verified locally by blocking the `sqlite_vec` import for the whole suite: the three skip, and the only two remaining failures are artifacts of the block itself (`test_db_extra.py::test_sqlite_vec_extension` imports the module directly; `test_sqlite_vec_unavailable_is_reported_at_warning` patches `sqlite_vec.load`) - both pass on the real macOS lane.

## Not in this PR

- `sources/docs.py` registry-lookup swallows - separate PR, another branch is open on that file.
- `db_cf.py`'s missing methods - that is the CF backend task; this PR only makes their absence loud.
- `tests/test_config.py::test_resolve_embedding_backend_none`, red on `main` for any machine with `EMBEDDING_MODELS` / `JINA_AI_API_KEY` set (it builds `Settings()` before `mock.patch.dict(..., clear=True)`). Untouched deliberately.
