### PR TITLE
fix: implement the 10 missing DocsDBCfBackend methods and a vector delete route

### DIFF
--- a/docs/cf-template.md
+++ b/docs/cf-template.md
@@ -27,8 +27,13 @@ Hardened for E.1 + E.2 (PR series cf-p3-01); do not re-solve those per server.
 - The Container DO shape (`defaultPort`, `sleepAfter`, `enableInternet`, `envVars`).
 
 ## KEEP ONLY IF USED
-- `d1Outbound` + `D1` binding -> ONLY if the server uses D1 (mnemo only).
-- `vectorizeOutbound` + `VECTORIZE` binding -> ONLY if the server uses Vectorize (mnemo only).
+- `d1Outbound` + `D1` binding -> ONLY if the server uses D1 (wet, mnemo).
+- `vectorizeOutbound` + `VECTORIZE` binding -> ONLY if the server uses Vectorize (wet, mnemo).
+  Routes: `POST /upsert`, `POST /query`, `POST /deleteByIds`, and `GET -> {ready:true}`.
+  `deleteByIds` is REQUIRED on any server whose records can be re-indexed or deleted:
+  dropping the D1 rows without dropping their vectors leaves entries that keep scoring
+  in vector search but resolve to no content. Delete vectors BEFORE the rows, and do not
+  wrap that call in a log-only `except` — a half-completed delete must be visible.
 - imagine / notion / email / telegram are KV-only: drop both handlers + bindings; keep `kvOutbound`.
 
 ## Security (non-negotiable)

