### PR TITLE
fix: stamp the server's embedding identity in the Tier 1 ingest script

### DIFF
--- a/scripts/build_tier1_index.py
+++ b/scripts/build_tier1_index.py
@@ -29,6 +29,35 @@ from pathlib import Path
 from typing import Any
 
 
+def open_docs_db(db_path: Path):
+    """Open the docs store this script ingests into, as the server opens it.
+
+    This ingests into the same ``docs.db`` a running server reads, and
+    ``DocsDB`` stamps ``(embedding_model, embedding_dims)`` into ``store_meta``
+    on first open and refuses to reopen a store stamped with a different
+    identity. So the identity used here is not a detail of this script -- it
+    has to be the server's, byte for byte.
+
+    Hence the delegation to ``make_docs_db`` rather than a second copy of the
+    dims/model resolution. The copy this replaces was ``DocsDB(db_path,
+    embedding_dims=0)``: an identity no server ever produces, which broke
+    ingest in both directions. On a machine that had run the server, the
+    script could not open the store at all. On a clean runner -- the weekly
+    ``refresh-tier1`` job -- the script stamped dims=0 first and left behind a
+    store no server could open, then exited 0 because nothing in CI starts a
+    server afterwards.
+
+    ``make_docs_db`` also rejects ``DOCS_DB_BACKEND=cf-d1`` here: everything
+    this script does with the path (migrations, the metrics file written
+    beside it) is SQLite-specific, so a cf-d1 environment gets a clear refusal
+    instead of a run that quietly ingests into D1.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+    from wet_mcp.server import make_docs_db
+
+    return make_docs_db(db_path=db_path)
+
+
 async def _amain() -> int:
     parser = argparse.ArgumentParser(description="Eager Tier 1 docs ingestion")
     parser.add_argument(
@@ -50,13 +79,12 @@ async def _amain() -> int:
 
     # Lazy imports so script-only deps stay out of the runtime hot path.
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-    from wet_mcp.db import DocsDB
     from wet_mcp.migrations import run_migrations_on_startup
     from wet_mcp.sources.docs import ingest_tier2
     from wet_mcp.sources.tier1_warmup import _load_tier1_payload, maybe_warm
 
     args.db_path.parent.mkdir(parents=True, exist_ok=True)
-    db = DocsDB(args.db_path, embedding_dims=0)
+    db = open_docs_db(args.db_path)
     run_migrations_on_startup(args.db_path)
     maybe_warm(db, force=True)
 

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -81,7 +81,7 @@ def _missing_docs_db_methods(backend) -> list[str]:
     )
 
 
-def make_docs_db():
+def make_docs_db(db_path: Path | None = None):
     """Select docs DB backend: sqlite (default) or cf-d1 (D1 + Vectorize).
 
     DOCS_DB_BACKEND is orthogonal to MCP_STORAGE_BACKEND. The selector is read
@@ -89,6 +89,14 @@ def make_docs_db():
     sqlite path uses the module Settings singleton (patchable in tests) and
     preserves the B2 embedding-model identity guard; the cf-d1 path routes
     relational + FTS5 to D1 and vectors to Vectorize via env-configured clients.
