### PR TITLE
fix: report weekly canary failures and keep their evidence

### DIFF
--- a/.github/workflows/canary-alert.yml
+++ b/.github/workflows/canary-alert.yml
@@ -1,0 +1,122 @@
+name: Canary Alert
+
+# Reports a failed weekly canary run into an issue.
+#
+# This deliberately lives OUTSIDE the workflow it watches. A notification step
+# inside `refresh-tier1` would be the obvious place for it, and it would not
+# work: `if: always()` and `if: failure()` are evaluated by the runner, so when
+# the runner itself dies they never run. Run 30736692116 is the proof -- the
+# `Build Tier 1 index` step failed with exit code 143 after
+# "The runner has received a shutdown signal", and the `Upload metrics
+# artifact` step that carries `if: always()` was reported as skipped, along
+# with every Post step. Nobody was told; the failure was found by hand a day
+# later.
+#
+# `workflow_run` fires on a different runner once the watched run has been
+# recorded as completed, so it survives the death of the run it reports on.
+#
+# Caveat worth knowing before relying on this: GitHub only dispatches
+# `workflow_run` from the copy of this file on the default branch, so it stays
+# inert until it is merged to main -- a pull request cannot exercise it.
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  report-canary-failure:
+    name: Open or update the canary failure issue
+    # CI runs exactly one job on `schedule` (refresh-tier1, itself gated on
+    # `github.event_name == 'schedule'`), so a failed scheduled CI run is a
+    # failed canary. Filtering on the event as well as the conclusion keeps
+    # ordinary red PR and push runs out of this path.
+    if: >-
+      github.event.workflow_run.event == 'schedule'
+      && github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      # `issues: write` covers both the issue and the label it is filed under.
+      issues: write
+      # `actions: read` is what lets `gh run view --log` read the run being
+      # reported; without it the issue would carry a link and no excerpt.
+      actions: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: File or update the canary failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_STARTED_AT: ${{ github.event.workflow_run.run_started_at }}
+          RUN_UPDATED_AT: ${{ github.event.workflow_run.updated_at }}
+          LABEL: canary-failure
+        run: |
+          set -euo pipefail
+
+          # Create the marker label first so the dedupe query below cannot fail
+          # on a repository that has never had a canary failure. Idempotent.
+          gh label create "$LABEL" --repo "$REPO" \
+            --color B60205 \
+            --description "Weekly Tier 1 canary run failed" \
+            2>/dev/null || true
+
+          # Prefer the failed step's log; a killed runner sometimes leaves no
+          # step marked failed, in which case the tail of the whole log is the
+          # only thing that shows what the run was doing when it stopped.
+          EXCERPT=$(gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null | tail -n 25 || true)
+          if [ -z "$EXCERPT" ]; then
+            EXCERPT=$(gh run view "$RUN_ID" --repo "$REPO" --log 2>/dev/null | tail -n 25 || true)
+          fi
+          if [ -z "$EXCERPT" ]; then
+            EXCERPT="(no log could be read; open the run and read it there)"
+          fi
+
+          BODY_FILE=$(mktemp)
+          {
+            echo "The weekly Tier 1 docs canary (\`refresh-tier1\` in CI) failed."
+            echo
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| run | $RUN_URL |"
+            echo "| run id | \`$RUN_ID\` |"
+            echo "| commit | \`$RUN_SHA\` |"
+            echo "| started | $RUN_STARTED_AT |"
+            echo "| ended | $RUN_UPDATED_AT |"
+            echo
+            echo "Last lines of the failing log:"
+            echo
+            echo '```'
+            echo "$EXCERPT"
+            echo '```'
+            echo
+            echo "Partial metrics, when the runner lived long enough for the"
+            echo "upload step to run, are in the \`tier1-index-metrics\` artifact"
+            echo "on that run. \`complete: false\` in that file means the script"
+            echo "was interrupted and the counts cover only the libraries listed."
+          } > "$BODY_FILE"
+
+          # Dedupe: one open issue holds the whole streak. Without this, every
+          # red week would file another issue and the canary would become its
+          # own source of backlog churn.
+          EXISTING=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+
+          if [ -n "$EXISTING" ]; then
+            echo "Appending to open canary issue #$EXISTING"
+            gh issue comment "$EXISTING" --repo "$REPO" --body-file "$BODY_FILE"
+          else
+            echo "No open canary issue; filing a new one"
+            gh issue create --repo "$REPO" \
+              --title "Weekly Tier 1 canary failed on $RUN_SHA" \
+              --label "$LABEL" \
+              --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,18 @@ jobs:
     name: Refresh Tier 1 docs index (weekly)
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    # Sized from measurement, not from the 6-hour default. The twelve green
+    # runs before #1590 finished in 2-7 minutes, but they were green because
+    # the ingest pipeline discarded every page, so they measure setup and
+    # discovery only. The first run that actually ingested (30736692116) got
+    # through 28 of the 50 libraries in 7m33s with the headless leg erroring
+    # out instantly, which extrapolates to ~14 minutes for the full list. The
+    # browser install below turns those instant errors back into real renders:
+    # 190 URLs escalated to headless in that run, and at the 60s crawler_timeout
+    # ceiling with _MAX_CONCURRENT_OPS=6 that is ~32 minutes of worst-case
+    # rendering on top. 45 covers measured base plus that arithmetic ceiling
+    # while still cutting a genuine hang eight times shorter than the default.
+    timeout-minutes: 45
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -254,12 +266,40 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Install chromium headless shell
+        # The canary crawls through the production strategy chain
+        # basic_http -> tls_spoof -> headless (crawler.py
+        # _build_scraping_agent), and the docs freshness target it guards is
+        # ">= 90% of Tier 1 within 7 days" (docs/BENCHMARKS.md), measured over
+        # that whole chain. Every other environment that runs this chain has a
+        # browser: the image installs one (Dockerfile, unless SLIM=1 drops the
+        # local legs on purpose) and so does the contributor setup
+        # (CONTRIBUTING.md). CI never did, which stayed invisible while the
+        # ingest pipeline was discarding pages anyway, and surfaced the week
+        # after #1590 unblocked it as 190 "All strategies failed ... last
+        # error: headless: BrowserType.launch: Executable doesn't exist"
+        # lines in run 30736692116.
+        #
+        # Only the headless shell is installed, not full chromium: the shell
+        # is the binary that run named (chromium_headless_shell-1228) because
+        # nothing here ever launches a headed browser, and it is the smaller
+        # download. --with-deps pulls the matching system libraries so this
+        # does not become a second silent missing-binary failure the first
+        # time the runner image drops one.
+        run: uv run playwright install --with-deps chromium-headless-shell
+
       - name: Build Tier 1 index
         run: uv run python scripts/build_tier1_index.py
 
       - name: Upload metrics artifact
