### PR TITLE
fix: report the active docs backend in config status

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1948,6 +1948,18 @@ async def help(tool_name: str = "search") -> str:
         return f"Error loading documentation: {e}"
 
 
+def _active_docs_backend() -> str:
+    """The docs-store selector, resolved exactly as ``make_docs_db`` resolves it.
+
+    Deliberately a byte-for-byte mirror of the expression in ``make_docs_db``
+    (env first, Settings singleton as the default; no strip/lower). Normalizing
+    here would let ``config(action="status")`` report ``cf-d1`` for a value that
+    ``make_docs_db`` fell through to SQLite on -- a status line that disagrees
+    with the object actually serving requests is the bug this reports on.
+    """
+    return os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+
+
 async def _handle_config_status() -> dict[str, Any]:
     from wet_mcp.embedder import get_backend
     from wet_mcp.reranker import get_reranker
@@ -1956,9 +1968,19 @@ async def _handle_config_status() -> dict[str, Any]:
     embed_backend = get_backend()
     reranker = get_reranker()
 
+    # The docs store is either a local SQLite file or Cloudflare D1 + Vectorize.
+    # On cf-d1 no local file is opened, so reporting settings.get_db_path()
+    # sends the operator to back up / inspect / copy a file that holds none of
+    # the served data. `path` is kept (readers keep their key) but goes null,
+    # and `backend` names which store the number in `docs_indexed` came from.
+    # No D1 identifier is exposed here: the tokens are secrets outright, and
+    # the account/database ids in MCP_D1_BASE_URL name the target a leaked
+    # token would open, while answering nothing the operator asked.
+    docs_backend = _active_docs_backend()
     status = {
         "database": {
-            "path": str(settings.get_db_path()),
+            "backend": docs_backend,
+            "path": (None if docs_backend == "cf-d1" else str(settings.get_db_path())),
             "docs_indexed": (_docs_db.stats() if _docs_db else {}),
         },
         "embedding": {

--- a/tests/test_config_status_backend.py
+++ b/tests/test_config_status_backend.py
@@ -1,0 +1,100 @@
+"""``config(action="status")`` must describe the docs store actually in use.
+
+The status payload is what an operator reads before they go looking for the
+data: they copy ``database.path`` into a backup script, an rsync, a `sqlite3`
+session. When ``DOCS_DB_BACKEND=cf-d1`` the docs live in Cloudflare D1 +
+Vectorize and no local file is opened at all, so printing
+``~/.wet-mcp/docs.db`` there is not merely unhelpful, it points the operator at
+a file whose contents are unrelated to what the server is serving.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def _status_backends():
+    """Keep the status call off the real embedder/reranker singletons."""
+    with (
+        patch("wet_mcp.embedder.get_backend", return_value=None),
+        patch("wet_mcp.reranker.get_reranker", return_value=None),
+    ):
+        yield
+
+
+async def test_status_on_cf_d1_does_not_claim_a_local_docs_file(
+    monkeypatch, _status_backends
+):
+    """cf-d1 opens no local file, so ``path`` must not name one."""
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    from wet_mcp.server import _handle_config_status
+
+    status = await _handle_config_status()
+
+    assert status["database"]["path"] is None
+
+
+async def test_status_names_the_active_docs_backend(monkeypatch, _status_backends):
+    """The operator can tell D1 from SQLite without reading the container env."""
+    from wet_mcp.server import _handle_config_status
+
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    assert (await _handle_config_status())["database"]["backend"] == "cf-d1"
+
+    monkeypatch.setenv("DOCS_DB_BACKEND", "sqlite")
+    assert (await _handle_config_status())["database"]["backend"] == "sqlite"
+
+
+async def test_status_on_sqlite_still_reports_the_local_path(
+    monkeypatch, _status_backends
+):
+    """The default backend keeps the field every existing reader expects."""
+    monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
+    from wet_mcp.config import settings
+    from wet_mcp.server import _handle_config_status
+
+    monkeypatch.setattr(settings, "docs_db_backend", "sqlite", raising=False)
+
+    status = await _handle_config_status()
+
+    assert status["database"]["path"] == str(settings.get_db_path())
+
+
+async def test_status_on_cf_d1_leaks_no_d1_credential_or_identifier(
+    monkeypatch, _status_backends
+):
+    """Naming the backend must not drag the D1 wiring into the payload.
+
+    ``config`` is an operator-facing tool, but its output gets pasted into bug
+    reports and agent transcripts. Tokens are secrets outright; the account and
+    database ids in ``MCP_D1_BASE_URL`` name the target a leaked token would
+    open. Neither is needed to answer "where are my docs".
+    """
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    from wet_mcp.config import settings
+    from wet_mcp.server import _handle_config_status
+
+    monkeypatch.setattr(settings, "mcp_d1_token", "SECRET-D1-TOKEN", raising=False)
+    monkeypatch.setattr(
+        settings, "mcp_vectorize_token", "SECRET-VECTORIZE-TOKEN", raising=False
+    )
+    monkeypatch.setattr(
+        settings,
+        "mcp_d1_base_url",
+        "https://api.cloudflare.com/client/v4/accounts/ACCTID123/d1/database/DBID456",
+        raising=False,
+    )
+    monkeypatch.setattr(settings, "mcp_vectorize_idx", "IDXNAME789", raising=False)
+
+    dumped = json.dumps(await _handle_config_status(), default=str)
+
+    for secret in (
+        "SECRET-D1-TOKEN",
+        "SECRET-VECTORIZE-TOKEN",
+        "ACCTID123",
+        "DBID456",
+        "IDXNAME789",
+    ):
+        assert secret not in dumped

--- a/tests/test_config_status_backend.py
+++ b/tests/test_config_status_backend.py
@@ -9,7 +9,7 @@ a file whose contents are unrelated to what the server is serving.
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,6 +22,47 @@ def _status_backends():
         patch("wet_mcp.reranker.get_reranker", return_value=None),
     ):
         yield
+
+
+@pytest.fixture
+def _built_backend(monkeypatch):
+    """Run the real ``make_docs_db`` selector, stubbing only its leaf builders.
+
+    The branch decision inside ``make_docs_db`` stays untouched -- that is the
+    thing under observation. What gets replaced is strictly what would demand a
+    disk file, a D1 account or the network:
+
+    * ``DocsDB.__init__`` on the real class (not the name ``server`` holds), so
+      ``_missing_docs_db_methods`` can still read ``vars(DocsDB)`` as its
+      contract while construction opens nothing.
+    * ``DocsDBCfBackend`` -> a ``MagicMock`` instance, whose auto-created
+      attributes are all callable, so the missing-method guard passes whatever
+      state the real cf backend is in. This test is about the selector, not
+      about that backend's surface.
+
+    Returns a list that records ``"sqlite"`` / ``"cf-d1"`` per construction.
+    """
+    from wet_mcp.db import DocsDB
+
+    built: list[str] = []
+
+    def _sqlite_init(self, *args, **kwargs):
+        built.append("sqlite")
+
+    def _cf_build(*args, **kwargs):
+        built.append("cf-d1")
+        return MagicMock()
+
+    monkeypatch.setattr(DocsDB, "__init__", _sqlite_init)
+    monkeypatch.setattr("wet_mcp.db_cf.DocsDBCfBackend", _cf_build)
+    monkeypatch.setattr(
+        "wet_mcp.backends.d1.d1_backend_from_env", lambda *a, **k: MagicMock()
+    )
+    monkeypatch.setattr(
+        "wet_mcp.backends.vectorize.vectorize_backend_from_env",
+        lambda *a, **k: MagicMock(),
+    )
+    return built
 
 
 async def test_status_on_cf_d1_does_not_claim_a_local_docs_file(
@@ -98,3 +139,52 @@ async def test_status_on_cf_d1_leaks_no_d1_credential_or_identifier(
         "IDXNAME789",
     ):
         assert secret not in dumped
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "cf-d1",
+        "sqlite",
+        None,
+        "CF-D1",
+        " cf-d1 ",
+        "",
+        "postgres",
+    ],
+)
+async def test_status_label_agrees_with_the_backend_make_docs_db_builds(
+    raw, monkeypatch, _built_backend, _status_backends
+):
+    """The status label and the constructed store must never disagree.
+
+    ``_active_docs_backend`` is documented as a byte-for-byte mirror of the
+    selector in ``make_docs_db``, but a docstring is a promise nobody checks:
+    add ``.strip().lower()`` to one side and the mirror cracks in silence --
+    ``make_docs_db`` builds D1 while ``config status`` keeps printing a local
+    path, which is exactly the bug this module exists to prevent.
+
+    The dirty spellings carry the weight here. ``"CF-D1"`` and ``" cf-d1 "``
+    are the inputs where a one-sided normalization changes one branch and not
+    the other, so they are the only ones that can catch the drift; the clean
+    values would stay green through it.
+    """
+    from wet_mcp.server import _active_docs_backend, _handle_config_status, make_docs_db
+
+    if raw is None:
+        monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
+        from wet_mcp.config import settings
+
+        monkeypatch.setattr(settings, "docs_db_backend", "sqlite", raising=False)
+    else:
+        monkeypatch.setenv("DOCS_DB_BACKEND", raw)
+
+    make_docs_db()
+    assert _built_backend, "make_docs_db built nothing; the stubs missed a branch"
+    built_is_cf = _built_backend[-1] == "cf-d1"
+
+    assert (_active_docs_backend() == "cf-d1") == built_is_cf
+
+    status = await _handle_config_status()
+    assert (status["database"]["path"] is None) == built_is_cf
+    assert (status["database"]["backend"] == "cf-d1") == built_is_cf


### PR DESCRIPTION
## Vấn đề

`config(action="status")` in `settings.get_db_path()` vô điều kiện. Khi server chạy với `DOCS_DB_BACKEND=cf-d1` (docs nằm ở Cloudflare D1 + Vectorize, không mở file local nào), status vẫn báo `~/.wet-mcp/docs.db`.

Đây là một lời nói dối vận hành: người vận hành đọc xong sẽ đi backup / mở `sqlite3` / rsync một file không chứa dữ liệu nào đang được phục vụ.

`src/wet_mcp/server.py:1961` (trên `main`) — dòng `path` không phụ thuộc backend nào cả, trong khi `make_docs_db()` ở `:98` chọn backend từ `DOCS_DB_BACKEND`.

## Thay đổi

- Thêm `database.backend` — giá trị selector, phân giải **y hệt** cách `make_docs_db()` phân giải (env trước, `Settings` singleton làm default, không `strip()`/`lower()`). Cố ý là bản sao từng ký tự: nếu normalize ở đây thì status có thể báo `cf-d1` cho một giá trị mà `make_docs_db()` đã rơi xuống SQLite — đúng loại bất đồng mà PR này đang sửa.
- `database.path` trả `null` khi backend là `cf-d1`, giữ nguyên đường dẫn khi là `sqlite`.

## Vì sao giữ khoá `path` thay vì bỏ

Đã rà toàn repo xem ai đọc `database.path`: **không có client nào**. Chỉ có các test kiểm tra sự tồn tại của khoá `database` (`tests/test_boost_coverage.py:1521`, `tests/test_live_protocol.py:120`, `tests/test_live_mcp.py:114`, `tests/test_full_live.py:272`) — không test nào đọc `.path`. `src/wet_mcp/docs/config.md:15` mô tả chung ("database stats"), không liệt kê tên trường.

Vẫn giữ khoá và cho `null` thay vì xoá: reader nào đang `status["database"]["path"]` thì nhận `None` (falsy, JSON `null`) chứ không `KeyError`. Trên `sqlite` — tức mặc định và mọi deploy local — output không đổi một byte.

## Vì sao KHÔNG in định danh D1

`config` là tool người vận hành gọi, nhưng output của nó bị paste vào bug report và transcript của agent.

- `MCP_D1_TOKEN` / `MCP_VECTORIZE_TOKEN` — secret, không bàn.
- `MCP_D1_BASE_URL` — ở chế độ REST fallback nó có dạng `.../accounts/<ACCOUNT_ID>/d1/database/<DB_ID>`. Account id + database id không phải secret, nhưng chúng **chỉ đích** cho một token bị lộ, mà lại không trả lời được câu hỏi người vận hành đang hỏi ("docs của tôi ở đâu"). Ở chế độ service binding nó là `http://d1.internal` — vô nghĩa với người đọc.
- `MCP_VECTORIZE_IDX` — cùng lý do.

Kết luận: `backend: "cf-d1"` là đủ và là thông tin hành động được (biết ngay không có file để backup). Có test `test_status_on_cf_d1_leaks_no_d1_credential_or_identifier` chốt điều này lại — token, account id, database id, index name đều phải vắng mặt khỏi payload.

## Test

4 test mới ở `tests/test_config_status_backend.py`, viết ĐỎ trước khi vá.

Output đỏ trên code chưa vá:

```
tests/test_config_status_backend.py::test_status_on_cf_d1_does_not_claim_a_local_docs_file FAILED [ 25%]
tests/test_config_status_backend.py::test_status_names_the_active_docs_backend FAILED [ 50%]
tests/test_config_status_backend.py::test_status_on_sqlite_still_reports_the_local_path PASSED [ 75%]
tests/test_config_status_backend.py::test_status_on_cf_d1_leaks_no_d1_credential_or_identifier PASSED [100%]

>       assert status["database"]["path"] is None
E       AssertionError: assert 'C:\...\wet_test_home0\.wet-mcp\docs.db' is None

>       assert (await _handle_config_status())["database"]["backend"] == "cf-d1"
E       KeyError: 'backend'

========================= 2 failed, 2 passed in 4.96s =========================
```

Sau khi vá: `4 passed`. Toàn bộ suite: `2213 passed, 35 skipped, 140 deselected`.

## Vấn đề liền kề — CỐ Ý KHÔNG SỬA trong PR này

Đã rà các trường còn lại của `_handle_config_status()`. Ba phát hiện, đều là **lỗi khác**, không gộp:

1. **`sync.provider` hardcode `"google_drive"`** (`server.py:2001`). Khi `SYNC_S3_BUCKET` được set, `resolve_active_backend()` trả `"s3"` và lifespan chạy `start_s3_auto_sync()` (`server.py:391-398`) — status vẫn báo `google_drive`. Nói dối trên mọi deploy S3/R2/B2, không liên quan `cf-d1`.
2. **`sync.enabled` không phải trạng thái thật.** Chỉ đường GDrive đọc `settings.sync_enabled` (`sync/gdrive.py:510,791`); vòng lặp S3 (`sync/__init__.py:187+`) không đọc. `SYNC_ENABLED=false` + có bucket => status báo `enabled: false` trong khi vòng push S3 vẫn chạy.
3. **Trên `cf-d1`, bản thân subsystem sync đẩy `settings.get_db_path()`** (`sync/__init__.py:210`, `sync/gdrive.py:535`) — một file không phải store. Đây là lỗi hành vi của sync, không phải lỗi báo cáo trạng thái.

Đã kiểm và **không** phải lỗi: `cache.path` trung thực. `WebCache` luôn là file SQLite local thật, khởi tạo vô điều kiện ở `server.py:336-339` bất kể `DOCS_DB_BACKEND`; `MCP_STORAGE_BACKEND=cf-kv` chỉ tác động lớp credential store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Bổ sung: chốt parity giữa hai đường phân giải (commit thứ 2)

Bản vá đầu chỉ bảo đảm "bản sao từng ký tự" bằng một **chú thích**. Chú thích không phải guard — nó là lời hứa không ai kiểm. Ai đó thêm `.strip().lower()` vào một phía là bản sao lệch đi trong im lặng, `config status` nói dối trở lại, và **cả 4 test ở bản vá đầu vẫn xanh** vì chúng chỉ kiểm một phía.

Đã kiểm chứng điều đó chứ không suy đoán. Tạm áp `.strip().lower()` vào `make_docs_db()` rồi chạy đúng 4 test cũ:

```
tests/test_config_status_backend.py::test_status_on_cf_d1_does_not_claim_a_local_docs_file PASSED [ 25%]
tests/test_config_status_backend.py::test_status_names_the_active_docs_backend PASSED [ 50%]
tests/test_config_status_backend.py::test_status_on_sqlite_still_reports_the_local_path PASSED [ 75%]
tests/test_config_status_backend.py::test_status_on_cf_d1_leaks_no_d1_credential_or_identifier PASSED [100%]
======================= 4 passed, 7 deselected in 3.85s =======================
```

Bốn test xanh trong khi server đang nói dối. Đó chính là lỗ.

### Guard mới

`test_status_label_agrees_with_the_backend_make_docs_db_builds` — parametrize 7 cách viết `DOCS_DB_BACKEND`: `cf-d1`, `sqlite`, không-set, `CF-D1`, `" cf-d1 "`, chuỗi rỗng, `postgres`. Với mỗi giá trị, chạy **`make_docs_db()` thật** rồi khẳng định nhãn `_active_docs_backend()` và `database.path` / `database.backend` luôn đồng ý với loại store thực sự được dựng.

Hai giá trị bẩn `CF-D1` và `" cf-d1 "` mới là phần mang trọng lượng: chúng là ca duy nhất mà normalize-một-phía làm đổi nhánh này mà không đổi nhánh kia. Các giá trị sạch sẽ xanh xuyên qua drift.

### Đỏ thật, cả hai chiều drift

Chiều A — normalize ở phía `_active_docs_backend()`:
```
>       assert (_active_docs_backend() == "cf-d1") == built_is_cf
E       AssertionError: assert ('cf-d1' == 'cf-d1') == False
FAILED ...test_status_label_agrees_with_the_backend_make_docs_db_builds[CF-D1]
FAILED ...test_status_label_agrees_with_the_backend_make_docs_db_builds[ cf-d1 ]
================= 2 failed, 5 passed, 4 deselected in 17.86s ==================
```

Chiều B — normalize bên trong `make_docs_db()` (đúng kịch bản lo ngại):
```
>       assert (_active_docs_backend() == "cf-d1") == built_is_cf
E       AssertionError: assert (' cf-d1 ' == 'cf-d1'
E         - cf-d1
E         +  cf-d1 
E         ? +     +) == True
FAILED ...test_status_label_agrees_with_the_backend_make_docs_db_builds[CF-D1]
FAILED ...test_status_label_agrees_with_the_backend_make_docs_db_builds[ cf-d1 ]
======================== 2 failed, 9 passed in 11.79s =========================
```

Cả hai sửa tạm đều đã revert bằng `git checkout -- src/wet_mcp/server.py`; đã grep lại xác nhận không còn `strip().lower()` sót trong `server.py`.

### Mock ở tầng thấp nhất, không mock hàm đang đo

`make_docs_db()` **không bị sửa** (vùng của #1605). Nhánh quyết định bên trong nó chạy thật; chỉ hai leaf builder bị thay:

- `DocsDB.__init__` vá trên **chính class thật** (không phải cái tên `server` đang giữ), nên `_missing_docs_db_methods` vẫn đọc được `vars(DocsDB)` làm contract trong khi construction không mở file nào.
- `DocsDBCfBackend` -> `MagicMock` (mọi attribute auto-tạo đều callable), nên guard missing-method pass bất kể surface của cf backend hiện ở trạng thái nào — test này đo selector, không đo surface đó. Nhờ vậy guard không phụ thuộc việc #1605 đã merge hay chưa.
- `d1_backend_from_env` / `vectorize_backend_from_env` stub để không cần env/credential/mạng.

Full suite sau khi thêm: `2220 passed, 35 skipped, 140 deselected`.