--- a/migrations/0002_project_context.sql
+++ b/migrations/0002_project_context.sql
@@ -1,0 +1,25 @@
+-- migrations/0002_project_context.sql
+-- Closes two gaps between migrations/0001_init_wet.sql and the SQLite DocsDB
+-- schema in db.py, both of which a DocsDBCfBackend method needs:
+--   1. project_context -- db.py _create_project_context_table (Cabinets project
+--      isolation). upsert/get/touch_project_context read and write it.
+--   2. libraries.metadata_seeded_at -- db.py _create_libraries_table.
+--      mark_metadata_seeded writes it so a Tier-1 metadata seed stays
+--      distinguishable from a real index.
+-- doc_chunks_vec stays absent on purpose: D1 cannot load the sqlite-vec
+-- extension, so vectors live in Vectorize instead.
+--
+-- No transaction-control statements here: wrangler scans migration text for
+-- them and refuses the file, matching on the raw text even inside a comment.
+
+CREATE TABLE IF NOT EXISTS project_context (
+  project_path TEXT PRIMARY KEY,
+  locked_libraries TEXT NOT NULL,
+  created_at REAL NOT NULL,
+  last_used_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_context_last_used
+  ON project_context(last_used_at);
+
+ALTER TABLE libraries ADD COLUMN metadata_seeded_at REAL;

--- a/src/wet_mcp/backends/d1.py
+++ b/src/wet_mcp/backends/d1.py
@@ -15,7 +15,16 @@ from typing import Any
 
 import httpx
 
-# SQLite bound-variable ceiling; D1 inherits it. Keep INSERT batches well under.
+# Cloudflare D1 rejects any single query carrying more than this many bound
+# parameters. It is a limit on PARAMETERS, not on rows -- a distinction the
+# previous comment here lost, which is how a 100-row batch of the 13-column
+# doc_chunks INSERT came to send 1300 parameters and get refused.
+# https://developers.cloudflare.com/d1/platform/limits/
+D1_MAX_BOUND_PARAMS = 100
+
+# Upper bound on rows per multi-row INSERT, applied on top of the parameter cap
+# above. The parameter cap is what D1 enforces; this only lets a caller ask for
+# smaller statements than the cap would allow.
 _DEFAULT_MAX_ROWS_PER_INSERT = 100
 
 # Matches the trailing VALUES (?,?,...) tuple of a single-row INSERT so it can
@@ -82,11 +91,31 @@ class D1Backend:
     def executemany(self, sql: str, rows: list[list[Any]]) -> None:
         # D1 has no native executemany over HTTP; batch rows into multi-row
         # INSERTs (one POST per chunk) by expanding the VALUES (...) tuple.
+        #
+        # Batch size is DERIVED from how wide the rows actually are, never
+        # assumed: one statement carries rows_per_statement * cols parameters,
+        # and D1 refuses the whole statement past D1_MAX_BOUND_PARAMS. Sizing
+        # by row count alone silently scales the parameter count with the
+        # table's width.
         if not rows:
             return
+        cols = max((len(r) for r in rows), default=0)
+        if cols > D1_MAX_BOUND_PARAMS:
+            raise ValueError(
+                f"executemany was given {cols}-column rows, but D1 accepts at "
+                f"most {D1_MAX_BOUND_PARAMS} bound parameters per statement, so "
+                "not even one row fits. Splitting the row across statements "
+                "would write corrupt partial rows; widen the schema less, or "
+                "write the row in pieces the caller can make atomic itself."
+            )
+        rows_per_statement = (
+            min(self.max_rows_per_insert, D1_MAX_BOUND_PARAMS // cols)
+            if cols
+            else self.max_rows_per_insert
+        )
         match = _VALUES_TUPLE_RE.search(sql)
-        for i in range(0, len(rows), self.max_rows_per_insert):
-            batch = rows[i : i + self.max_rows_per_insert]
+        for i in range(0, len(rows), rows_per_statement):
+            batch = rows[i : i + rows_per_statement]
             if match and len(batch) > 1:
                 tuple_sql = match.group(1)
                 values = ", ".join(tuple_sql for _ in batch)

--- a/src/wet_mcp/backends/vectorize.py
+++ b/src/wet_mcp/backends/vectorize.py
@@ -2,6 +2,7 @@
 
 upsert: POST {base}/upsert (ndjson lines {id, values, metadata}) -> {"mutationId": ...}
 query:  POST {base}/query json {vector, topK, filter} -> {"matches": [{id, score, metadata}]}
+delete: POST {base}/deleteByIds json {ids} -> {"mutationId": ...}
 ready:  GET  {base} -> {"ready": bool}
 Upsert is eventual (~seconds); add_chunks() callers must wait_until_indexed()
 before asserting search results. Fail-loud on non-200.
@@ -14,6 +15,11 @@ import os
 import time
 
 import httpx
+
+# Ids per `POST /deleteByIds` request. Cloudflare documents no hard id count for
+# this endpoint, so this is a client-side bound only -- it keeps re-indexing a
+# large version from building one enormous request body, and can be raised.
+VECTORIZE_DELETE_CHUNK = 500
 
 
 class _HttpxHttp:
@@ -59,6 +65,27 @@ class VectorizeBackend:
         if status != 200:
             raise RuntimeError(f"VectorizeBackend query failed: HTTP {status}")
         return json.loads(data.decode()).get("matches", [])
+
+    def delete_by_ids(self, ids: list[str]) -> list[str]:
+        """Delete vectors by id; returns one mutation id per request sent.
+
+        Fail-loud like upsert/query. A caller deleting chunk rows must be able
+        to tell that the matching vectors did NOT go: vectors left behind
+        outlive their content and come back as search hits with nothing to
+        show for them.
+        """
+        mutations: list[str] = []
+        for i in range(0, len(ids), VECTORIZE_DELETE_CHUNK):
+            body = json.dumps({"ids": ids[i : i + VECTORIZE_DELETE_CHUNK]}).encode()
+            status, data = self._http.request(
+                "POST", f"{self.base_url}/deleteByIds", body, self._headers()
+            )
+            if status != 200:
+                raise RuntimeError(
+                    f"VectorizeBackend deleteByIds failed: HTTP {status}"
+                )
+            mutations.append(json.loads(data.decode()).get("mutationId", ""))
+        return mutations
 
     def wait_until_indexed(
         self, poll_interval: float = 1.0, max_wait: float = 30.0

--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -8,8 +8,11 @@ URL diversity 2/url, adjacent prefetch) is REUSED from db.py, not reimplemented.
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
+
+from loguru import logger
 
 from wet_mcp.backends.d1 import D1Backend
 from wet_mcp.backends.vectorize import VectorizeBackend
@@ -153,6 +156,173 @@ class DocsDBCfBackend:
             # Upsert is eventual; block until index is ready so an immediate
             # search() doesn't return empty (mirrors spec risk mitigation).
             self._vec.wait_until_indexed()
+
+    def clear_version_chunks(self, version_id: str) -> int:
+        """Drop a version's chunks from D1 and their vectors from Vectorize.
+
+        Vectors go FIRST, and the delete is not error-suppressed. If Vectorize
+        refuses, the D1 rows stay as well, leaving the store merely stale --
+        the alternative ordering leaves vectors whose chunk row is gone, and
+        those come back from search() as hits with no content behind them.
+
+        Returns the number of chunks removed, counted from the ids actually
+        read (the D1 HTTP contract returns rows, not a rowcount).
+        """
+        rows = self._d1.execute(
+            "SELECT id FROM doc_chunks WHERE version_id = ?", [version_id]
+        )
+        ids = [r["id"] for r in rows]
+        if not ids:
+            return 0
+        self._vec.delete_by_ids(ids)
+        self._d1.execute("DELETE FROM doc_chunks WHERE version_id = ?", [version_id])
+        return len(ids)
+
+    # --- index bookkeeping ---
+
+    def mark_version_indexed(
+        self, version_id: str, page_count: int, chunk_count: int
+    ) -> None:
+        """Mark a version indexed with its counts.
+
+        The absence of exactly this method is what made cf-d1 lose data: the
+        indexer wrote chunks, raised AttributeError here inside a log-only
+        `except Exception`, and left the version at status='pending' so the
+        next request indexed it all over again.
+        """
+        self._d1.execute(
+            "UPDATE versions SET status = 'indexed', indexed_at = ?,"
+            " page_count = ?, chunk_count = ? WHERE id = ?",
+            [time.time(), page_count, chunk_count, version_id],
+        )
+
+    def mark_library_indexed(
+        self, library_id: str, total_versions: int | None = None
+    ) -> None:
+        """Update libraries.last_indexed_at, and total_versions when given.
+
+        DocsDB.mark_library_indexed probes pragma_table_info because a
+        pre-Alembic SQLite file may lack these columns. D1's schema is owned by
+        migrations/0001_init_wet.sql, which has both, so this writes fixed SQL
+        with no column names assembled at runtime.
+        """
+        if total_versions is None:
+            self._d1.execute(
+                "UPDATE libraries SET last_indexed_at = ? WHERE id = ?",
+                [time.time(), library_id],
+            )
+            return
+        self._d1.execute(
+            "UPDATE libraries SET last_indexed_at = ?, total_versions = ? WHERE id = ?",
+            [time.time(), int(total_versions), library_id],
+        )
+
+    def mark_metadata_seeded(self, library_id: str) -> None:
+        """Record a metadata-only seed pass (Tier 1 warmup freshness anchor).
+
+        Deliberately separate from last_indexed_at so a seeded-but-unindexed
+        library stays distinguishable from an indexed one. The column arrives
+        in migrations/0002_project_context.sql.
+        """
+        self._d1.execute(
+            "UPDATE libraries SET metadata_seeded_at = ? WHERE id = ?",
+            [time.time(), library_id],
+        )
+
+    # --- project context (Cabinets isolation) ---
+
+    def upsert_project_context(
+        self, project_path: str, locked_libraries: list[dict]
+    ) -> None:
+        """Persist a project's locked-library set, preserving created_at."""
+        now = time.time()
+        payload = json.dumps(locked_libraries, ensure_ascii=False)
+        existing = self._d1.fetchone(
+            "SELECT created_at FROM project_context WHERE project_path = ?",
+            [project_path],
+        )
+        if existing:
+            self._d1.execute(
+                "UPDATE project_context SET locked_libraries = ?, last_used_at = ?"
+                " WHERE project_path = ?",
+                [payload, now, project_path],
+            )
+            return
+        self._d1.execute(
+            "INSERT INTO project_context (project_path, locked_libraries,"
+            " created_at, last_used_at) VALUES (?,?,?,?)",
+            [project_path, payload, now, now],
+        )
+
+    def get_project_context(self, project_path: str) -> dict | None:
+        """Return the lock entry for a project, or None if not locked."""
+        row = self._d1.fetchone(
+            "SELECT project_path, locked_libraries, created_at, last_used_at"
+            " FROM project_context WHERE project_path = ?",
+            [project_path],
+        )
+        if row is None:
+            return None
+        result = dict(row)
+        try:
+            libs = json.loads(result["locked_libraries"])
+            if not isinstance(libs, list):
+                libs = []
+            result["locked_libraries"] = libs
+        except (TypeError, json.JSONDecodeError) as e:
+            # Same trade-off DocsDB.get_project_context documents: an unreadable
+            # lock reads as "nothing locked", which is shaped exactly like a
+            # project that was never locked, so it is logged rather than hidden.
+            logger.warning(
+                f"project_context row for {project_path!r} has unreadable "
+                f"locked_libraries ({type(e).__name__}: {e}); treating the "
+                "project as unlocked"
+            )
+            result["locked_libraries"] = []
+        return result
+
+    def touch_project_context(self, project_path: str) -> None:
+        """Update last_used_at; call before each query that honors a lock."""
+        self._d1.execute(
+            "UPDATE project_context SET last_used_at = ? WHERE project_path = ?",
+            [time.time(), project_path],
+        )
+
+    # --- lifecycle + file-based sync ---
+
+    def close(self) -> None:
+        """No handle to release: D1 and Vectorize are reached per request.
+
+        DocsDB.close() ends a long-lived sqlite3 connection. D1Backend and
+        VectorizeBackend hold nothing open between calls, so there is nothing
+        here to close. server.py calls this during shutdown, so it returns
+        quietly because there genuinely is no work -- not because a failure
+        was swallowed.
+        """
+
+    def export_jsonl(self) -> str:
+        raise NotImplementedError(
+            "export_jsonl is not available on DOCS_DB_BACKEND=cf-d1. The store "
+            "is Cloudflare D1 + Vectorize, already shared and durable across "
+            "every instance, so there is no local docs.db to export and no "
+            "second copy to keep in step. The GDrive/S3 DB-sync exists to move "
+            "a single-machine SQLite file around and is redundant here (see "
+            "docs/cf-template.md, 'Sync mode-gating'). Leave SYNC_ENABLED off "
+            "on a cf-d1 deployment, or read the rows directly with "
+            "`wrangler d1 execute`."
+        )
+
+    def import_jsonl(self, data: str, mode: str = "merge") -> dict:
+        raise NotImplementedError(
+            "import_jsonl is not available on DOCS_DB_BACKEND=cf-d1. Sync JSONL "
+            "carries no embeddings -- export_jsonl drops them by design -- so "
+            "every imported chunk would land in D1 with no matching vector in "
+            "Vectorize. Those chunks would answer FTS queries while staying "
+            "invisible to the vector arm of search(), i.e. a half-ranked index "
+            "that looks like a working one. Index the library normally so "
+            "chunks and embeddings are written together, or bulk-load D1 with "
+            "`wrangler d1 execute` and re-embed."
+        )
 
     # --- hybrid search (ranking pipeline reused from db.py) ---
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -28,6 +28,7 @@ export interface Env {
   VECTORIZE: {
     upsert(v: unknown[]): Promise<{ mutationId: string }>
     query(vector: number[], opts: { topK: number; filter?: unknown }): Promise<{ matches: unknown[] }>
+    deleteByIds(ids: string[]): Promise<{ mutationId: string }>
   }
   WET?: { idFromName(n: string): unknown; get(id: unknown): { fetch(r: Request): Promise<Response> } }
   // Container config (wrangler.jsonc `vars`) + secrets (`wrangler secret put`),
@@ -161,6 +162,12 @@ const vectorizeOutbound: OutboundHandler<Env> = async (request, env) => {
   if (url.pathname === '/query' && request.method === 'POST') {
     const { vector, topK, filter } = (await request.json()) as { vector: number[]; topK: number; filter?: unknown }
     return Response.json(await env.VECTORIZE.query(vector, { topK, filter }))
+  }
+  // Re-indexing deletes chunk rows from D1; without this route their vectors
+  // stay in the index and come back as search hits whose content is gone.
+  if (url.pathname === '/deleteByIds' && request.method === 'POST') {
+    const { ids } = (await request.json()) as { ids: string[] }
+    return Response.json(await env.VECTORIZE.deleteByIds(ids))
   }
   if (request.method === 'GET') return Response.json({ ready: true })
   return new Response('not found', { status: 404 })

--- a/tests/conftest_cf.py
+++ b/tests/conftest_cf.py
@@ -99,6 +99,10 @@ class FakeVectorizeHttp:
                 rec = json.loads(line)
                 self.vectors[rec["id"]] = (rec["values"], rec.get("metadata", {}))
             return (200, json.dumps({"mutationId": "mut-test"}).encode())
+        if url.endswith("/deleteByIds"):
+            for cid in json.loads(data.decode())["ids"]:
+                self.vectors.pop(cid, None)
+            return (200, json.dumps({"mutationId": "mut-del"}).encode())
         if url.endswith("/query"):
             q = json.loads(data.decode())
             ranked = sorted(

--- a/tests/test_backends_d1.py
+++ b/tests/test_backends_d1.py
@@ -33,6 +33,99 @@ def test_d1_executemany_chunks_large_batches():
     assert len(calls) == 2  # 2 + 1 rows -> 2 batched POSTs
 
 
+def _statements(payload):
+    """Flatten one captured POST body into the statements it carries.
+
+    `/query` sends a single {"sql", "params"} object; `/batch` sends a list of
+    them. The bound-parameter cap applies per statement either way.
+    """
+    return payload if isinstance(payload, list) else [payload]
+
+
+def test_executemany_never_exceeds_d1_bound_param_cap():
+    """No single D1 statement may carry more than 100 bound parameters.
+
+    Chunking by row count alone blows the cap on any table wider than one
+    column: the live doc_chunks INSERT writes 13 columns, so a full 100-row
+    batch carried 1300 parameters. D1 answers non-200, D1Backend raises
+    RuntimeError, and the indexing layer's broad `except Exception` logs and
+    moves on -- so no chunk is ever written and no error reaches the user.
+    """
+    payloads = []
+
+    class Http:
+        def request(self, method, url, data=None, headers=None):
+            payloads.append(json.loads(data.decode()))
+            return (200, json.dumps({"results": []}).encode())
+
+    cols = 13
+    rows = [[f"r{r}c{c}" for c in range(cols)] for r in range(50)]
+    sql = (
+        "INSERT INTO doc_chunks (id, version_id, library_id, url, title,"
+        " chunk_index, content, heading_path, section, topic, content_hash,"
+        " token_count, created_at) VALUES (" + ",".join(["?"] * cols) + ")"
+    )
+
+    db = D1Backend(base_url="http://d1.internal", http=Http())
+    db.executemany(sql, rows)
+
+    over = [
+        len(s["params"])
+        for p in payloads
+        for s in _statements(p)
+        if len(s["params"]) > 100
+    ]
+    assert not over, f"statements exceeding D1's 100-parameter cap: {over}"
+
+    # And every row must still arrive -- a cap honored by dropping rows would
+    # be the same silent data loss in a new costume.
+    sent = sum(len(s["params"]) for p in payloads for s in _statements(p))
+    assert sent == 50 * cols
+
+
+def test_executemany_batches_are_sized_from_column_count():
+    """Rows per statement is derived from the data, not assumed.
+
+    13 columns against a 100-parameter cap is 7 rows (91 params) per statement,
+    so 50 rows go out as 8 statements. Asserting the arithmetic keeps a future
+    column addition from silently re-crossing the cap.
+    """
+    payloads = []
+
+    class Http:
+        def request(self, method, url, data=None, headers=None):
+            payloads.append(json.loads(data.decode()))
+            return (200, json.dumps({"results": []}).encode())
+
+    cols = 13
+    rows = [[f"r{r}c{c}" for c in range(cols)] for r in range(50)]
+    sql = "INSERT INTO doc_chunks (a) VALUES (" + ",".join(["?"] * cols) + ")"
+    D1Backend(base_url="http://d1.internal", http=Http()).executemany(sql, rows)
+
+    sizes = [len(s["params"]) // cols for p in payloads for s in _statements(p)]
+    assert sizes == [7, 7, 7, 7, 7, 7, 7, 1]
+
+
+def test_executemany_rejects_a_row_too_wide_to_bind():
+    """A row wider than the cap cannot be sent at all -- say so, loudly.
+
+    Silently splitting such a row across statements would write corrupt
+    partial rows; returning quietly would write nothing.
+    """
+    import pytest
+
+    class Http:
+        def request(self, method, url, data=None, headers=None):
+            raise AssertionError("must not reach the network")
+
+    db = D1Backend(base_url="http://d1.internal", http=Http())
+    with pytest.raises(ValueError, match="bound parameter"):
+        db.executemany(
+            "INSERT INTO wide VALUES (" + ",".join(["?"] * 101) + ")",
+            [[f"c{i}" for i in range(101)]],
+        )
+
+
 def test_d1_raises_on_http_error():
     class Http:
         def request(self, method, url, data=None, headers=None):

--- a/tests/test_d1_schema_0002.py
+++ b/tests/test_d1_schema_0002.py
@@ -1,0 +1,87 @@
+"""Schema parity between the local SQLite DocsDB and the D1 migrations.
+
+wrangler owns the D1 schema; `db.py` owns the SQLite one. Anything `DocsDBCfBackend`
+reads or writes has to exist in BOTH, and nothing but the sqlite-vec table may be
+missing from D1 (D1 cannot load the extension).
+"""
+
+import sqlite3
+from pathlib import Path
+
+MIGRATIONS = Path("migrations")
+
+
+def _d1_conn():
+    conn = sqlite3.connect(":memory:")
+    for path in sorted(MIGRATIONS.glob("*.sql")):
+        conn.executescript(path.read_text(encoding="utf-8"))
+    return conn
+
+
+def _cols(conn, table):
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def test_project_context_table_exists_on_d1():
+    """`upsert_project_context` needs this table; 0001 never created it."""
+    conn = _d1_conn()
+    assert _cols(conn, "project_context") == {
+        "project_path",
+        "locked_libraries",
+        "created_at",
+        "last_used_at",
+    }
+
+
+def test_project_context_roundtrips():
+    conn = _d1_conn()
+    conn.execute(
+        "INSERT INTO project_context (project_path, locked_libraries, created_at,"
+        " last_used_at) VALUES (?,?,?,?)",
+        ("/repo", '[{"id": "lib1", "version": "1.0"}]', 1.0, 1.0),
+    )
+    row = conn.execute(
+        "SELECT locked_libraries FROM project_context WHERE project_path = ?",
+        ("/repo",),
+    ).fetchone()
+    assert row[0] == '[{"id": "lib1", "version": "1.0"}]'
+
+
+def test_libraries_has_metadata_seeded_at():
+    """`mark_metadata_seeded` writes this column; 0001 omitted it.
+
+    Without it a Tier-1 warmup seed is indistinguishable from a real index.
+    """
+    assert "metadata_seeded_at" in _cols(_d1_conn(), "libraries")
+
+
+def test_d1_tables_match_local_docsdb():
+    """The only table allowed to be D1-absent is the sqlite-vec virtual one."""
+    from wet_mcp.db import DocsDB
+
+    local_path = Path("__schema_parity.db")
+    try:
+        DocsDB(local_path, embedding_dims=0).close()
+        local = sqlite3.connect(local_path)
+        names = {
+            r[0]
+            for r in local.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+            if not r[0].startswith("sqlite_")
+        }
+        local.close()
+    finally:
+        local_path.unlink(missing_ok=True)
+
+    d1 = _d1_conn()
+    d1_names = {
+        r[0]
+        for r in d1.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        if not r[0].startswith("sqlite_")
+    }
+
+    missing = {n for n in names - d1_names if not n.startswith("doc_chunks_vec")}
+    assert not missing, f"tables present locally but missing from D1: {sorted(missing)}"

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -9,7 +9,11 @@ from wet_mcp.backends.vectorize import VectorizeBackend
 from wet_mcp.db import DocsDB
 from wet_mcp.db_cf import DocsDBCfBackend
 
-DDL = Path("migrations/0001_init_wet.sql").read_text(encoding="utf-8")
+# The D1 schema now spans more than one migration (0002 adds project_context and
+# libraries.metadata_seeded_at), so apply them all in order rather than pinning 0001.
+DDL = "\n".join(
+    p.read_text(encoding="utf-8") for p in sorted(Path("migrations").glob("*.sql"))
+)
 
 
 def _backend(ready_after=0):

--- a/tests/test_db_cf_contract.py
+++ b/tests/test_db_cf_contract.py
@@ -1,0 +1,234 @@
+"""DocsDBCfBackend must satisfy the whole DocsDB contract, not part of it.
+
+A partial backend does not fail at startup, it fails mid-index: chunks get
+written by `add_chunks`, then the next call raises AttributeError inside a
+log-only `except Exception`, so the version never reaches status='indexed' and
+every subsequent request re-indexes it. `server._missing_docs_db_methods` is the
+boot-time gate; this module keeps it satisfied and pins the behaviour of the
+methods that gate only proves are *present*.
+"""
+
+from pathlib import Path
+
+import pytest
+from conftest_cf import FakeD1Http, FakeVectorizeHttp
+
+from wet_mcp.backends.d1 import D1Backend
+from wet_mcp.backends.vectorize import VectorizeBackend
+from wet_mcp.db_cf import DocsDBCfBackend
+from wet_mcp.server import _missing_docs_db_methods
+
+DDL = "\n".join(
+    p.read_text(encoding="utf-8") for p in sorted(Path("migrations").glob("*.sql"))
+)
+
+
+def _backend():
+    d1 = D1Backend("http://d1.internal", http=FakeD1Http(DDL))
+    vec = VectorizeBackend(
+        "http://vectorize.internal", idx="wet", http=FakeVectorizeHttp()
+    )
+    return DocsDBCfBackend(d1, vec, embedding_dims=768)
+
+
+def _seeded(db):
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    ver_id = db.upsert_version(lib_id, "1.0", docs_url="https://a")
+    return lib_id, ver_id
+
+
+def test_cf_backend_implements_every_docs_db_method():
+    """The boot gate in make_docs_db() must find nothing missing."""
+    assert _missing_docs_db_methods(_backend()) == []
+
+
+def test_mark_version_indexed_sets_status_and_counts():
+    """The exact call whose absence cost 11 weeks of silent re-indexing."""
+    db = _backend()
+    _lib_id, ver_id = _seeded(db)
+    db.mark_version_indexed(ver_id, 12, 340)
+    row = db._d1.fetchone("SELECT * FROM versions WHERE id = ?", [ver_id])
+    assert row["status"] == "indexed"
+    assert (row["page_count"], row["chunk_count"]) == (12, 340)
+    assert row["indexed_at"] > 0
+
+
+def test_mark_library_indexed_records_time_and_versions():
+    db = _backend()
+    lib_id, _ver_id = _seeded(db)
+    db.mark_library_indexed(lib_id, total_versions=3)
+    row = db._d1.fetchone("SELECT * FROM libraries WHERE id = ?", [lib_id])
+    assert row["last_indexed_at"] > 0
+    assert row["total_versions"] == 3
+
+
+def test_mark_library_indexed_without_total_leaves_count_alone():
+    db = _backend()
+    lib_id, _ver_id = _seeded(db)
+    db.mark_library_indexed(lib_id, total_versions=5)
+    db.mark_library_indexed(lib_id)
+    row = db._d1.fetchone("SELECT * FROM libraries WHERE id = ?", [lib_id])
+    assert row["total_versions"] == 5
+
+
+def test_mark_metadata_seeded_is_distinct_from_indexed():
+    """A Tier-1 seed must stay distinguishable from a real index."""
+    db = _backend()
+    lib_id, _ver_id = _seeded(db)
+    db.mark_metadata_seeded(lib_id)
+    row = db._d1.fetchone("SELECT * FROM libraries WHERE id = ?", [lib_id])
+    assert row["metadata_seeded_at"] > 0
+    assert row["last_indexed_at"] is None
+
+
+def test_clear_version_chunks_removes_rows_and_vectors():
+    """Chunks and their vectors go together, or search returns ghosts."""
+    db = _backend()
+    lib_id, ver_id = _seeded(db)
+    chunks = [
+        {
+            "id": f"c{i}",
+            "url": "https://a/p",
+            "title": "T",
+            "chunk_index": i,
+            "content": f"content number {i}",
+            "heading_path": "T",
+        }
+        for i in range(3)
+    ]
+    db.add_chunks(ver_id, lib_id, chunks, embeddings=[[0.1] * 768 for _ in chunks])
+    assert len(db._vec._http.vectors) == 3
+
+    removed = db.clear_version_chunks(ver_id)
+
+    assert removed == 3
+    assert (
+        db._d1.execute("SELECT id FROM doc_chunks WHERE version_id = ?", [ver_id]) == []
+    )
+    assert db._vec._http.vectors == {}, "vectors outlived their chunks -> ghost hits"
+
+
+def test_clear_version_chunks_on_empty_version_returns_zero():
+    db = _backend()
+    _lib_id, ver_id = _seeded(db)
+    assert db.clear_version_chunks(ver_id) == 0
+
+
+def test_project_context_roundtrip():
+    db = _backend()
+    locked = [{"id": "lib1", "version": "1.0"}]
+    db.upsert_project_context("/repo", locked)
+    got = db.get_project_context("/repo")
+    assert got is not None
+    assert got["locked_libraries"] == locked
+    assert got["project_path"] == "/repo"
+
+
+def test_upsert_project_context_updates_without_duplicating():
+    db = _backend()
+    db.upsert_project_context("/repo", [{"id": "lib1", "version": "1.0"}])
+    created = db.get_project_context("/repo")["created_at"]
+    db.upsert_project_context("/repo", [{"id": "lib2", "version": "2.0"}])
+    got = db.get_project_context("/repo")
+    assert got["locked_libraries"] == [{"id": "lib2", "version": "2.0"}]
+    assert got["created_at"] == created
+    rows = db._d1.execute("SELECT project_path FROM project_context", [])
+    assert len(rows) == 1
+
+
+def test_get_project_context_missing_returns_none():
+    assert _backend().get_project_context("/never-locked") is None
+
+
+def test_touch_project_context_advances_last_used():
+    db = _backend()
+    db.upsert_project_context("/repo", [])
+    db._d1.execute(
+        "UPDATE project_context SET last_used_at = ? WHERE project_path = ?",
+        [1.0, "/repo"],
+    )
+    db.touch_project_context("/repo")
+    assert db.get_project_context("/repo")["last_used_at"] > 1.0
+
+
+def test_close_is_safe_and_repeatable():
+    """No persistent handle exists to close; it must not pretend otherwise."""
+    db = _backend()
+    db.close()
+    db.close()
+    assert db.stats()["libraries"] == 0  # backend still usable
+
+
+def test_add_chunks_stays_inside_the_d1_parameter_cap():
+    """The live 13-column INSERT, measured at the real call site.
+
+    Guards the whole chain, not just D1Backend's arithmetic: if a column is
+    ever added to doc_chunks, this fails here rather than as a swallowed
+    non-200 that writes nothing.
+    """
+    import json as _json
+
+    captured = []
+
+    class RecordingHttp:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def request(self, method, url, data=None, headers=None):
+            if url.endswith(("/query", "/batch")):
+                captured.append(_json.loads(data.decode()))
+            return self._inner.request(method, url, data, headers)
+
+    d1 = D1Backend("http://d1.internal", http=RecordingHttp(FakeD1Http(DDL)))
+    vec = VectorizeBackend(
+        "http://vectorize.internal", idx="wet", http=FakeVectorizeHttp()
+    )
+    db = DocsDBCfBackend(d1, vec, embedding_dims=768)
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    ver_id = db.upsert_version(lib_id, "1.0", docs_url="https://a")
+
+    db.add_chunks(
+        ver_id,
+        lib_id,
+        [
+            {
+                "id": f"c{i}",
+                "url": "https://a/p",
+                "title": "T",
+                "chunk_index": i,
+                "content": f"body {i}",
+                "heading_path": "T",
+            }
+            for i in range(30)
+        ],
+        embeddings=None,
+    )
+
+    inserts = [
+        s
+        for p in captured
+        for s in (p if isinstance(p, list) else [p])
+        if "INSERT INTO doc_chunks" in s["sql"]
+    ]
+    assert inserts, "no doc_chunks INSERT was captured"
+    widths = [len(s["params"]) for s in inserts]
+    assert max(widths) <= 100
+    # 13 columns against a 100-parameter cap: 7 rows / 91 params per statement.
+    assert widths == [91, 91, 91, 91, 26]
+    assert db.stats()["chunks"] == 30
+
+
+@pytest.mark.parametrize("method", ["export_jsonl", "import_jsonl"])
+def test_jsonl_sync_degrades_loudly(method):
+    """File-based DB sync is meaningless on CF -- say so, do not return empties.
+
+    Returning "" or {"chunks": 0} would look exactly like a successful sync of
+    an empty store, which is the failure mode this whole repair exists to kill.
+    """
+    db = _backend()
+    args = () if method == "export_jsonl" else ("{}",)
+    with pytest.raises(NotImplementedError) as exc:
+        getattr(db, method)(*args)
+    message = str(exc.value)
+    assert "cf-d1" in message
+    assert "Vectorize" in message  # names why, and what holds the data instead

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -17,6 +17,11 @@ function fakeEnv() {
     VECTORIZE: {
       upsert: async () => ({ mutationId: 'm1' }),
       query: async () => ({ matches: [{ id: 'a', score: 0.9 }] }),
+      deleted: [] as string[][],
+      async deleteByIds(ids: string[]) {
+        this.deleted.push(ids)
+        return { mutationId: 'm-del' }
+      },
     },
   }
 }
@@ -62,6 +67,18 @@ describe('outbound handlers', () => {
     )
     const body = (await res.json()) as { matches: unknown[] }
     expect(body.matches.length).toBe(1)
+  })
+
+  it('Vectorize deleteByIds forwards the ids to the binding', async () => {
+    const env = fakeEnv()
+    const res = await vectorizeH(
+      new Request('http://vectorize.internal/deleteByIds', { method: 'POST', body: JSON.stringify({ ids: ['c1', 'c2'] }) }),
+      env as never,
+      ctx,
+    )
+    expect(res.status).toBe(200)
+    expect(env.VECTORIZE.deleted).toEqual([['c1', 'c2']])
+    expect(await res.json()).toEqual({ mutationId: 'm-del' })
   })
 
   it('KV readiness probe: GET __ready -> {ready:true}', async () => {


### PR DESCRIPTION
Surface half of the `cf-d1` repair. **Stacked on #1601** (base is that branch, not `main`) because these methods need its `0002` schema and its parameter-cap fix to write anything at all. Merge #1601 first; this PR's base then retargets to `main`.

`DocsDBCfBackend` implemented **7 of `DocsDB`'s 17** public methods, so `DOCS_DB_BACKEND=cf-d1` is currently refused at boot by the capability gate in `make_docs_db()`. This makes that list empty for real:

```
$ DOCS_DB_BACKEND=cf-d1 ... python -c "from wet_mcp.server import make_docs_db, _missing_docs_db_methods; ..."
boot OK -> DocsDBCfBackend
missing methods: []
```

## The 10 methods

The gate checks **presence**, not behaviour, so a `raise NotImplementedError` still passes it. Where that is used below it is deliberate: a loud raise is enormously better than the silent path that cost 11 weeks, but it is never used to paper over something that could be done properly.

| method | disposition | why |
|---|---|---|
| `mark_version_indexed` | real | The exact absence that caused the incident; version now reaches `status='indexed'` |
| `mark_library_indexed` | real | Fixed SQL, no runtime-assembled column names (D1's schema is migration-owned, unlike legacy SQLite files) |
| `mark_metadata_seeded` | real | Needs `libraries.metadata_seeded_at` from #1601 |
| `clear_version_chunks` | real | Deletes vectors then rows; see below |
| `upsert_project_context` | real | Needs `project_context` from #1601; preserves `created_at` on update |
| `get_project_context` | real | No caller today, but the contract needs it; mirrors local incl. the unreadable-JSON warning |
| `touch_project_context` | real | No caller today; same reason |
| `close` | real (documented no-op) | `DocsDB.close()` releases a sqlite3 connection; the HTTP backends hold no handle between calls. Returns quietly because there is genuinely no work, not because a failure was hidden. Called on shutdown, so it must not raise |
| `export_jsonl` | **loud degrade** | File-based DB sync is redundant when D1+Vectorize is already the shared durable store; there is no local `docs.db` to export |
| `import_jsonl` | **loud degrade** | Cannot be done honestly: sync JSONL carries no embeddings, so imported chunks would answer FTS queries while staying **invisible to the vector arm** of `search()` -- a half-ranked index that looks like a working one |

Neither degraded method returns `[]`, `None`, `0` or `""`. Both raises name the reason and the alternative.

## Vector delete path (new on both sides)

`clear_version_chunks` that drops rows but not vectors leaves hits that keep scoring and resolve to no content. Neither side had a delete path: no `deleteByIds` route in `worker.ts`, and `VectorizeBackend` had only `upsert`/`query`/`wait_until_indexed`. Added both.

Ordering matters and is asserted: **vectors are deleted before the D1 rows**, and the call is *not* error-suppressed. A failure leaves the store merely stale; the other order leaves ghosts. (The local `DocsDB` wraps its vector delete in a log-only `except` -- that pattern is deliberately not copied.)

`docs/cf-template.md` is updated to match, since it is the frozen copy contract for the 5 other P3 servers. While there I also corrected `d1Outbound`/`vectorizeOutbound` from "(mnemo only)" to "(wet, mnemo)" -- wet demonstrably uses both, so the copy matrix was wrong.

## Tests

All 14 contract tests red before (`_missing_docs_db_methods` first):

```
FAILED test_cf_backend_implements_every_docs_db_method
  AssertionError: assert ['clear_versi...indexed', ...] == []
  Left contains 10 more items, first extra item: 'clear_version_chunks'
AttributeError: 'DocsDBCfBackend' object has no attribute 'mark_version_indexed'
AttributeError: 'DocsDBCfBackend' object has no attribute 'clear_version_chunks'
AttributeError: 'DocsDBCfBackend' object has no attribute 'upsert_project_context'
AttributeError: 'DocsDBCfBackend' object has no attribute 'close'
AttributeError: 'DocsDBCfBackend' object has no attribute 'export_jsonl'
AttributeError: 'DocsDBCfBackend' object has no attribute 'import_jsonl'
14 failed
```

Green after: **2240 passed, 35 skipped** (python) + **17 passed** (vitest, incl. new `deleteByIds` route test).

`test_add_chunks_stays_inside_the_d1_parameter_cap` measures the real 13-column call site end-to-end and pins `widths == [91, 91, 91, 91, 26]`, so adding a `doc_chunks` column fails here rather than as a swallowed non-200.

`test_server_cf_mode.py::test_cf_backend_is_complete_or_refused` was already written as a flipping invariant; it now takes its "complete backend" branch and exercises the real boot path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)