### PR TITLE
fix: isolate test_config Settings() from leaked provider env vars

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,135 @@ from unittest import mock
 
 import pytest
 from pydantic import SecretStr
+from pydantic_settings.sources import EnvSettingsSource
 
 from wet_mcp.config import Settings
+from wet_mcp.credential_state import CLOUD_KEYS
+
+
+def _settings_env_names() -> set[str]:
+    """Every env var name that ``Settings`` itself reads.
+
+    Derived from the model instead of hand-listed. ``EnvSettingsSource`` is the
+    same resolver pydantic-settings runs at ``Settings.__init__``, so it already
+    accounts for ``env_prefix`` (empty in this repo) and ``case_sensitive``.
+    Adding or renaming a settings field therefore updates this set automatically
+    instead of silently drifting behind a hand-written list.
+    """
+    source = EnvSettingsSource(Settings)
+    return {
+        env_name.upper()
+        for field_name, field in Settings.model_fields.items()
+        for _, env_name, _ in source._extract_field_info(field, field_name)
+    }
+
+
+# Env vars that steer these tests but are NOT declared as ``Settings`` fields,
+# so they cannot be derived from the model and must be named by hand:
+#   * ``CLOUD_KEYS`` -- provider API keys read straight from ``os.environ`` by
+#     wet's litellm passthrough (embedder.py, reranker.py, llm.py) and by
+#     credential_state.resolve_credential_state(). Imported from
+#     ``credential_state`` rather than retyped so the two lists cannot diverge.
+#   * ``GOOGLE_API_KEY`` -- the GEMINI alias that ``Settings._key_available`` /
+#     ``resolve_provider_mode`` probe directly via ``os.getenv``; not itself a
+#     Settings field.
+#   * ``USE_BUNDLED_GOOGLE_CLIENT`` -- read inside
+#     ``mcp_core.auth.resolve_bundled_client`` while resolving the
+#     ``google_drive_client_*`` field defaults; the kill-switch var itself has
+#     no corresponding Settings field.
+#   * ``EMBEDDING_API_BASE`` / ``RERANK_API_BASE`` / ``LLM_API_BASE`` -- the
+#     per-task custom-endpoint overrides read directly via ``os.getenv`` in
+#     embedder.py / reranker.py / llm.py, never declared as Settings fields.
+_EXTRA_ENV_NAMES = {
+    *CLOUD_KEYS,
+    "GOOGLE_API_KEY",
+    "USE_BUNDLED_GOOGLE_CLIENT",
+    "EMBEDDING_API_BASE",
+    "RERANK_API_BASE",
+    "LLM_API_BASE",
+}
+# litellm's per-provider endpoint override lives beside each provider key
+# (JINA_AI_API_KEY -> JINA_AI_API_BASE). Real developer shells do export these
+# (a gateway URL), so derive the siblings instead of listing them one by one.
+_EXTRA_ENV_NAMES |= {
+    f"{key.removesuffix('_API_KEY')}_API_BASE"
+    for key in _EXTRA_ENV_NAMES
+    if key.endswith("_API_KEY")
+}
+
+
+def _clean_env_names() -> set[str]:
+    """Full set of env vars the ``clean_env`` fixture unsets."""
+    return _settings_env_names() | _EXTRA_ENV_NAMES
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Ensure environment isolation for configuration tests.
+
+    Clears every env var ``Settings`` declares (derived from the model, see
+    :func:`_settings_env_names`) plus the provider keys and endpoint overrides
+    that are read directly from ``os.environ`` (see :data:`_EXTRA_ENV_NAMES`).
+
+    This runs before each test body, so a developer shell exporting e.g.
+    ``EMBEDDING_MODELS`` / ``JINA_AI_API_KEY`` can no longer bake a leaked
+    value into a ``Settings()`` constructed later in the test. Clearing
+    *after* construction -- the old per-test
+    ``with mock.patch.dict(os.environ, {}, clear=True):`` pattern still used
+    below for isolating ``os.environ`` mutations made by ``setup_api_keys()``
+    -- is too late for that purpose, because pydantic-settings resolves env
+    vars once, synchronously, inside ``Settings.__init__``.
+    """
+    vars_to_clear = _clean_env_names()
+    # Thoroughly clear any variant of these keys in os.environ.
+    for k in list(os.environ.keys()):
+        if k.upper() in vars_to_clear:
+            monkeypatch.delenv(k, raising=False)
+    for v in vars_to_clear:
+        monkeypatch.delenv(v, raising=False)
+
+
+class TestCleanEnvCoverage:
+    """Guards against the clear-list drifting behind ``Settings`` again."""
+
+    def test_current_chain_vars_are_derived(self):
+        """The plural chain vars a hand-written list would be prone to miss."""
+        derived = _settings_env_names()
+        for name in ("EMBEDDING_MODELS", "RERANK_MODELS", "LLM_MODELS"):
+            assert name in derived, name
+
+    def test_deprecated_singular_vars_still_covered(self):
+        """The deprecated shims are still fields, so they stay in the set."""
+        derived = _settings_env_names()
+        assert {
+            "EMBEDDING_MODEL",
+            "RERANK_MODEL",
+            "EMBEDDING_BACKEND",
+            "RERANK_BACKEND",
+        } <= derived
+
+    def test_cloud_keys_are_cleared(self):
+        """Provider keys read directly from ``os.environ`` are all cleared."""
+        names = _clean_env_names()
+        assert set(CLOUD_KEYS) <= names
+
+    def test_endpoint_overrides_are_cleared(self):
+        """``*_API_BASE`` is read via os.getenv, never declared on Settings."""
+        names = _clean_env_names()
+        assert {"EMBEDDING_API_BASE", "RERANK_API_BASE", "LLM_API_BASE"} <= names
+        # litellm per-provider endpoint siblings.
+        assert {"JINA_AI_API_BASE", "GEMINI_API_BASE"} <= names
+
+    def test_google_alias_and_kill_switch_are_cleared(self):
+        """GOOGLE_API_KEY alias + the bundled-client kill-switch are covered."""
+        names = _clean_env_names()
+        assert {"GOOGLE_API_KEY", "USE_BUNDLED_GOOGLE_CLIENT"} <= names
+
+    def test_every_settings_field_is_represented(self):
+        """No field may be silently absent from the clear-list."""
+        names = _clean_env_names()
+        missing = [f for f in Settings.model_fields if f.upper() not in names]
+        assert missing == []
 
 
 def test_setup_api_keys_valid():

--- a/tests/test_config_gpu.py
+++ b/tests/test_config_gpu.py
@@ -125,8 +125,12 @@ def test_resolve_local_model_no_gpu_no_gguf():
         assert _resolve_local_model("onnx", "gguf") == "onnx"
 
 
-def test_resolve_local_embedding_model_gpu():
+def test_resolve_local_embedding_model_gpu(monkeypatch):
     """Test resolve_local_embedding_model returns GGUF when GPU and GGUF available."""
+    # A dev shell exporting LOCAL_EMBEDDING_MODEL (BYO override) would otherwise
+    # get baked into Settings() below, short-circuiting resolve_local_embedding_model()
+    # before it ever reaches the GPU/GGUF branch this test targets.
+    monkeypatch.delenv("LOCAL_EMBEDDING_MODEL", raising=False)
     s = Settings()
     with (
         mock.patch("wet_mcp.config._detect_gpu", return_value=True),
@@ -137,8 +141,9 @@ def test_resolve_local_embedding_model_gpu():
         assert "Embedding" in result
 
 
-def test_resolve_local_embedding_model_no_gpu():
+def test_resolve_local_embedding_model_no_gpu(monkeypatch):
     """Test resolve_local_embedding_model returns ONNX when no GPU."""
+    monkeypatch.delenv("LOCAL_EMBEDDING_MODEL", raising=False)
     s = Settings()
     with (
         mock.patch("wet_mcp.config._detect_gpu", return_value=False),
@@ -149,8 +154,10 @@ def test_resolve_local_embedding_model_no_gpu():
         assert "Embedding" in result
 
 
-def test_resolve_local_rerank_model_gpu():
+def test_resolve_local_rerank_model_gpu(monkeypatch):
     """Test resolve_local_rerank_model returns GGUF when GPU and GGUF available."""
+    # Same leak vector as above, for the rerank BYO override.
+    monkeypatch.delenv("LOCAL_RERANK_MODEL", raising=False)
     s = Settings()
     with (
         mock.patch("wet_mcp.config._detect_gpu", return_value=True),
@@ -161,8 +168,9 @@ def test_resolve_local_rerank_model_gpu():
         assert "Reranker" in result
 
 
-def test_resolve_local_rerank_model_no_gpu():
+def test_resolve_local_rerank_model_no_gpu(monkeypatch):
     """Test resolve_local_rerank_model returns ONNX when no GPU."""
+    monkeypatch.delenv("LOCAL_RERANK_MODEL", raising=False)
     s = Settings()
     with (
         mock.patch("wet_mcp.config._detect_gpu", return_value=False),


### PR DESCRIPTION
## The bug

`tests/test_config.py::test_resolve_embedding_backend_none` constructs
`Settings()`, then clears `os.environ` with
`mock.patch.dict(os.environ, {}, clear=True)` -- but pydantic-settings
resolves every env var once, synchronously, inside `Settings.__init__`.
Clearing *after* construction is too late: a dev shell exporting
`EMBEDDING_MODELS=jina_ai/jina-embeddings-v5-text-small` +
`JINA_AI_API_KEY=...` bakes a leaked cloud chain into the instance, and
the test asserts `'local'` against the actual `'cloud'`. CI never sees
this because its runners are clean; it only hazes local dev (and blocks
pre-commit on unrelated commits).

The file has ~70 `Settings(...)` construction sites and ~26
`patch.dict` blocks, so this ordering mistake is a repeatable trap, not
a one-off typo -- a fresh contributor copying the existing style
reproduces it.

## The fix

Add an autouse `clean_env` fixture (module-scoped to `test_config.py`,
no blast radius on other files) that clears every env var `Settings`
declares -- derived from the model via pydantic-settings' own
`EnvSettingsSource` (the exact resolver `Settings.__init__` runs), so a
future field addition/rename updates the set automatically instead of
drifting behind a hand-written list -- plus the provider keys /
endpoint overrides read directly from `os.environ` and never declared
as `Settings` fields: `credential_state.CLOUD_KEYS`, the
`GOOGLE_API_KEY` GEMINI alias, `USE_BUNDLED_GOOGLE_CLIENT` (the bundled
OAuth client kill-switch), and `EMBEDDING_API_BASE` /
`RERANK_API_BASE` / `LLM_API_BASE` (+ their litellm per-provider
`_API_BASE` siblings).

This fixture runs before each test body -- ahead of *any* `Settings()`
call in that test, regardless of where a `patch.dict` block sits in the
function -- so it fixes the ordering bug at the mechanism, the same way
`n24q02m/mnemo-mcp#1041` fixed the analogous drift in mnemo's
`test_config.py` (mnemo's `Settings` additionally has `AliasChoices`
fields wet's `Settings` does not, so this port omits that part).
`TestCleanEnvCoverage` (6 tests) locks the invariant in so it can't
silently regress.

The individual `with mock.patch.dict(os.environ, ...)` blocks already in
the file are left in place: several aren't for input-isolation at all --
they restore `os.environ` after `setup_api_keys()` mutates it, which the
new fixture doesn't replace.

### Second instance found in the same audit

`tests/test_config_gpu.py` has the identical bug via the
`LOCAL_EMBEDDING_MODEL` / `LOCAL_RERANK_MODEL` BYO-override fields, with
*no* isolation at all (not even a `patch.dict`): `resolve_local_embedding_model()`
/ `resolve_local_rerank_model()` return the leaked override verbatim
before ever reaching the GPU/GGUF branch under test, so 4 tests fail if
either var is set in the shell. Fixed with a narrow
`monkeypatch.delenv(...)` immediately before each `Settings()` call --
matching the style already used elsewhere in this repo for
single-purpose env isolation (`test_browser_backends.py`,
`test_cf_config.py`, `test_embed_rerank_cloud.py`), rather than importing
the broader `test_config.py` fixture across files.

## Evidence

**1. Red before** (`test_config.py` only), on unpatched `21ab77c`, in a
shell with `EMBEDDING_MODELS=jina_ai/jina-embeddings-v5-text-small` +
`JINA_AI_API_KEY=<leaked>`:

```
$ uv run pytest tests/test_config.py -q
FAILED tests/test_config.py::test_resolve_embedding_backend_none - AssertionError: assert 'cloud' == 'local'
1 failed, 67 passed in 32.52s
```

**2. Green after**, same polluted shell:

```
$ uv run pytest tests/test_config.py -q
74 passed in 24.51s
```
(67 + 1 formerly-failing + 6 new `TestCleanEnvCoverage` tests.)

**3. No regression**, same command with the leaked vars unset:

```
$ env -u EMBEDDING_MODELS -u JINA_AI_API_KEY uv run pytest tests/test_config.py -q
74 passed in 28.89s
```

**4. Second bug, isolated repro** (`test_config_gpu.py`, unpatched, with
`LOCAL_EMBEDDING_MODEL=<leaked>` + `LOCAL_RERANK_MODEL=<leaked>`):

```
4 failed, 11 passed in 27.91s
```
Patched, same env: `15 passed`.

**5. Full suite**, unpatched vs. patched, same shell carrying all four
leaked vars at once (`EMBEDDING_MODELS`, `JINA_AI_API_KEY`,
`LOCAL_EMBEDDING_MODEL`, `LOCAL_RERANK_MODEL`):

```
before (polluted, unpatched): 1 failed, 2187 passed, 33 skipped, 140 deselected  (390.19s)
after  (polluted, patched):       2194 passed, 33 skipped, 140 deselected       (343.76s)
```
2187 + 1 (fixed) + 6 (new `TestCleanEnvCoverage`) = 2194 -- exact accounting, no test lost or newly broken elsewhere.

**6. Survey of every other file constructing `Settings()`:**
`test_api_keys_security.py`, `test_browser_backends.py`,
`test_cf_config.py`, `test_embed_rerank_cloud.py`,
`test_server_cf_mode.py` each already `delenv`/`setenv` the exact vars
their own assertions depend on *before* constructing `Settings()` --
correct order, narrow scope, no drift liability. Left unchanged (out of
scope, nothing broken there).

## Scope

`tests/` only. Does not touch `src/wet_mcp/server.py` or
`src/wet_mcp/sources/db.py` (in flight on
`fix/silent-error-swallowing-server-db`, #1595).