-        # Runs even when the build step exits non-zero: a failing index run
-        # is exactly when the metrics file is worth reading.
+        # Covers the build step exiting non-zero, and -- now that the job has
+        # a timeout-minutes -- a hang that the runner cancels. It does NOT
+        # cover the runner being killed: `if: always()` is still evaluated by
+        # the runner, so in run 30736692116 this step was reported as skipped
+        # after "The runner has received a shutdown signal". For that case the
+        # only mitigation is upstream: build_tier1_index.py rewrites the
+        # metrics file after every library, so whatever the job manages to
+        # upload is a real partial record rather than nothing.
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/scripts/build_tier1_index.py
+++ b/scripts/build_tier1_index.py
@@ -4,8 +4,9 @@ Invoked manually or via CI weekly cron (.github/workflows/ci.yml).
 Walks every entry in src/wet_mcp/data/tier1_libraries.json, calls
 ``ingest_tier2`` so doc chunks are pulled via the web-core
 ``library_docs_strategy`` chain (RTD / Docusaurus / Mintlify / GitHub
-README), and writes a ``tier1_index_metrics.json`` summary alongside
-``docs.db``.
+README), and rewrites a ``tier1_index_metrics.json`` summary alongside
+``docs.db`` after every library, so an interrupted run still leaves the
+libraries it did reach on disk (``"complete": false`` marks such a file).
 
 Exits non-zero when fewer than ``--min-success-rate`` of the curated
 libraries end up with at least one chunk, so a run that indexes nothing
