### PR TITLE
fix: size D1 INSERT batches by bound parameters, add project_context to D1

### DIFF
--- a/migrations/0002_project_context.sql
+++ b/migrations/0002_project_context.sql
@@ -1,0 +1,25 @@
+-- migrations/0002_project_context.sql
+-- Closes two gaps between migrations/0001_init_wet.sql and the SQLite DocsDB
+-- schema in db.py, both of which a DocsDBCfBackend method needs:
+--   1. project_context -- db.py _create_project_context_table (Cabinets project
+--      isolation). upsert/get/touch_project_context read and write it.
+--   2. libraries.metadata_seeded_at -- db.py _create_libraries_table.
+--      mark_metadata_seeded writes it so a Tier-1 metadata seed stays
+--      distinguishable from a real index.
+-- doc_chunks_vec stays absent on purpose: D1 cannot load the sqlite-vec
+-- extension, so vectors live in Vectorize instead.
+--
+-- No transaction-control statements here: wrangler scans migration text for
+-- them and refuses the file, matching on the raw text even inside a comment.
+
+CREATE TABLE IF NOT EXISTS project_context (
+  project_path TEXT PRIMARY KEY,
+  locked_libraries TEXT NOT NULL,
+  created_at REAL NOT NULL,
+  last_used_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_context_last_used
+  ON project_context(last_used_at);
+
+ALTER TABLE libraries ADD COLUMN metadata_seeded_at REAL;

--- a/src/wet_mcp/backends/d1.py
+++ b/src/wet_mcp/backends/d1.py
@@ -15,7 +15,16 @@ from typing import Any
 
 import httpx
 
-# SQLite bound-variable ceiling; D1 inherits it. Keep INSERT batches well under.
+# Cloudflare D1 rejects any single query carrying more than this many bound
+# parameters. It is a limit on PARAMETERS, not on rows -- a distinction the
+# previous comment here lost, which is how a 100-row batch of the 13-column
+# doc_chunks INSERT came to send 1300 parameters and get refused.
+# https://developers.cloudflare.com/d1/platform/limits/
+D1_MAX_BOUND_PARAMS = 100
+
+# Upper bound on rows per multi-row INSERT, applied on top of the parameter cap
+# above. The parameter cap is what D1 enforces; this only lets a caller ask for
+# smaller statements than the cap would allow.
 _DEFAULT_MAX_ROWS_PER_INSERT = 100
 
 # Matches the trailing VALUES (?,?,...) tuple of a single-row INSERT so it can
@@ -82,11 +91,31 @@ class D1Backend:
     def executemany(self, sql: str, rows: list[list[Any]]) -> None:
         # D1 has no native executemany over HTTP; batch rows into multi-row
         # INSERTs (one POST per chunk) by expanding the VALUES (...) tuple.
+        #
+        # Batch size is DERIVED from how wide the rows actually are, never
+        # assumed: one statement carries rows_per_statement * cols parameters,
+        # and D1 refuses the whole statement past D1_MAX_BOUND_PARAMS. Sizing
+        # by row count alone silently scales the parameter count with the
+        # table's width.
         if not rows:
             return
+        cols = max((len(r) for r in rows), default=0)
+        if cols > D1_MAX_BOUND_PARAMS:
+            raise ValueError(
+                f"executemany was given {cols}-column rows, but D1 accepts at "
+                f"most {D1_MAX_BOUND_PARAMS} bound parameters per statement, so "
+                "not even one row fits. Splitting the row across statements "
+                "would write corrupt partial rows; widen the schema less, or "
+                "write the row in pieces the caller can make atomic itself."
+            )
+        rows_per_statement = (
+            min(self.max_rows_per_insert, D1_MAX_BOUND_PARAMS // cols)
+            if cols
+            else self.max_rows_per_insert
+        )
         match = _VALUES_TUPLE_RE.search(sql)
-        for i in range(0, len(rows), self.max_rows_per_insert):
-            batch = rows[i : i + self.max_rows_per_insert]
+        for i in range(0, len(rows), rows_per_statement):
+            batch = rows[i : i + rows_per_statement]
             if match and len(batch) > 1:
                 tuple_sql = match.group(1)
                 values = ", ".join(tuple_sql for _ in batch)

--- a/tests/test_backends_d1.py
+++ b/tests/test_backends_d1.py
@@ -33,6 +33,99 @@ def test_d1_executemany_chunks_large_batches():
     assert len(calls) == 2  # 2 + 1 rows -> 2 batched POSTs
 
 
+def _statements(payload):
+    """Flatten one captured POST body into the statements it carries.
+
+    `/query` sends a single {"sql", "params"} object; `/batch` sends a list of
+    them. The bound-parameter cap applies per statement either way.
+    """
+    return payload if isinstance(payload, list) else [payload]
+
+
+def test_executemany_never_exceeds_d1_bound_param_cap():
+    """No single D1 statement may carry more than 100 bound parameters.
+
+    Chunking by row count alone blows the cap on any table wider than one
+    column: the live doc_chunks INSERT writes 13 columns, so a full 100-row
+    batch carried 1300 parameters. D1 answers non-200, D1Backend raises
+    RuntimeError, and the indexing layer's broad `except Exception` logs and
+    moves on -- so no chunk is ever written and no error reaches the user.
+    """
+    payloads = []
+
+    class Http:
+        def request(self, method, url, data=None, headers=None):
+            payloads.append(json.loads(data.decode()))
+            return (200, json.dumps({"results": []}).encode())
+
+    cols = 13
+    rows = [[f"r{r}c{c}" for c in range(cols)] for r in range(50)]
+    sql = (
+        "INSERT INTO doc_chunks (id, version_id, library_id, url, title,"
+        " chunk_index, content, heading_path, section, topic, content_hash,"
+        " token_count, created_at) VALUES (" + ",".join(["?"] * cols) + ")"
+    )
+
+    db = D1Backend(base_url="http://d1.internal", http=Http())
+    db.executemany(sql, rows)
+
+    over = [
+        len(s["params"])
+        for p in payloads
+        for s in _statements(p)
+        if len(s["params"]) > 100
+    ]
+    assert not over, f"statements exceeding D1's 100-parameter cap: {over}"
+
+    # And every row must still arrive -- a cap honored by dropping rows would
+    # be the same silent data loss in a new costume.
+    sent = sum(len(s["params"]) for p in payloads for s in _statements(p))
+    assert sent == 50 * cols
+
+
+def test_executemany_batches_are_sized_from_column_count():
+    """Rows per statement is derived from the data, not assumed.
+
+    13 columns against a 100-parameter cap is 7 rows (91 params) per statement,
+    so 50 rows go out as 8 statements. Asserting the arithmetic keeps a future
+    column addition from silently re-crossing the cap.
+    """
+    payloads = []
+
+    class Http:
+        def request(self, method, url, data=None, headers=None):
+            payloads.append(json.loads(data.decode()))
+            return (200, json.dumps({"results": []}).encode())
+
+    cols = 13
+    rows = [[f"r{r}c{c}" for c in range(cols)] for r in range(50)]
+    sql = "INSERT INTO doc_chunks (a) VALUES (" + ",".join(["?"] * cols) + ")"
+    D1Backend(base_url="http://d1.internal", http=Http()).executemany(sql, rows)
+
+    sizes = [len(s["params"]) // cols for p in payloads for s in _statements(p)]
+    assert sizes == [7, 7, 7, 7, 7, 7, 7, 1]
+
+
+def test_executemany_rejects_a_row_too_wide_to_bind():
+    """A row wider than the cap cannot be sent at all -- say so, loudly.
+
+    Silently splitting such a row across statements would write corrupt
+    partial rows; returning quietly would write nothing.
+    """
+    import pytest
+
+    class Http:
+        def request(self, method, url, data=None, headers=None):
+            raise AssertionError("must not reach the network")
+
+    db = D1Backend(base_url="http://d1.internal", http=Http())
+    with pytest.raises(ValueError, match="bound parameter"):
+        db.executemany(
+            "INSERT INTO wide VALUES (" + ",".join(["?"] * 101) + ")",
+            [[f"c{i}" for i in range(101)]],
+        )
+
+
 def test_d1_raises_on_http_error():
     class Http:
         def request(self, method, url, data=None, headers=None):

--- a/tests/test_d1_schema_0002.py
+++ b/tests/test_d1_schema_0002.py
@@ -1,0 +1,87 @@
+"""Schema parity between the local SQLite DocsDB and the D1 migrations.
+
+wrangler owns the D1 schema; `db.py` owns the SQLite one. Anything `DocsDBCfBackend`
+reads or writes has to exist in BOTH, and nothing but the sqlite-vec table may be
+missing from D1 (D1 cannot load the extension).
+"""
+
+import sqlite3
+from pathlib import Path
+
+MIGRATIONS = Path("migrations")
+
+
+def _d1_conn():
+    conn = sqlite3.connect(":memory:")
+    for path in sorted(MIGRATIONS.glob("*.sql")):
+        conn.executescript(path.read_text(encoding="utf-8"))
+    return conn
+
+
+def _cols(conn, table):
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def test_project_context_table_exists_on_d1():
+    """`upsert_project_context` needs this table; 0001 never created it."""
+    conn = _d1_conn()
+    assert _cols(conn, "project_context") == {
+        "project_path",
+        "locked_libraries",
+        "created_at",
+        "last_used_at",
+    }
+
+
+def test_project_context_roundtrips():
+    conn = _d1_conn()
+    conn.execute(
+        "INSERT INTO project_context (project_path, locked_libraries, created_at,"
+        " last_used_at) VALUES (?,?,?,?)",
+        ("/repo", '[{"id": "lib1", "version": "1.0"}]', 1.0, 1.0),
+    )
+    row = conn.execute(
+        "SELECT locked_libraries FROM project_context WHERE project_path = ?",
+        ("/repo",),
+    ).fetchone()
+    assert row[0] == '[{"id": "lib1", "version": "1.0"}]'
+
+
+def test_libraries_has_metadata_seeded_at():
+    """`mark_metadata_seeded` writes this column; 0001 omitted it.
+
+    Without it a Tier-1 warmup seed is indistinguishable from a real index.
+    """
+    assert "metadata_seeded_at" in _cols(_d1_conn(), "libraries")
+
+
+def test_d1_tables_match_local_docsdb():
+    """The only table allowed to be D1-absent is the sqlite-vec virtual one."""
+    from wet_mcp.db import DocsDB
+
+    local_path = Path("__schema_parity.db")
+    try:
+        DocsDB(local_path, embedding_dims=0).close()
+        local = sqlite3.connect(local_path)
+        names = {
+            r[0]
+            for r in local.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+            if not r[0].startswith("sqlite_")
+        }
+        local.close()
+    finally:
+        local_path.unlink(missing_ok=True)
+
+    d1 = _d1_conn()
+    d1_names = {
+        r[0]
+        for r in d1.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        if not r[0].startswith("sqlite_")
+    }
+
+    missing = {n for n in names - d1_names if not n.startswith("doc_chunks_vec")}
+    assert not missing, f"tables present locally but missing from D1: {sorted(missing)}"


### PR DESCRIPTION
Infrastructure half of the `cf-d1` repair: make writes land correctly before adding the surface that depends on them. Follow-up PR implements the 10 missing `DocsDBCfBackend` methods on top of this.

## 1. INSERT batches were sized by rows, not parameters

`D1Backend.executemany` chunked by **row count** (`_DEFAULT_MAX_ROWS_PER_INSERT = 100`) under a comment claiming "SQLite bound-variable ceiling; D1 inherits it" — conflating *rows* with *bound variables*. D1 caps a statement at **100 bound parameters**.

The only live caller (`db_cf.py:132`) inserts **13-column** `doc_chunks` rows, so a full batch carried **1300** parameters. Just **8 rows** (8 x 13 = 104) already exceeds the cap. Result chain:

D1 non-200 -> `RuntimeError` -> swallowed by the indexing layer's log-only `except Exception` -> **not one chunk written**, no error surfaced.

Batch size is now **derived from the data**: `D1_MAX_BOUND_PARAMS // cols`. At 13 columns that is **7 rows / 91 parameters** per statement. A row too wide to bind at all (>100 columns) raises rather than being split into corrupt partial rows.

Sized the same way as the sibling fix in `mnemo-mcp` (`db_cf.py`, `D1_MAX_BOUND_PARAMS = 100`).

## 2. `migrations/0002` closes two schema gaps

`0001_init_wet.sql` defines 5 tables; the SQLite `DocsDB` has 7. Excluding `doc_chunks_vec` (deliberately absent — D1 cannot load sqlite-vec), two gaps remain, both needed by CF backend methods in the follow-up PR:

| gap | needed by |
|---|---|
| `project_context` table + index | `upsert_project_context` / `get_project_context` / `touch_project_context` |
| `libraries.metadata_seeded_at` column | `mark_metadata_seeded` |

`metadata_seeded_at` was **not** in the original scope note — found by diffing `_create_libraries_table` against `0001`. Without it a Tier-1 warmup seed is indistinguishable from a real index.

The migration contains no transaction-control statements anywhere, comments included (wrangler's `mayContainTransaction` scan matches raw text even inside comments). `migrations_dir` verified as `migrations` in `wrangler.jsonc`.

## Tests

All four new schema tests and three new batching tests were **red before the fix**:

```
FAILED test_executemany_never_exceeds_d1_bound_param_cap
  AssertionError: statements exceeding D1's 100-parameter cap: [650]
FAILED test_executemany_batches_are_sized_from_column_count
  assert [50] == [7, 7, 7, 7, 7, 7, 7, 1]
FAILED test_executemany_rejects_a_row_too_wide_to_bind
FAILED test_project_context_table_exists_on_d1
  AssertionError: assert set() == {'created_at', ... 'project_path'}
FAILED test_project_context_roundtrips
  sqlite3.OperationalError: no such table: project_context
FAILED test_libraries_has_metadata_seeded_at
FAILED test_d1_tables_match_local_docsdb
  AssertionError: tables present locally but missing from D1: ['project_context']
7 failed, 4 passed
```

(650 = 50 test rows x 13 columns in a single statement; production's 100-row batch is 1300.)

Green after: **2216 passed, 35 skipped**. `test_d1_tables_match_local_docsdb` is a standing guard — any future table added to `DocsDB` but not to D1 now fails CI instead of surfacing as a mid-index `AttributeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)