+
+    ``db_path`` overrides ``settings.get_db_path()`` for a caller that opens a
+    store at an explicit location -- ``scripts/build_tier1_index.py --db-path``
+    is the one that does. It exists so that caller does not have to rebuild the
+    embedding identity itself: the dims and model id below are what the guard
+    in ``DocsDB`` compares against, so a second implementation of them stamps a
+    store the server then refuses to open. It is meaningful only for the sqlite
+    backend; under cf-d1 there is no local file to point at.
     """
     import os
 
@@ -96,6 +104,15 @@ def make_docs_db():
 
     dims = settings.resolve_embedding_dims() or _DEFAULT_EMBEDDING_DIMS
     backend = os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+    if backend == "cf-d1" and db_path is not None:
+        raise RuntimeError(
+            f"make_docs_db(db_path={str(db_path)!r}) was called while "
+            "DOCS_DB_BACKEND=cf-d1 selects the D1 + Vectorize store, where "
+            "that path addresses nothing. Honouring the selector would write "
+            "to a store the caller did not name, and honouring the path would "
+            "ignore the selector. Unset DOCS_DB_BACKEND to use the local "
+            "SQLite store at that path, or drop the path to use cf-d1."
+        )
     if backend == "cf-d1":
         from wet_mcp.backends.d1 import d1_backend_from_env
         from wet_mcp.backends.vectorize import vectorize_backend_from_env
@@ -132,7 +149,7 @@ def make_docs_db():
     else:  # unavailable -- local disabled + no cloud chain; no active embed model
         model_identity = ""
     return DocsDB(
-        settings.get_db_path(),
+        settings.get_db_path() if db_path is None else db_path,
         embedding_dims=dims,
         model_identity=model_identity,
         reindex_on_model_change=settings.reindex_on_model_change,

--- a/tests/test_tier1_index_embedding_identity.py
+++ b/tests/test_tier1_index_embedding_identity.py
@@ -1,0 +1,250 @@
+"""The Tier 1 ingest script and the server must agree on embedding identity.
+
+``DocsDB`` stamps ``(embedding_model, embedding_dims)`` into ``store_meta`` on
+first open and refuses to reopen a store stamped with a different identity
+(``EmbeddingModelMismatch``). That guard is correct. What was wrong is that
+``scripts/build_tier1_index.py`` opened the SAME ``~/.wet-mcp/docs.db`` with a
+hand-written identity of its own -- ``DocsDB(path, embedding_dims=0)``, no
+model id -- which no server ever produces. The two callers therefore stamped
+two different identities into one file, and whichever ran second was refused:
+
+* server first, script second -- eager ingest is impossible on any machine
+  that has ever started the server.
+* script first, server second -- the weekly ``refresh-tier1`` job exits 0 on a
+  clean runner and leaves behind a ``docs.db`` no server can open. Nothing in
+  CI starts a server afterwards, so the job reports success.
+
+These tests pin both directions, and pin the CI-runner case specifically: with
+no provider key in the environment the stamped dims must still be the server's
+768, never 0.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sqlite3
+
+import pytest
+
+from wet_mcp import server
+from wet_mcp.config import settings
+from wet_mcp.db import EmbeddingModelMismatch
+
+_SCRIPT = (
+    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "build_tier1_index.py"
+)
+_spec = importlib.util.spec_from_file_location("build_tier1_index", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+build_tier1_index = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_tier1_index)
+
+# Every provider key the curated embedding chain can be gated on. Cleared so a
+# developer shell that exports one does not turn a clean-runner test into a
+# cloud-identity test.
+_PROVIDER_KEYS = (
+    "JINA_AI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "COHERE_API_KEY",
+)
+
+
+@pytest.fixture
+def clean_runner_env(monkeypatch):
+    """Reproduce a clean CI runner: no provider keys, no rebuild escape hatch.
+
+    ``REINDEX_ON_MODEL_CHANGE`` is cleared on both the env and the settings
+    singleton: with it set the guard rebuilds instead of raising, which is
+    exactly how a developer shell that exports it hides this bug.
+    """
+    for key in _PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("EMBEDDING_MODELS", raising=False)
+    monkeypatch.delenv("EMBEDDING_DIMS", raising=False)
+    monkeypatch.delenv("REINDEX_ON_MODEL_CHANGE", raising=False)
+    monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
+    monkeypatch.setattr(settings, "embedding_models", "")
+    monkeypatch.setattr(settings, "embedding_model", "")
+    monkeypatch.setattr(settings, "embedding_backend", "")
+    monkeypatch.setattr(settings, "embedding_dims", 0)
+    monkeypatch.setattr(settings, "reindex_on_model_change", False)
+    monkeypatch.setattr(settings, "docs_db_backend", "sqlite")
+
+
+@pytest.fixture
+def cloud_embedding_env(clean_runner_env, monkeypatch):
+    """A machine configured the way the README's manual config example is."""
+    monkeypatch.setenv("JINA_AI_API_KEY", "placeholder-not-a-real-key")
+    monkeypatch.setattr(
+        settings, "embedding_models", "jina_ai/jina-embeddings-v5-text-small"
+    )
+
+
+def _stamp(db_path: pathlib.Path) -> dict[str, str]:
+    """Read the embedding identity recorded in ``store_meta``."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return dict(
+            conn.execute(
+                "SELECT key, value FROM store_meta "
+                "WHERE key IN ('embedding_model', 'embedding_dims')"
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+
+def _open_as_server(db_path: pathlib.Path, monkeypatch):
+    """Open ``db_path`` through the server's own construction path.
+
+    Goes through ``settings.get_db_path()`` rather than an argument, so the
+    test exercises the resolution a running server actually uses.
+    """
+    monkeypatch.setattr(settings, "docs_db_path", str(db_path))
+    return server.make_docs_db()
+
+
+def test_script_stamped_store_opens_with_server_construction(
+    tmp_path, monkeypatch, clean_runner_env
+):
+    """Direction 2: the weekly job's store must be openable by a server.
+
+    This is the CI case. No provider key is present, which is precisely when
+    the script used to stamp dims=0.
+    """
+    db_path = tmp_path / "docs.db"
+
+    build_tier1_index.open_docs_db(db_path).close()
+    script_stamp = _stamp(db_path)
+
+    # The stamp has to be a real identity, not the "no model, no dims"
+    # placeholder: dims=0 disables sqlite-vec entirely, so a store carrying it
+    # could never hold the vectors the server expects to find there.
+    assert script_stamp.get("embedding_dims") != "0", (
+        f"script stamped a dims=0 identity no server produces: {script_stamp}"
+    )
+
+    _open_as_server(db_path, monkeypatch).close()
+    assert _stamp(db_path) == script_stamp, (
+        "opening as the server changed the stamp, so the two callers still "
+        "disagree about identity"
+    )
+
+
+def test_script_opens_store_stamped_by_server(
+    tmp_path, monkeypatch, cloud_embedding_env
+):
+    """Direction 1: eager ingest on a machine that has run the server.
+
+    The reported crash: a real ``~/.wet-mcp/docs.db`` stamped
+    ``jina_ai/jina-embeddings-v5-text-small`` dims=768 by the server, which the
+    script then refused to open.
+    """
+    db_path = tmp_path / "docs.db"
+
+    _open_as_server(db_path, monkeypatch).close()
+    server_stamp = _stamp(db_path)
+    assert server_stamp == {
+        "embedding_dims": "768",
+        "embedding_model": "jina_ai/jina-embeddings-v5-text-small",
+    }, server_stamp
+
+    build_tier1_index.open_docs_db(db_path).close()
+    assert _stamp(db_path) == server_stamp
+
+
+def test_script_and_server_agree_without_any_provider_key(
+    tmp_path, monkeypatch, clean_runner_env
+):
+    """Both orders agree on a clean runner, and neither stamps dims=0.
+
+    Pins the answer to "what does a keyless runner resolve to": the local ONNX
+    identity at the server's default 768 dims, not ``unavailable``/0.
+    """
+    script_first = tmp_path / "script_first.db"
+    build_tier1_index.open_docs_db(script_first).close()
+
+    server_first = tmp_path / "server_first.db"
+    _open_as_server(server_first, monkeypatch).close()
+
+    assert _stamp(script_first) == _stamp(server_first)
+    assert _stamp(script_first)["embedding_dims"] == "768"
+
+
+def test_script_refuses_cf_d1_instead_of_writing_the_wrong_store(
+    tmp_path, monkeypatch, clean_runner_env
+):
+    """``DOCS_DB_BACKEND=cf-d1`` must fail loudly, not ingest somewhere else.
+
+    The script is SQLite-shaped end to end: ``--db-path``,
+    ``run_migrations_on_startup(args.db_path)``, and a metrics file written
+    next to the database. Under cf-d1 the store lives in D1 + Vectorize and
+    the path means nothing, so honouring the flag silently would ingest into a
+    different store than the operator named.
+    """
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+
+    with pytest.raises(RuntimeError, match="cf-d1"):
+        build_tier1_index.open_docs_db(tmp_path / "docs.db")
+
+
+def test_ingest_works_without_an_embedder_available(
+    tmp_path, monkeypatch, clean_runner_env
+):
+    """A keyless runner must still be able to write chunks.
+
+    The fix raises the stamped dims from 0 to 768, which turns on the
+    sqlite-vec table. CI has no provider key and downloads no local model, so
+    if ``add_chunks`` needed an embedder once dims > 0 the fix would trade a
+    corrupt store for a broken weekly job.
+    """
+    db_path = tmp_path / "docs.db"
+    db = build_tier1_index.open_docs_db(db_path)
+    try:
+        lib_id = db.upsert_library(name="requests", canonical_name="requests")
+        ver_id = db.upsert_version(library_id=lib_id, version="latest")
+        # Exactly how ingest_tier2 calls it: no ``embeddings`` argument.
+        written = db.add_chunks(
+            version_id=ver_id,
+            library_id=lib_id,
+            chunks=[
+                {
+                    "url": "https://example.com/doc",
+                    "title": "Doc",
+                    "content": "some documentation text",
+                    "heading_path": "",
+                    "chunk_index": 0,
+                }
+            ],
+        )
+    finally:
+        db.close()
+
+    assert written == 1
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert conn.execute("SELECT count(*) FROM doc_chunks").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_guard_still_fires_on_a_genuine_model_change(
+    tmp_path, monkeypatch, clean_runner_env
+):
+    """Positive control: the fix must not have defanged the guard.
+
+    Every other test here asserts something opens. Without this one they would
+    also pass if the guard had been disabled, the exception swallowed, or
+    ``REINDEX_ON_MODEL_CHANGE`` switched on.
+    """
+    db_path = tmp_path / "docs.db"
+    build_tier1_index.open_docs_db(db_path).close()
+
+    monkeypatch.setenv("JINA_AI_API_KEY", "placeholder-not-a-real-key")
+    monkeypatch.setattr(
+        settings, "embedding_models", "jina_ai/jina-embeddings-v5-text-small"
+    )
+    with pytest.raises(EmbeddingModelMismatch):
+        build_tier1_index.open_docs_db(db_path)


### PR DESCRIPTION
## The defect

`scripts/build_tier1_index.py` ingests into the same `~/.wet-mcp/docs.db` a running server reads, but built its own embedding identity to open it:

```python
db = DocsDB(args.db_path, embedding_dims=0)     # scripts/build_tier1_index.py:59
```

`DocsDB` stamps `(embedding_model, embedding_dims)` into `store_meta` on first open and refuses to reopen a store stamped with a different identity (`_guard_embedding_identity`, `src/wet_mcp/db.py`). `dims=0` with no model id is an identity no server ever produces, so the two callers wrote two identities into one file and whichever ran second was refused.

**Direction 1 - server-first machine.** A store the server stamped `jina_ai/jina-embeddings-v5-text-small` dims=768; the script then died at construction, before any ingest:

```
wet_mcp.db.EmbeddingModelMismatch: Docs vector store was built with embedding model
'jina_ai/jina-embeddings-v5-text-small' (dims=768) but the server is now configured
for '<unknown>' (dims=0).
```

Eager Tier 1 ingest was impossible on any machine that had ever started the server.

**Direction 2 - clean runner, which is what the weekly `refresh-tier1` job is.** The script ran to completion, exited 0, and left `store_meta = {'embedding_dims': '0'}`. Opening that store the way the server does:

```
wet_mcp.db.EmbeddingModelMismatch: Docs vector store was built with embedding model
'<unknown>' (dims=0) but the server is now configured for
'n24q02m/Qwen3-Embedding-0.6B-ONNX' (dims=768).
```

The job painted CI green while leaving behind a database no server could open. Nothing in CI starts a server afterwards, so nothing noticed.

## The fix

The guard is correct; the caller was wrong. The script now delegates to `make_docs_db`, which grows an optional `db_path` defaulting to `settings.get_db_path()`. Identity resolution lives in exactly one place, so the script cannot drift from the server again.

Deliberately **not** done: no `REINDEX_ON_MODEL_CHANGE`, no delete-and-recreate, no catching `EmbeddingModelMismatch`. A test asserts the guard still fires on a genuine model change, so the passing tests cannot be passing because the guard was defanged.

Duplicating the dims/model resolution into the script was rejected: a second implementation of the thing the guard compares against is exactly how one identity became two.

## What a keyless runner actually resolves to

Measured with the environment cleared to a strict allowlist, because a developer shell here exports `EMBEDDING_MODELS` and `REINDEX_ON_MODEL_CHANGE=true`, and the latter silently turns the guard into a rebuild:

| call | value |
|---|---|
| `resolve_embedding_dims()` | `0` -> `make_docs_db` normalises to `_DEFAULT_EMBEDDING_DIMS` = **768** |
| `resolve_embedding_backend()` | **`local`**, not `unavailable` (`DISABLE_LOCAL_EMBED` is unset) |
| `resolve_local_embedding_model()` | `n24q02m/Qwen3-Embedding-0.6B-ONNX` |

So routing through `make_docs_db` stamps `(768, n24q02m/Qwen3-Embedding-0.6B-ONNX)` on a clean runner, which is byte for byte what a server on that same runner stamps. Direction 2 is fixed, not merely relocated.

Raising the stamp from 0 to 768 turns the sqlite-vec table on, so the obvious follow-up question is whether ingest still works with no embedder available. It does: `ingest_tier2` calls `add_chunks` with no `embeddings` argument, and `_add_chunk_vectors` returns early when there are none. Verified by running the real `ingest_tier2` at dims=768 with no provider key: `status=ok`, 2 chunks written, `vec_enabled=True`.

## DOCS_DB_BACKEND=cf-d1

Refused, not silently ignored. This script is SQLite-shaped end to end - `--db-path`, `run_migrations_on_startup` on that path, a metrics file written beside it - so under cf-d1 the path addresses nothing. Honouring the selector would ingest into a store the operator did not name; honouring the path would ignore the selector. `make_docs_db` now raises when both are given, which surfaces before anything is written.

## Verification

Both directions were reproduced against the unmodified script as subprocesses before the fix, then re-run after. Full order/environment matrix, real script, only the page fetch stubbed:

| environment | order | before | after |
|---|---|---|---|
| no provider key | script-first, then server | server refused | both exit 0, stamp `768 / Qwen3-Embedding-0.6B-ONNX` |
| no provider key | server-first, then script | script refused | both exit 0, same stamp |
| Jina key set | script-first, then server | server refused | both exit 0, stamp `768 / jina-embeddings-v5-text-small` |
| Jina key set | server-first, then script | script refused | both exit 0, same stamp |
| `DOCS_DB_BACKEND=cf-d1` | - | ingested into D1 regardless of `--db-path` | exit 1 with a message naming both the path and the selector |

New tests red before the fix, green after:

```
5 failed, 1 passed    ->    6 passed
```

Full suite: `2258 passed, 35 skipped, 140 deselected in 178.37s`. `ruff check`, `ruff format --check`, `ty check` all clean.

## Adjacent, deliberately not fixed

- `scripts/build_tier1_index.py:66` defaults `--db-path` to a hardcoded `Path.home() / ".wet-mcp" / "docs.db"`, which ignores `DOCS_DB_PATH` and `CACHE_DIR` that `settings.get_db_path()` honours (`src/wet_mcp/config.py:295`). Same second-source-of-truth family as this bug, different axis: with `CACHE_DIR` set, the script ingests into a file the server never reads. The identities agree, so this fix is not affected.
- `server.py:1969` `_active_docs_backend` is documented as a deliberate byte-for-byte mirror of the selector expression in `make_docs_db` - the same duplication shape, currently held in place by a test rather than by construction.
- `_resolve_local_model` picks the GGUF or the ONNX id from `_detect_gpu() and _has_gguf_support()`, so the stamped model id is machine-dependent even with identical env. A store moved between a CUDA machine and a CPU machine trips the guard. Pre-existing server behaviour, not script-specific.
- The weekly job still never opens the store as a server would, so CI cannot catch an identity regression on its own; only `tier1_index_metrics.json` is uploaded and the database is discarded with the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