@@ -61,10 +62,53 @@ async def _amain() -> int:
 
     payload = _load_tier1_payload()
     libraries = payload.get("libraries", [])
-    print(f"Eager-ingesting {len(libraries)} Tier 1 libraries...")
+    # This line and every progress line below it flush explicitly. Python
+    # block-buffers stdout when it is a pipe, which a CI log always is, so in
+    # run 30736692116 the entire progress trace -- starting with this line --
+    # was still sitting in the buffer when the runner was killed, and the log
+    # kept only the loguru output that goes to stderr.
+    print(f"Eager-ingesting {len(libraries)} Tier 1 libraries...", flush=True)
 
     metrics: list[dict[str, Any]] = []
     started = time.time()
+    out_path = args.db_path.parent / "tier1_index_metrics.json"
+
+    def write_metrics(*, complete: bool) -> dict[str, Any]:
+        """Rewrite the metrics file from whatever has been collected so far.
+
+        Called after every library rather than once at the end. A run that is
+        cut short -- the CI job hitting its timeout, an unhandled crash, a
+        cancel -- then leaves a readable record of how far it got instead of no
+        file at all, which is what the 2026-08-02 canary failure left behind.
+        ``complete`` is how a reader tells the two apart: in a partial file the
+        aggregate counts describe only the libraries listed under ``metrics``,
+        and ``success_rate`` is therefore a lower bound, not a verdict.
+
+        The write goes to a sibling temp file and is renamed over the target,
+        so being killed mid-write cannot replace a usable file with a
+        truncated one.
+        """
+        indexed = [m for m in metrics if (m.get("chunk_count") or 0) > 0]
+        summary = {
+            "timestamp": time.time(),
+            "complete": complete,
+            "total_libraries": len(libraries),
+            "libraries_attempted": len(metrics),
+            "libraries_with_chunks": len(indexed),
+            "success_rate": round(len(indexed) / len(libraries), 4)
+            if libraries
+            else 0.0,
+            "min_success_rate": args.min_success_rate,
+            "total_pages": sum(m.get("page_count") or 0 for m in metrics),
+            "total_chunks": sum(m.get("chunk_count") or 0 for m in metrics),
+            "duration_seconds": round(time.time() - started, 2),
+            "metrics": metrics,
+        }
+        tmp_path = out_path.with_name(out_path.name + ".tmp")
+        tmp_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        tmp_path.replace(out_path)
+        return summary
+
     for entry in libraries:
         name = entry["id"]
         t0 = time.time()
@@ -82,35 +126,25 @@ async def _amain() -> int:
             )
             print(
                 f"  {name}: {result.get('status')} "
-                f"({result.get('chunk_count', 0)} chunks, {duration:.1f}s)"
+                f"({result.get('chunk_count', 0)} chunks, {duration:.1f}s)",
+                flush=True,
             )
         except Exception as exc:  # pragma: no cover - script-level guard
             metrics.append({"library": name, "status": "error", "error": str(exc)})
-            print(f"  {name}: ERROR {exc}")
+            print(f"  {name}: ERROR {exc}", flush=True)
+        write_metrics(complete=False)
 
-    indexed = [m for m in metrics if (m.get("chunk_count") or 0) > 0]
-    total_chunks = sum(m.get("chunk_count") or 0 for m in metrics)
-    total_pages = sum(m.get("page_count") or 0 for m in metrics)
-    success_rate = len(indexed) / len(libraries) if libraries else 0.0
-
-    summary = {
-        "timestamp": time.time(),
-        "total_libraries": len(libraries),
-        "libraries_with_chunks": len(indexed),
-        "success_rate": round(success_rate, 4),
-        "min_success_rate": args.min_success_rate,
-        "total_pages": total_pages,
-        "total_chunks": total_chunks,
-        "duration_seconds": round(time.time() - started, 2),
-        "metrics": metrics,
-    }
-    out_path = args.db_path.parent / "tier1_index_metrics.json"
-    out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    summary = write_metrics(complete=True)
+    indexed = summary["libraries_with_chunks"]
+    # Recomputed here rather than read back from the summary, which rounds:
+    # the threshold below is a gate, so it compares the exact ratio.
+    success_rate = indexed / len(libraries) if libraries else 0.0
 
     print("\n" + "=" * 60)
     print(
-        f"Tier 1 index: {len(indexed)}/{len(libraries)} libraries with chunks "
-        f"({success_rate:.0%}), {total_pages} pages, {total_chunks} chunks"
+        f"Tier 1 index: {indexed}/{len(libraries)} libraries with chunks "
+        f"({success_rate:.0%}), {summary['total_pages']} pages, "
+        f"{summary['total_chunks']} chunks"
     )
     print(f"Metrics written to {out_path}")
     print("=" * 60)


