### PR TITLE
fix: quote loguru Record type + lowercase Renovate lock-file-maintenance subject

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       "before 5am"
     ],
     "automerge": true,
-    "automergeType": "pr"
+    "automergeType": "pr",
+    "commitMessageAction": "lock file maintenance"
   },
   "packageRules": [
     {

--- a/tests/test_silent_failure_surfacing.py
+++ b/tests/test_silent_failure_surfacing.py
@@ -14,7 +14,7 @@ that is the property that hid the bug.
 import contextlib
 import json
 import sqlite3
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -23,6 +23,9 @@ from loguru import logger
 from wet_mcp import server
 from wet_mcp.db import DocsDB
 from wet_mcp.server import search
+
+if TYPE_CHECKING:
+    from loguru import Record
 
 _LEVELS = {
     "TRACE": 5,
@@ -42,7 +45,7 @@ def captured_logs(level: str = "DEBUG"):
     ``logger.add`` is additive, so the module-level stderr sink configured by
     ``wet_mcp.server`` keeps working and no global logger state is mutated.
     """
-    records: list[dict] = []
+    records: list[Record] = []
     sink_id = logger.add(lambda message: records.append(message.record), level=level)
     try:
         yield records
@@ -50,13 +53,13 @@ def captured_logs(level: str = "DEBUG"):
         logger.remove(sink_id)
 
 
-def at_least(records: list[dict], level: str) -> list[dict]:
+def at_least(records: list["Record"], level: str) -> list["Record"]:
     """Records logged at ``level`` or above."""
     floor = _LEVELS[level]
     return [r for r in records if r["level"].no >= floor]
 
 
-def messages(records: list[dict], level: str) -> list[str]:
+def messages(records: list["Record"], level: str) -> list[str]:
     return [r["message"] for r in at_least(records, level)]
 
 


### PR DESCRIPTION
## Summary

Two independent, unrelated root-cause fixes bundled per instructions (one branch, one PR):

- **Fix 1** — `tests/test_silent_failure_surfacing.py`: the `records: list[dict]` annotation is wrong. `logger.add`'s callback appends `message.record`, which is loguru's `Record` `TypedDict` — a `TypedDict` is not assignable to a bare/mutable `dict` (real typing rule: `dict` permits destructive ops like `.clear()` that a `TypedDict` doesn't support). `ty` 0.0.59 (current pin) doesn't catch it; `ty` 0.0.65 (the version Renovate PR #1604 bumps to) correctly rejects it with `error[invalid-argument-type]` at `tests/test_silent_failure_surfacing.py:46:57`. Fixed the annotation, not the runtime code: `Record` is imported under `TYPE_CHECKING` (verified against the installed `loguru==0.7.3` in this repo's `.venv` — `Record` is defined in `loguru/__init__.pyi` but **not** exported by the runtime `loguru/__init__.py`, so an unconditional `from loguru import Record` raises `ImportError` at collection time). The two function-signature usages keep the string-quoted form (`list["Record"]`); the one local-variable usage doesn't need quoting (ruff's `UP037` confirms — CPython doesn't evaluate local variable annotations at all, unlike parameter/return annotations). Grepped for the same "list[dict]-of-loguru-records" pattern elsewhere (`tests/test_docs.py`, `tests/test_per_sub_credential_isolation.py`) — those `list[dict]` usages hold plain dict literals / `dict(kwargs)`, not loguru's `Record`, and are not flagged by either `ty` version, so left untouched.

- **Fix 2** — `renovate.json`: lock-file-maintenance PRs are born red on the "Validate PR title (Conventional Commits subset)" CI check (`amannn/action-semantic-pull-request`, `subjectPattern: ^(?![A-Z]).+$`) because Renovate's built-in default for `lockFileMaintenance.commitMessageAction` is `"Lock file maintenance"` (capital L), confirmed against the official default value documented at https://docs.renovatebot.com/configuration-options/#lockfilemaintenance. This repo's `commitMessageLowerCase: "auto"` (the default, unset) does not rescue it in practice -- `git log` shows real merged PRs titled `fix(deps): Lock file maintenance` (e.g. e10da4e, 43355f4, d340b0d), all landing *after* commit `3a06a09` statically overrode `commitMessagePrefix`/`commitMessageAction`/`semanticCommitType` at the top level (before that, e.g. commit `99d6e2b`, it correctly read `fix(deps): lock file maintenance`). Since `lockFileMaintenance` keeps its own nested default independent of the top-level `commitMessageAction: "update"` override, and the "auto" lowercase pass evidently isn't reliably reached for this branch type once the prefix is manually pinned, the deterministic fix is to override `lockFileMaintenance.commitMessageAction` directly to the already-lowercase `"lock file maintenance"` (matching this repo's pre-3a06a09 convention). Validated the whole file with the real `renovate-config-validator` (`npx -p renovate renovate-config-validator renovate.json`): `INFO: Config validated successfully against 1 file(s)`, with `lockFileMaintenance.commitMessageAction` accepted unchanged in both the "oldConfig"/"newConfig" migration preview (i.e., no deprecation/rename needed for this key). Did not touch the CI validator (it's correct); did not touch `commitMessageLowerCase` (already at its documented default and not the actual lever here).

## Test plan

- [x] `uv run --no-sync ty check` (pinned `ty==0.0.59` per `uv.lock`, synced via `uv sync --frozen --group dev` -- did not touch `uv.lock`/`pyproject.toml`) -- `All checks passed!` (0 diagnostics for `tests/test_silent_failure_surfacing.py`, verified via targeted grep before/after)
- [x] `uvx ty@0.0.65 check` (the version Renovate PR #1604 targets) -- went from `error[invalid-argument-type]` at `tests/test_silent_failure_surfacing.py:46:57` (baseline, reproduced) to 0 diagnostics for that file after the fix
- [x] `uv run --no-sync pytest tests/test_silent_failure_surfacing.py -q` -- `16 passed`
- [x] `npx -p renovate renovate-config-validator renovate.json` -- `INFO: Config validated successfully against 1 file(s)`
- [x] Grepped `tests/` for the same `list[dict]`-of-records pattern; confirmed the other two hits are unrelated plain-dict usages, not loguru `Record`, and left them alone

Note: a full whole-repo `ty check` from this shared multi-agent working directory also reports 27 pre-existing diagnostics under `.claude/worktrees/*` -- those are other concurrently-running agents' own git worktrees in this same session, entirely unrelated to this PR's two files, and out of this PR's scope.