### PR DESCRIPTION
## What happened

The weekly `refresh-tier1` canary in CI went red for the first time on 2026-08-02 (run [30736692116](https://github.com/n24q02m/wet-mcp/actions/runs/30736692116), sha `bf60e92`) and nobody found out until someone went looking. Four separate things had to be true for that to happen, and this PR addresses each one.

## 1. Nothing watched the canary

The obvious fix -- a notification step at the end of `refresh-tier1` -- does not work here. That run ended with

```
##[error]The runner has received a shutdown signal. ...
##[error]Process completed with exit code 143.
```

and `gh run view 30736692116 --json jobs` reports the `Upload metrics artifact` step, which carries `if: always()`, as **skipped**, along with every Post step. `if: always()` and `if: failure()` are evaluated by the runner; a dead runner evaluates nothing.

So the alert lives in a new `.github/workflows/canary-alert.yml`, on `workflow_run` (`workflows: [CI]`, `types: [completed]`), which runs on a different runner after the watched run is recorded. It is filtered to `workflow_run.event == 'schedule'` and `workflow_run.conclusion == 'failure'` -- CI runs exactly one job on `schedule`, so a failed scheduled CI run is a failed canary.

Deduplication: it looks for an open issue carrying the `canary-failure` label and comments on that one if it exists, filing a new issue only when none is open. Without that, every red week files another issue and the canary becomes its own backlog churn. The issue body carries the run link, run id, sha, start/end timestamps, and the last 25 log lines (`--log-failed`, falling back to the tail of the whole log).

Uses the built-in `GITHUB_TOKEN` with `issues: write` (labels included) and `actions: read` (needed to read the log).

**Known limitation, stated rather than hidden:** GitHub only dispatches `workflow_run` from the copy of the file on the default branch, so this alert cannot be exercised by this PR. It arms on merge.

## 2. The missing browser was unintentional -- evidence for (a)

The crawl chain is `basic_http` -> `tls_spoof` -> `headless` (`_build_scraping_agent`, `src/wet_mcp/sources/crawler.py`), and on this runner the third leg failed for every URL that reached it (190 occurrences of `All strategies failed ... tried ['basic_http', 'tls_spoof', 'headless'], last error: headless: BrowserType.launch: Executable doesn't exist at .../chromium_headless_shell-1228/...`).

Reading that as intentional would need some sign that the canary is meant to measure the HTTP tier only. There is none, and there are four signs of the opposite:

1. **The metric it guards spans the whole chain.** `docs/BENCHMARKS.md` and `docs/docs-search.md` both state the target as ">= 90% of Tier 1 fresh within 7 days", measured by this cron. Not "of the pages reachable without JS".
2. **The threshold was calibrated with a browser present.** #1590 set `--min-success-rate` to 0.8 and reported "Verified end to end against the real crawler: 45/50 libraries indexed, 648 pages, 9183 chunks" -- a local run, and `CONTRIBUTING.md` tells contributors to run `playwright install chromium`. Keeping 0.8 while removing the leg that the 0.9 measurement came from would be incoherent.
3. **Every other environment installs a browser.** `Dockerfile` runs `playwright install chromium`, and the one place that deliberately drops the local browser -- the `SLIM=1` Cloudflare build -- says so in a comment and pairs with the documented `DISABLE_LOCAL_BROWSER` toggle. That toggle is the supported way to express intent (b), and it is not set here.
4. **It only became visible now, and for an unrelated reason.** The 12 green runs predate #1590, which found that "every fetched page was discarded" and "build_tier1_index.py returned 0 unconditionally". The headless leg was never reached, so its absence could not show. The failing sha has #1590 as an ancestor.

So: **(a), unintentional.** Added an install step. Only `chromium-headless-shell` is installed, not full chromium: `playwright install --dry-run chromium-headless-shell` resolves to `chromium_headless_shell-1228`, exactly the directory the failure named, and nothing in this codebase launches a headed browser. `--with-deps` is included so a future runner-image change cannot turn this into a second silent missing-binary failure.

## 3. `timeout-minutes: 45`

Job wall-clock from `gh run view <id> --json jobs` for all 13 scheduled runs:

| date | duration | result |
| --- | --- | --- |
| 2026-08-02 | 8m05s | failure |
| 2026-07-26 | 5m56s | success |
| 2026-07-19 | 2m16s | success |
| 2026-07-12 | 2m02s | success |
| 2026-07-05 | 2m56s | success |
| 2026-06-28 | 2m21s | success |
| 2026-06-21 | 2m58s | success |
| 2026-06-14 | 2m07s | success |
| 2026-06-07 | 5m20s | success |
| 2026-05-31 | 2m16s | success |
| 2026-05-24 | 2m52s | success |
| 2026-05-17 | 7m18s | success |
| 2026-05-10 | 2m11s | success |

Taking the 7m18s maximum and adding margin would be wrong, because those runs did no ingestion (see #1590) -- they measure setup and discovery. The usable number comes from the failing run itself: the script ran 06:52:18 to 06:59:51 (7m33s) and got through 28 of 50 libraries, which extrapolates to ~14 minutes for the full list. Restoring the browser turns 190 instant errors into real renders; at the 60s `crawler_timeout` ceiling over `_MAX_CONCURRENT_OPS = 6` that is up to ~32 minutes more. 14 + 32 rounds to **45**: room for the slowest plausible honest run, while a genuine hang surfaces eight times sooner than the 6-hour default.

## 4. Metrics that survive

`scripts/build_tier1_index.py` wrote `tier1_index_metrics.json` once, at the end. It now rewrites it after every library (temp file + rename, so a kill mid-write cannot truncate it), with a new `"complete"` flag: `false` while running, `true` on the final write. A partial file's `success_rate` is a lower bound over `libraries_attempted`, and the docstring says so.

The comment beside the upload step claimed more than it delivered, so it now says what is actually true: `if: always()` covers a non-zero exit and -- new with `timeout-minutes` -- a cancelled hang, but not a killed runner, and the incremental write is the mitigation for that case.

One extra finding from the same log: **no `print()` output from the script survives at all** in run 30736692116, not even the `Eager-ingesting 50 Tier 1 libraries...` header. Python block-buffers stdout into a pipe, and a CI log is a pipe, so the entire progress trace died in the buffer when the process was killed; only the loguru output, which goes to stderr, made it. The progress prints now pass `flush=True`. Same failure mode, same fix.

## Verification

- `ruff check`, `ruff format --check`, `ty check` clean; the full pre-commit suite (gitleaks, ruff, ty, pytest, yaml, diacritics) passed on commit.
- Both workflow files parse as YAML; the alert step's shell body passes `bash -n`.
- Ran the script against a scratch db and confirmed `tier1_index_metrics.json` appears after the **first** library with `"complete": false`, `"libraries_attempted": 1`.
- Ran it to completion over a single-library payload: `"complete": true`, exit 0 on a passing threshold and exit 1 on a failing one, no `.tmp` file left behind.
- `gh run view 30736692116 --log-failed | tail` does return the shutdown lines, so the issue excerpt will not be empty for this class of failure; `gh issue list --label canary-failure` on a repo without that label returns empty with exit 0.

Not verified, and not verifiable from a PR: the `workflow_run` trigger itself (see the limitation under section 1), and the real duration of a full 50-library run with the browser present -- the 45-minute budget is arithmetic, and the first scheduled run after merge is what measures it.

Generated with [Claude Code](https://claude.com/claude-code)
