### PR TITLE
fix: make background docs indexing durable and self-reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ Run your own single-user wet instance serverless on Cloudflare (Containers + D1 
    ```
    wrangler d1 create wet-docs
    wrangler d1 execute wet-docs --file migrations/0001_init_wet.sql --remote
+   wrangler d1 execute wet-docs --file migrations/0002_project_context.sql --remote
+   wrangler d1 execute wet-docs --file migrations/0003_version_index_state.sql --remote
    wrangler vectorize create wet-docs-vectors --dimensions 768 --metric cosine
    wrangler kv namespace create wet-kv
    ```

--- a/migrations/0003_version_index_state.sql
+++ b/migrations/0003_version_index_state.sql
@@ -1,0 +1,25 @@
+-- migrations/0003_version_index_state.sql
+-- Durable record of what the background indexer did, per (library, version).
+--
+-- Without it, `chunks: 0` in config(action="status") is one number covering
+-- four different states -- never attempted, still running, failed, and
+-- succeeded with no content -- and the failure path only ever wrote a
+-- logger.error inside the Cloudflare container, where nothing collects it.
+-- These three columns put the outcome where the normal query path can read
+-- it, i.e. outside the container.
+--
+-- index_state is deliberately NOT the existing `status` column: `status`
+-- gates what get_best_version serves, so a version must be able to stay
+-- 'indexed' (still serving its old chunks) while its newest re-index attempt
+-- reads 'failed'. page_count / chunk_count stay owned by mark_version_indexed
+-- and keep describing the last SUCCESSFUL index.
+--
+-- Mirrors the SQLite side: db.py _create_versions_table + the
+-- docs_006_version_index_state Alembic revision.
+--
+-- No transaction-control statements here: wrangler scans migration text for
+-- them and refuses the file, matching on the raw text even inside a comment.
+
+ALTER TABLE versions ADD COLUMN index_state TEXT;
+ALTER TABLE versions ADD COLUMN index_error TEXT;
+ALTER TABLE versions ADD COLUMN index_state_at REAL;

--- a/src/wet_mcp/alembic/versions/docs_006_version_index_state.py
+++ b/src/wet_mcp/alembic/versions/docs_006_version_index_state.py
@@ -1,0 +1,65 @@
+"""Record indexing-attempt outcomes on ``versions``.
+
+Adds the nullable ``index_state`` / ``index_error`` / ``index_state_at``
+columns so a background indexing attempt leaves something durable behind.
+
+Before this revision the only trace of a failed index was a ``logger.error``
+inside the process that failed, so a store reporting zero chunks could equally
+be one that was never asked to index, one still working, one that failed
+permanently, and one that succeeded on a page with no extractable content.
+
+``index_state`` is deliberately separate from the existing ``status`` column:
+``status`` gates what ``get_best_version`` serves, so a version has to be able
+to keep serving its old chunks (``status = 'indexed'``) while its most recent
+re-index attempt reads ``failed``.
+
+Idempotent: each column add is guarded by ``PRAGMA table_info``.
+
+Revision ID: docs_006_version_index_state
+Revises: docs_005_metadata_seeded_at
+Create Date: 2026-08-03
+"""
+
+from __future__ import annotations
+
+import logging
+
+from alembic import op
+
+# Revision identifiers used by Alembic.
+revision = "docs_006_version_index_state"
+down_revision = "docs_005_metadata_seeded_at"
+branch_labels = None
+depends_on = None
+
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    """Add the three nullable indexing-state columns to ``versions``."""
+    existing_cols = {
+        row[0]
+        for row in op.get_bind()
+        .exec_driver_sql("SELECT name FROM pragma_table_info(?)", ("versions",))
+        .fetchall()
+    }
+    if "index_state" not in existing_cols:
+        op.execute("ALTER TABLE versions ADD COLUMN index_state TEXT")
+    if "index_error" not in existing_cols:
+        op.execute("ALTER TABLE versions ADD COLUMN index_error TEXT")
+    if "index_state_at" not in existing_cols:
+        op.execute("ALTER TABLE versions ADD COLUMN index_state_at REAL")
+
+
+def downgrade() -> None:
+    """No-op: dropping the columns would discard the only failure record.
+
+    The columns are nullable and no code path requires them to be absent, so
+    leaving them in place is harmless when rolling back to
+    ``docs_005_metadata_seeded_at``.
+    """
+    logger.warning(
+        "docs_006_version_index_state downgrade is a no-op; "
+        "versions.index_state / index_error / index_state_at are left in place"
+    )

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -112,6 +112,14 @@ _DOC_CHUNKS_COLUMNS = {
 # Directive-heavy content (mkdocs leftover, rst directives)
 _DIRECTIVE_RE = re.compile(r"^(?:!!!|:::|\.\.)\s", re.MULTILINE)
 
+# Values written to ``versions.index_state`` by ``set_index_state``. They record
+# what the LAST indexing attempt did, which ``versions.status`` cannot: status
+# gates what ``get_best_version`` serves, so a version can be serving usable
+# chunks (status='indexed') while its newest re-index attempt is 'failed'.
+INDEX_STATE_RUNNING = "running"
+INDEX_STATE_DONE = "done"
+INDEX_STATE_FAILED = "failed"
+
 
 def _build_fts_queries(query: str) -> list[str]:
     """Build tiered FTS5 queries: PHRASE -> AND -> OR.
@@ -535,6 +543,9 @@ class DocsDB:
                 status TEXT DEFAULT 'pending',
                 release_date REAL,
                 source_url TEXT,
+                index_state TEXT,
+                index_error TEXT,
+                index_state_at REAL,
                 FOREIGN KEY (library_id) REFERENCES libraries(id) ON DELETE CASCADE,
                 UNIQUE(library_id, version)
             )
@@ -543,6 +554,9 @@ class DocsDB:
         for sql in (
             "ALTER TABLE versions ADD COLUMN release_date REAL",
             "ALTER TABLE versions ADD COLUMN source_url TEXT",
+            "ALTER TABLE versions ADD COLUMN index_state TEXT",
+            "ALTER TABLE versions ADD COLUMN index_error TEXT",
+            "ALTER TABLE versions ADD COLUMN index_state_at REAL",
         ):
             try:
                 self._conn.execute(sql)
@@ -991,6 +1005,93 @@ class DocsDB:
             (_now_ts(), page_count, chunk_count, version_id),
         )
         self._conn.commit()
+
+    def set_index_state(
+        self, version_id: str, state: str, error: str | None = None
+    ) -> None:
+        """Record the outcome of an indexing attempt on a version.
+
+        ``state`` is one of ``INDEX_STATE_RUNNING`` / ``INDEX_STATE_DONE`` /
+        ``INDEX_STATE_FAILED``. Writing it to the database is the point: the
+        background indexer's only previous record of a failure was a
+        ``logger.error`` inside the container, which reaches nobody, so
+        ``chunks: 0`` was indistinguishable from never-attempted,
+        still-running, failed and succeeded-with-no-content.
+
+        ``page_count`` / ``chunk_count`` are deliberately NOT written here.
+        They describe the last SUCCESSFUL index (``mark_version_indexed`` owns
+        them), and zeroing them on a failed attempt would erase the only
+        record that usable chunks are still stored for this version.
+        """
+        self._conn.execute(
+            """UPDATE versions
+               SET index_state = ?, index_error = ?, index_state_at = ?
+               WHERE id = ?""",
+            (state, error, _now_ts(), version_id),
+        )
+        self._conn.commit()
+
+    def get_index_state(self, version_id: str) -> dict | None:
+        """Return the indexing-attempt record for a version.
+
+        ``None`` means no attempt was ever recorded (or the version is gone),
+        which is a different answer from a recorded failure -- telling those
+        two apart is the whole reason this row exists.
+        """
+        row = self._conn.execute(
+            """SELECT id, library_id, version, index_state, index_error,
+                      index_state_at, page_count, chunk_count
+               FROM versions WHERE id = ?""",
+            (version_id,),
+        ).fetchone()
+        if row is None or row["index_state"] is None:
+            return None
+        return {
+            "version_id": row["id"],
+            "library_id": row["library_id"],
+            "version": row["version"],
+            "state": row["index_state"],
+            "error": row["index_error"],
+            "updated_at": row["index_state_at"],
+            "page_count": row["page_count"],
+            "chunk_count": row["chunk_count"],
+        }
+
+    def index_status(self, limit: int = 20) -> dict:
+        """Summarize recorded indexing attempts for ``config(action="status")``.
+
+        Returns a per-state tally plus the most recently touched attempts,
+        newest first, so an operator reading the status payload can tell a
+        store that indexed nothing from one that failed eight times and say
+        why.
+        """
+        counts = {
+            r["state"]: r["n"]
+            for r in self._conn.execute(
+                "SELECT index_state AS state, COUNT(*) AS n FROM versions "
+                "WHERE index_state IS NOT NULL GROUP BY index_state"
+            ).fetchall()
+        }
+        recent = [
+            {
+                "library": r["library"],
+                "version": r["version"],
+                "state": r["index_state"],
+                "error": r["index_error"],
+                "updated_at": r["index_state_at"],
+                "page_count": r["page_count"],
+                "chunk_count": r["chunk_count"],
+            }
+            for r in self._conn.execute(
+                "SELECT v.version, v.index_state, v.index_error, v.index_state_at,"
+                " v.page_count, v.chunk_count, l.name AS library"
+                " FROM versions v LEFT JOIN libraries l ON v.library_id = l.id"
+                " WHERE v.index_state IS NOT NULL"
+                " ORDER BY v.index_state_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        ]
+        return {"counts": counts, "recent": recent}
 
     def get_best_version(
         self, library_id: str, target: str | None = None

--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -196,6 +196,74 @@ class DocsDBCfBackend:
             [time.time(), page_count, chunk_count, version_id],
         )
 
+    def set_index_state(
+        self, version_id: str, state: str, error: str | None = None
+    ) -> None:
+        """Record an indexing attempt's outcome on D1.
+
+        This is the CF half of the durability fix: a background indexer
+        running inside the Cloudflare container writes its logs to a stderr
+        nothing collects, so D1 is the only place a failure can be read from
+        outside the container. Four bound parameters, well inside D1's
+        per-statement parameter ceiling -- and fixed, not scaled by row count.
+        """
+        self._d1.execute(
+            "UPDATE versions SET index_state = ?, index_error = ?,"
+            " index_state_at = ? WHERE id = ?",
+            [state, error, time.time(), version_id],
+        )
+
+    def get_index_state(self, version_id: str) -> dict | None:
+        """Return the indexing-attempt record for a version, or None."""
+        row = self._d1.fetchone(
+            "SELECT id, library_id, version, index_state, index_error,"
+            " index_state_at, page_count, chunk_count FROM versions WHERE id = ?",
+            [version_id],
+        )
+        if row is None or row.get("index_state") is None:
+            return None
+        return {
+            "version_id": row["id"],
+            "library_id": row["library_id"],
+            "version": row["version"],
+            "state": row["index_state"],
+            "error": row["index_error"],
+            "updated_at": row["index_state_at"],
+            "page_count": row["page_count"],
+            "chunk_count": row["chunk_count"],
+        }
+
+    def index_status(self, limit: int = 20) -> dict:
+        """Summarize recorded indexing attempts. Mirrors DocsDB.index_status."""
+        counts = {
+            r["state"]: r["n"]
+            for r in self._d1.execute(
+                "SELECT index_state AS state, COUNT(*) AS n FROM versions"
+                " WHERE index_state IS NOT NULL GROUP BY index_state",
+                [],
+            )
+        }
+        recent = [
+            {
+                "library": r["library"],
+                "version": r["version"],
+                "state": r["index_state"],
+                "error": r["index_error"],
+                "updated_at": r["index_state_at"],
+                "page_count": r["page_count"],
+                "chunk_count": r["chunk_count"],
+            }
+            for r in self._d1.execute(
+                "SELECT v.version, v.index_state, v.index_error, v.index_state_at,"
+                " v.page_count, v.chunk_count, l.name AS library"
+                " FROM versions v LEFT JOIN libraries l ON v.library_id = l.id"
+                " WHERE v.index_state IS NOT NULL"
+                " ORDER BY v.index_state_at DESC LIMIT ?",
+                [limit],
+            )
+        ]
+        return {"counts": counts, "recent": recent}
+
     def mark_library_indexed(
         self, library_id: str, total_versions: int | None = None
     ) -> None:

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -1,12 +1,14 @@
 """WET MCP Server - Main server definition."""
 
 import asyncio
+import datetime
 import difflib
 import functools
 import io
 import json
 import os
 import sys
+import time
 
 # Fix Windows console encoding for Unicode output
 if sys.platform == "win32":
@@ -26,7 +28,12 @@ from mcp.types import ToolAnnotations
 
 from wet_mcp.cache import WebCache
 from wet_mcp.config import settings
-from wet_mcp.db import DocsDB
+from wet_mcp.db import (
+    INDEX_STATE_DONE,
+    INDEX_STATE_FAILED,
+    INDEX_STATE_RUNNING,
+    DocsDB,
+)
 from wet_mcp.searxng_runner import ensure_searxng, stop_searxng
 from wet_mcp.security import UNTRUSTED_SOURCE, build_external_tool_result
 from wet_mcp.sources import search_backends
@@ -63,6 +70,47 @@ _RERANK_CANDIDATE_MULTIPLIER = 3
 _web_cache: WebCache | None = None
 _docs_db: DocsDB | None = None
 _embedding_dims: int = 0
+
+# Strong references to fire-and-forget background tasks. asyncio keeps only a
+# WEAK reference to a running task, so a task whose handle is discarded can be
+# garbage-collected mid-flight and simply stop. Holding it here until it
+# finishes is what makes "launched" mean "ran".
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _on_background_task_done(task: asyncio.Task, label: str) -> None:
+    """Release a finished background task and report what it did.
+
+    An exception nobody retrieves surfaces only as a GC-time "Task exception
+    was never retrieved" on stderr -- which, inside a Cloudflare container, is
+    a place no operator can read. Log it here, with the traceback, at the
+    moment it happens.
+
+    Formatted with ``traceback`` rather than ``logger.opt(exception=True)``
+    because the stderr sink runs with loguru's default ``diagnose=True``, which
+    would dump every local (chunk bodies, provider objects) into the log.
+    """
+    _background_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        import traceback
+
+        logger.error(
+            f"Background task '{label}' failed: {type(exc).__name__}: {exc}\n"
+            + "".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            ).rstrip()
+        )
+
+
+def _launch_background_task(coro, label: str) -> asyncio.Task:
+    """Start ``coro`` as a tracked task instead of an unreferenced one."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(functools.partial(_on_background_task_done, label=label))
+    return task
 
 
 def _missing_docs_db_methods(backend) -> list[str]:
@@ -351,7 +399,7 @@ async def _lifespan_startup() -> asyncio.Task | None:
         except Exception as e:
             logger.error(f"Background backend init failed: {e}")
 
-    asyncio.create_task(_init_backends_task())
+    _launch_background_task(_init_backends_task(), "init-backends")
 
     # 5. Initialize docs DB (sqlite or cf-d1) via the backend factory, then run
     #    Alembic migrations (auto-migrate-on-startup with backup-before-migrate
@@ -1367,7 +1415,9 @@ async def search(  # noqa: PLR0913
             # status='indexed'.
             if not resolved or resolved[0].get("latest_version") is None:
                 # Tier 2 lazy ingest: fire-and-forget, return progress hint.
-                asyncio.create_task(ingest_tier2(_docs_db, library))
+                _launch_background_task(
+                    ingest_tier2(_docs_db, library), f"ingest-tier2:{library}"
+                )
                 return {
                     "status": "indexing_in_progress",
                     "library": library,
@@ -1982,6 +2032,11 @@ async def _handle_config_status() -> dict[str, Any]:
             "backend": docs_backend,
             "path": (None if docs_backend == "cf-d1" else str(settings.get_db_path())),
             "docs_indexed": (_docs_db.stats() if _docs_db else {}),
+            # docs_indexed alone cannot say why a number is what it is: zero
+            # chunks reads the same whether nothing was ever indexed, an
+            # indexer is running now, or every attempt failed. This is the
+            # recorded outcome of those attempts, read back from the store.
+            "indexing": (_docs_db.index_status() if _docs_db else {}),
         },
         "embedding": {
             "backend": (type(embed_backend).__name__ if embed_backend else None),
@@ -2504,6 +2559,90 @@ async def _fetch_and_chunk_docs(
 # Docs search (library documentation with auto-indexing)
 # ---------------------------------------------------------------------------
 
+# A ``running`` record older than this counts as abandoned. The indexer lives
+# in a process that can vanish without unwinding (container evicted, OOM kill,
+# redeploy), and a ``running`` row nobody will ever finish would otherwise lock
+# its library out of indexing forever. The pipeline's own sub-timeouts
+# (_DISCOVERY_TIMEOUT + _FETCH_TIMEOUT + _SEARXNG_TIMEOUT + _FALLBACK_TIMEOUT +
+# _EMBED_TIMEOUT) sum to well under this, so a live run is never mistaken for
+# an abandoned one.
+_INDEX_RUNNING_STALE_AFTER = 900.0
+
+
+def _index_attempt_in_flight(state: dict[str, Any] | None) -> bool:
+    """True when another indexer is still working on this version."""
+    if not isinstance(state, dict) or state.get("state") != INDEX_STATE_RUNNING:
+        return False
+    started = state.get("updated_at")
+    if not isinstance(started, int | float):
+        # A ``running`` row with no timestamp cannot be aged out; treat it as
+        # live rather than relaunch on top of an indexer that may be running.
+        return True
+    return (time.time() - started) < _INDEX_RUNNING_STALE_AFTER
+
+
+def _format_index_timestamp(ts: Any) -> str:
+    """Epoch seconds as a readable UTC stamp for a user-facing message."""
+    if not isinstance(ts, int | float):
+        return "an unrecorded time"
+    return (
+        datetime.datetime.fromtimestamp(ts, tz=datetime.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+    )
+
+
+def _docs_indexing_message(
+    library: str, state: dict[str, Any] | None, already_running: bool
+) -> str:
+    """Describe what actually happened to this library's index.
+
+    A docs search that finds no chunks used to answer with one unconditional
+    "indexing in progress, this may take 3-5 minutes" whether the version had
+    never been attempted, was still running, or had failed on every previous
+    try -- so a permanently broken library was reported as a slow one forever.
+    """
+    if already_running and isinstance(state, dict):
+        return (
+            f"Library '{library}' has been indexing since "
+            f"{_format_index_timestamp(state.get('updated_at'))} (started by an "
+            "earlier request); no second indexing run was launched. Retry "
+            "shortly. In the meantime, here are temporary web search results."
+        )
+    if isinstance(state, dict) and state.get("state") == INDEX_STATE_FAILED:
+        return (
+            f"The previous indexing attempt for '{library}' failed at "
+            f"{_format_index_timestamp(state.get('updated_at'))}: "
+            f"{state.get('error') or 'no reason was recorded'}. A fresh attempt "
+            "has started; here are temporary web search results."
+        )
+    return (
+        f"Library '{library}' is currently being downloaded and indexed in the "
+        "background (this may take 3-5 minutes). In the meantime, here are "
+        "temporary web search results."
+    )
+
+
+def _record_index_state(ver_id: str, state: str, error: str | None = None) -> None:
+    """Persist a background indexing outcome, without ever masking it.
+
+    This is the reporting channel of last resort, so it must not be able to
+    throw over the failure it is reporting: the caller is an `except` handler
+    holding the real error. A missing store means there is nothing to record
+    into and nothing was indexed either; a store that rejects the write leaves
+    only the log, which is the very situation this record exists to improve on,
+    so say so loudly rather than let it pass as recorded.
+    """
+    if _docs_db is None:
+        return
+    try:
+        _docs_db.set_index_state(ver_id, state, error)
+    except Exception as exc:
+        logger.error(
+            f"Could not record indexing state '{state}' for version {ver_id}: "
+            f"{type(exc).__name__}: {exc}"
+        )
+
 
 async def _background_index_and_search(
     library: str,
@@ -2606,9 +2745,13 @@ async def _background_index_and_search(
                 )
 
         if not all_chunks:
-            logger.error(
-                f"Background indexing failed: Could not extract content from {docs_url}"
-            )
+            reason = f"Could not extract content from {docs_url}"
+            logger.error(f"Background indexing failed: {reason}")
+            # The log line above never leaves the process. Record the outcome
+            # where the normal query path can read it, so a store reporting
+            # zero chunks can say WHY instead of looking identical to one that
+            # was never asked to index.
+            _record_index_state(ver_id, INDEX_STATE_FAILED, reason)
             return
 
         # Generate embeddings
@@ -2646,6 +2789,12 @@ async def _background_index_and_search(
                     )
                     embeddings = None
 
+        # Drop the previous content only now that its replacement is in hand.
+        # This clear used to run at launch time in _do_docs_search, so every
+        # docs search on an already-indexed library wiped it first and a failed
+        # re-index left nothing behind.
+        _docs_db.clear_version_chunks(ver_id)
+
         # Store chunks
         _docs_db.add_chunks(
             version_id=ver_id,
@@ -2663,24 +2812,28 @@ async def _background_index_and_search(
         # `versions` (the table is UNIQUE(library_id, version)) and a
         # hardcoded 1 would be wrong.
         _docs_db.mark_library_indexed(lib_id)
+        _record_index_state(ver_id, INDEX_STATE_DONE)
         logger.info(
             f"Background indexing complete for '{library}'. Pages: {page_count}, Chunks: {len(all_chunks)}"
         )
 
     except Exception as e:
-        # Fire-and-forget task: nothing ever inspects its result, so this is
-        # the only record that the library was never indexed. A bare `{e}` on
-        # a KeyError/TypeError prints just the attribute name, which is what
-        # made the Tier 1 breakage of #1590 unreadable -- keep the traceback.
-        # Formatted here rather than via ``logger.opt(exception=True)`` because
-        # the stderr sink runs with loguru's default ``diagnose=True``, which
-        # would dump every local (chunk bodies, provider objects) into the log.
+        # A bare `{e}` on a KeyError/TypeError prints just the attribute name,
+        # which is what made the Tier 1 breakage of #1590 unreadable -- keep
+        # the traceback. Formatted here rather than via
+        # ``logger.opt(exception=True)`` because the stderr sink runs with
+        # loguru's default ``diagnose=True``, which would dump every local
+        # (chunk bodies, provider objects) into the log.
         import traceback
 
         logger.error(
             f"Background indexing failed for '{library}' ({docs_url}): "
             f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
         )
+        # And record it durably: an unexpected exception must leave the same
+        # readable trace as the empty-chunks case, or the version stays
+        # 'running' forever and the log is again the only witness.
+        _record_index_state(ver_id, INDEX_STATE_FAILED, f"{type(e).__name__}: {e}")
 
 
 async def _search_cached_index(
@@ -2912,23 +3065,30 @@ async def _do_docs_search(
         docs_url=docs_url,
     )
 
-    # Clear old chunks for re-indexing
-    _docs_db.clear_version_chunks(ver_id)
-
-    # Step 3: Launch background indexer
-    asyncio.create_task(
-        _background_index_and_search(
-            library=library,
-            lib_key=lib_key,
-            language=language,
-            docs_url=docs_url,
-            repo_url=repo_url,
-            query=query,
-            version=version,
-            lib_id=lib_id,
-            ver_id=ver_id,
+    # Step 3: launch a background indexer, unless one is already working this
+    # version. The old-chunk clear that used to sit here has moved into the
+    # indexer, next to the write that replaces them: clearing before the
+    # replacement exists meant one failed re-index destroyed the library's
+    # only good copy, and left every later search restarting the same failing
+    # work against an empty store.
+    index_state = _docs_db.get_index_state(ver_id)
+    already_running = _index_attempt_in_flight(index_state)
+    if not already_running:
+        _docs_db.set_index_state(ver_id, INDEX_STATE_RUNNING)
+        _launch_background_task(
+            _background_index_and_search(
+                library=library,
+                lib_key=lib_key,
+                language=language,
+                docs_url=docs_url,
+                repo_url=repo_url,
+                query=query,
+                version=version,
+                lib_id=lib_id,
+                ver_id=ver_id,
+            ),
+            f"docs-index:{lib_key}",
         )
-    )
 
     fallback_data = await _do_immediate_fallback_search(
         docs_url=docs_url,
@@ -2940,7 +3100,12 @@ async def _do_docs_search(
 
     return {
         "status": "indexing_in_progress",
-        "message": f"Library '{library}' is currently being downloaded and indexed in the background (this may take 3-5 minutes). In the meantime, here are temporary web search results.",
+        "message": _docs_indexing_message(library, index_state, already_running),
+        # The last attempt on record, machine-readable next to the prose. Named
+        # for what it is: when one was already running this IS that run, and
+        # when a fresh one was just launched this is the attempt it follows
+        # (carrying the reason the previous one failed).
+        "last_index_attempt": index_state,
         "temporary_results": fallback_data.get("results", []),
         "library": library,
         "docs_url": docs_url,

--- a/tests/test_db_cf_contract.py
+++ b/tests/test_db_cf_contract.py
@@ -81,6 +81,101 @@ def test_mark_metadata_seeded_is_distinct_from_indexed():
     assert row["last_indexed_at"] is None
 
 
+def test_index_state_roundtrips_through_d1():
+    """The whole point of the record: it is readable from outside the container.
+
+    A background indexer inside the Cloudflare container logs to a stderr
+    nothing collects, so D1 is the only surface where its outcome can be seen.
+    """
+    db = _backend()
+    _lib_id, ver_id = _seeded(db)
+
+    db.set_index_state(ver_id, "running")
+    assert db.get_index_state(ver_id)["state"] == "running"
+
+    db.set_index_state(ver_id, "failed", "Could not extract content from https://a")
+
+    state = db.get_index_state(ver_id)
+    assert state["state"] == "failed"
+    assert state["error"] == "Could not extract content from https://a"
+    assert state["updated_at"] > 0
+    assert state["version"] == "1.0"
+
+
+def test_index_state_is_absent_until_something_attempts_an_index():
+    """Never-attempted must not read as an outcome."""
+    db = _backend()
+    _lib_id, ver_id = _seeded(db)
+    assert db.get_index_state(ver_id) is None
+    assert db.get_index_state("no-such-version") is None
+
+
+def test_failed_state_does_not_disturb_the_counts():
+    """Recording a failure must not zero the chunks the version still serves."""
+    db = _backend()
+    _lib_id, ver_id = _seeded(db)
+    db.mark_version_indexed(ver_id, 12, 340)
+
+    db.set_index_state(ver_id, "failed", "docs host returned 503")
+
+    row = db._d1.fetchone("SELECT * FROM versions WHERE id = ?", [ver_id])
+    assert (row["page_count"], row["chunk_count"]) == (12, 340)
+    assert row["status"] == "indexed", "a failed retry must not unpublish good data"
+
+
+def test_index_status_summarizes_what_config_status_reports():
+    """config(action='status') reads this to say why chunks is zero."""
+    db = _backend()
+    lib_id, ver_id = _seeded(db)
+    other_ver = db.upsert_version(lib_id, "2.0", docs_url="https://a")
+    db.set_index_state(ver_id, "failed", "Could not extract content")
+    db.set_index_state(other_ver, "running")
+
+    status = db.index_status()
+
+    assert status["counts"] == {"failed": 1, "running": 1}
+    recent = {r["version"]: r for r in status["recent"]}
+    assert recent["1.0"]["error"] == "Could not extract content"
+    assert recent["1.0"]["library"] == "alpha"
+    assert recent["2.0"]["state"] == "running"
+
+
+def test_index_state_writes_use_a_fixed_parameter_count():
+    """Never scale a D1 statement by row count -- that is what PR #1601 fixed."""
+    import json as _json
+
+    captured = []
+
+    class RecordingHttp:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def request(self, method, url, data=None, headers=None):
+            if url.endswith(("/query", "/batch")):
+                captured.append(_json.loads(data.decode()))
+            return self._inner.request(method, url, data, headers)
+
+    d1 = D1Backend("http://d1.internal", http=RecordingHttp(FakeD1Http(DDL)))
+    vec = VectorizeBackend(
+        "http://vectorize.internal", idx="wet", http=FakeVectorizeHttp()
+    )
+    db = DocsDBCfBackend(d1, vec, embedding_dims=768)
+    lib_id = db.upsert_library("alpha", docs_url="https://a")
+    for i in range(20):
+        db.set_index_state(
+            db.upsert_version(lib_id, f"{i}.0", docs_url="https://a"), "running"
+        )
+
+    updates = [
+        s
+        for p in captured
+        for s in (p if isinstance(p, list) else [p])
+        if "UPDATE versions SET index_state" in s["sql"]
+    ]
+    assert len(updates) == 20
+    assert {len(s["params"]) for s in updates} == {4}
+
+
 def test_clear_version_chunks_removes_rows_and_vectors():
     """Chunks and their vectors go together, or search returns ghosts."""
     db = _backend()

--- a/tests/test_index_state_durability.py
+++ b/tests/test_index_state_durability.py
@@ -1,0 +1,432 @@
+"""A background indexing attempt must leave a durable, readable record.
+
+Reproduced on a deployed Cloudflare container: ``config(action="status")``
+reported ``docs_indexed: {libraries: 8, chunks: 0}`` while the container was
+demonstrably awake, egress worked, and the background indexer issued zero
+writes to D1. The task produced no effect and no trace outside the container,
+because its only failure report was a ``logger.error`` on a stderr nothing
+collects -- so ``chunks: 0`` covered four different states at once: never
+attempted, running now, failed permanently, and succeeded with no content.
+
+Three defects are pinned here:
+
+1. the launch sites discarded the ``asyncio.Task``, so an exception surfaced
+   only as a GC-time "Task exception was never retrieved" and the task itself
+   could be collected mid-flight (asyncio holds only a weak reference);
+2. the failure path wrote nothing durable;
+3. every poll cleared the version's chunks BEFORE the replacement existed and
+   relaunched work that was already running, so one failed re-index destroyed
+   the library's only good copy.
+
+The happy path is covered too, but only as a control: it is the failure paths
+below that this module exists for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from loguru import logger
+
+from wet_mcp import server
+from wet_mcp.db import (
+    INDEX_STATE_DONE,
+    INDEX_STATE_FAILED,
+    INDEX_STATE_RUNNING,
+    DocsDB,
+)
+
+DOCS_URL = "https://example.test/alpha"
+
+
+@pytest.fixture
+def docs_db(tmp_path, monkeypatch):
+    """A real DocsDB wired in as the server's store.
+
+    Deliberately not a MagicMock: the thing under test is whether the outcome
+    survives in the database and can be read back through the normal query
+    path, which a mock would assert away.
+    """
+    db = DocsDB(tmp_path / "docs.db", embedding_dims=0)
+    monkeypatch.setattr(server, "_docs_db", db)
+    yield db
+    db.close()
+
+
+def _chunks(n: int, prefix: str = "old"):
+    return [
+        {
+            "url": f"{DOCS_URL}/page",
+            "title": "T",
+            "chunk_index": i,
+            "content": f"{prefix} chunk body number {i}",
+            "heading_path": "T",
+        }
+        for i in range(n)
+    ]
+
+
+def _seed_indexed_library(db: DocsDB, chunk_count: int = 3):
+    """A library that already holds usable chunks, as production would."""
+    lib_id = db.upsert_library(name="alpha", docs_url=DOCS_URL)
+    ver_id = db.upsert_version(library_id=lib_id, version="latest", docs_url=DOCS_URL)
+    db.add_chunks(version_id=ver_id, library_id=lib_id, chunks=_chunks(chunk_count))
+    db.mark_version_indexed(ver_id, page_count=2, chunk_count=chunk_count)
+    db.set_index_state(ver_id, INDEX_STATE_DONE)
+    return lib_id, ver_id
+
+
+async def _run_indexer(lib_id: str, ver_id: str):
+    return await server._background_index_and_search(
+        library="alpha",
+        lib_key="alpha",
+        language=None,
+        docs_url=DOCS_URL,
+        repo_url="",
+        query="how to install",
+        version=None,
+        lib_id=lib_id,
+        ver_id=ver_id,
+    )
+
+
+@pytest.fixture
+def no_searxng(monkeypatch):
+    """Keep the indexer's SearXNG fallback leg off the network.
+
+    ``_background_index_and_search`` reaches for an alternate docs source
+    whenever the primary fetch came back thin, which is exactly the situation
+    every failure test here sets up.
+    """
+    monkeypatch.setattr(
+        server,
+        "ensure_searxng",
+        AsyncMock(side_effect=RuntimeError("searxng disabled in tests")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: a failed attempt must leave something readable behind
+# ---------------------------------------------------------------------------
+
+
+async def test_indexer_exception_leaves_a_readable_failed_record(
+    docs_db, no_searxng, monkeypatch
+):
+    """An unexpected exception is recorded, not just logged into the void."""
+    lib_id, ver_id = _seed_indexed_library(docs_db)
+    docs_db.set_index_state(ver_id, INDEX_STATE_RUNNING)
+
+    async def _explode(**_kwargs):
+        raise RuntimeError("GitHub raw fetch exploded")
+
+    monkeypatch.setattr(server, "_fetch_and_chunk_docs", _explode)
+
+    await _run_indexer(lib_id, ver_id)
+
+    state = docs_db.get_index_state(ver_id)
+    assert state is not None, "the attempt left no record at all"
+    assert state["state"] == INDEX_STATE_FAILED
+    assert "RuntimeError" in state["error"]
+    assert "GitHub raw fetch exploded" in state["error"]
+    assert state["updated_at"] > 0
+
+
+async def test_zero_chunks_records_the_reason_not_just_a_zero(
+    docs_db, no_searxng, monkeypatch
+):
+    """Extracting nothing is a failure with a reason, not a silent return."""
+    lib_id = docs_db.upsert_library(name="alpha", docs_url=DOCS_URL)
+    ver_id = docs_db.upsert_version(library_id=lib_id, version="latest")
+    docs_db.set_index_state(ver_id, INDEX_STATE_RUNNING)
+
+    monkeypatch.setattr(
+        server, "_fetch_and_chunk_docs", AsyncMock(return_value=([], 0))
+    )
+
+    await _run_indexer(lib_id, ver_id)
+
+    state = docs_db.get_index_state(ver_id)
+    assert state is not None
+    assert state["state"] == INDEX_STATE_FAILED
+    assert "Could not extract content" in state["error"]
+    assert state["chunk_count"] == 0
+
+
+async def test_recording_a_failure_never_masks_it(docs_db, no_searxng, monkeypatch):
+    """A broken store must not turn "docs fetch failed" into "DB write failed".
+
+    The recorder runs inside the ``except`` handler holding the real error, so
+    an exception raised there would replace the diagnosis with a symptom.
+    """
+    lib_id, ver_id = _seed_indexed_library(docs_db)
+    records: list[str] = []
+    sink = logger.add(records.append, level="ERROR")
+
+    async def _explode(**_kwargs):
+        raise RuntimeError("GitHub raw fetch exploded")
+
+    monkeypatch.setattr(server, "_fetch_and_chunk_docs", _explode)
+    monkeypatch.setattr(
+        docs_db,
+        "set_index_state",
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("D1 returned 500")),
+    )
+
+    try:
+        await _run_indexer(lib_id, ver_id)
+    finally:
+        logger.remove(sink)
+
+    joined = "".join(records)
+    assert "GitHub raw fetch exploded" in joined, "the real failure was lost"
+    assert "Could not record indexing state" in joined
+    assert "D1 returned 500" in joined
+
+
+async def test_recording_without_a_store_is_a_no_op():
+    """No store means nothing was indexed and there is nowhere to record."""
+    with patch.object(server, "_docs_db", None):
+        server._record_index_state("ver-1", INDEX_STATE_FAILED, "boom")
+
+
+async def test_never_attempted_is_distinguishable_from_failed(docs_db):
+    """``None`` (never asked) must not read the same as a recorded failure."""
+    lib_id = docs_db.upsert_library(name="alpha", docs_url=DOCS_URL)
+    ver_id = docs_db.upsert_version(library_id=lib_id, version="latest")
+
+    assert docs_db.get_index_state(ver_id) is None
+
+    docs_db.set_index_state(ver_id, INDEX_STATE_FAILED, "boom")
+    assert docs_db.get_index_state(ver_id)["state"] == INDEX_STATE_FAILED
+
+
+async def test_config_status_reports_why_there_are_no_chunks(docs_db):
+    """The status payload carries the outcome next to the raw counts."""
+    lib_id = docs_db.upsert_library(name="alpha", docs_url=DOCS_URL)
+    ver_id = docs_db.upsert_version(library_id=lib_id, version="latest")
+    docs_db.set_index_state(ver_id, INDEX_STATE_FAILED, "Could not extract content")
+
+    with (
+        patch("wet_mcp.embedder.get_backend", return_value=None),
+        patch("wet_mcp.reranker.get_reranker", return_value=None),
+    ):
+        status = await server._handle_config_status()
+
+    indexing = status["database"]["indexing"]
+    assert status["database"]["docs_indexed"]["chunks"] == 0
+    assert indexing["counts"] == {INDEX_STATE_FAILED: 1}
+    assert indexing["recent"][0]["library"] == "alpha"
+    assert indexing["recent"][0]["error"] == "Could not extract content"
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: good data must survive, and running work must not be relaunched
+# ---------------------------------------------------------------------------
+
+
+async def test_existing_chunks_survive_a_failed_reindex(
+    docs_db, no_searxng, monkeypatch
+):
+    """A failed re-index must not leave the library emptier than it found it."""
+    lib_id, ver_id = _seed_indexed_library(docs_db, chunk_count=3)
+
+    async def _explode(**_kwargs):
+        raise RuntimeError("docs host returned 503")
+
+    monkeypatch.setattr(server, "_fetch_and_chunk_docs", _explode)
+
+    await _run_indexer(lib_id, ver_id)
+
+    assert docs_db.stats()["chunks"] == 3, "a failed re-index destroyed good data"
+    assert docs_db.get_index_state(ver_id)["state"] == INDEX_STATE_FAILED
+    # The version keeps serving what it already had.
+    assert docs_db.get_best_version(lib_id)["chunk_count"] == 3
+    assert docs_db.search("chunk body", library_name="alpha")
+
+
+async def test_successful_reindex_still_replaces_the_old_chunks(
+    docs_db, no_searxng, monkeypatch
+):
+    """Moving the clear must not turn a replace into an append."""
+    lib_id, ver_id = _seed_indexed_library(docs_db, chunk_count=3)
+
+    monkeypatch.setattr(
+        server,
+        "_fetch_and_chunk_docs",
+        AsyncMock(return_value=(_chunks(2, prefix="fresh"), 2)),
+    )
+    monkeypatch.setattr(
+        "wet_mcp.embedder.resolve_embed_backend_for_request", lambda: None
+    )
+
+    await _run_indexer(lib_id, ver_id)
+
+    assert docs_db.stats()["chunks"] == 2
+    assert docs_db.get_index_state(ver_id)["state"] == INDEX_STATE_DONE
+    contents = [r["content"] for r in docs_db.search("chunk", library_name="alpha")]
+    assert contents and all(c.startswith("fresh") for c in contents)
+
+
+@pytest.fixture
+def launch_recorder(monkeypatch):
+    """Capture background launches without scheduling an orphan Task."""
+    launched: list[str] = []
+
+    def _record(coro, label):
+        coro.close()
+        launched.append(label)
+        return None
+
+    monkeypatch.setattr(server, "_launch_background_task", _record)
+    return launched
+
+
+@pytest.fixture
+def offline_docs_search(monkeypatch):
+    """Pin the network-touching legs of ``_do_docs_search``."""
+    monkeypatch.setattr(
+        server,
+        "_discover_docs_url",
+        AsyncMock(return_value=(DOCS_URL, "", "registry", "desc")),
+    )
+    monkeypatch.setattr(
+        server, "_do_immediate_fallback_search", AsyncMock(return_value={"results": []})
+    )
+    monkeypatch.setattr(server, "_embed", AsyncMock(return_value=None))
+
+
+async def test_second_search_while_running_neither_relaunches_nor_clears(
+    docs_db, launch_recorder, offline_docs_search
+):
+    """The poll that used to wipe the index now reports on it instead."""
+    _lib_id, ver_id = _seed_indexed_library(docs_db, chunk_count=3)
+    docs_db.set_index_state(ver_id, INDEX_STATE_RUNNING)
+
+    # A query no stored chunk matches is what drops the cached-index path and
+    # sends production into the re-index branch.
+    result = await server._do_docs_search(library="alpha", query="zzzznomatch")
+
+    assert launch_recorder == [], "relaunched an index that was already running"
+    assert docs_db.stats()["chunks"] == 3, "cleared chunks a live indexer was using"
+    assert result["status"] == "indexing_in_progress"
+    assert result["last_index_attempt"]["state"] == INDEX_STATE_RUNNING
+    assert "has been indexing since" in result["message"]
+
+
+async def test_a_stale_running_record_does_not_lock_the_library_out(
+    docs_db, launch_recorder, offline_docs_search
+):
+    """A process that died mid-index must not block the version forever."""
+    _lib_id, ver_id = _seed_indexed_library(docs_db, chunk_count=3)
+    docs_db.set_index_state(ver_id, INDEX_STATE_RUNNING)
+    docs_db._conn.execute(
+        "UPDATE versions SET index_state_at = ? WHERE id = ?",
+        (docs_db.get_index_state(ver_id)["updated_at"] - 10_000, ver_id),
+    )
+    docs_db._conn.commit()
+
+    await server._do_docs_search(library="alpha", query="zzzznomatch")
+
+    assert launch_recorder == ["docs-index:alpha"]
+
+
+async def test_a_previous_failure_is_named_in_the_reply(
+    docs_db, launch_recorder, offline_docs_search
+):
+    """ "Indexing in progress (3-5 minutes)" must not stand in for "it failed"."""
+    _lib_id, ver_id = _seed_indexed_library(docs_db, chunk_count=3)
+    docs_db.set_index_state(ver_id, INDEX_STATE_FAILED, "docs host returned 503")
+
+    result = await server._do_docs_search(library="alpha", query="zzzznomatch")
+
+    assert launch_recorder == ["docs-index:alpha"], "a failed version was never retried"
+    assert "previous indexing attempt" in result["message"]
+    assert "docs host returned 503" in result["message"]
+    assert result["last_index_attempt"]["state"] == INDEX_STATE_FAILED
+
+
+async def test_launching_marks_the_version_running_before_it_starts(
+    docs_db, launch_recorder, offline_docs_search
+):
+    """Without this write, a concurrent poll sees "never attempted" and races."""
+    await server._do_docs_search(library="alpha", query="anything")
+
+    assert launch_recorder == ["docs-index:alpha"]
+    lib = docs_db.get_library("alpha")
+    ver_id = docs_db._conn.execute(
+        "SELECT id FROM versions WHERE library_id = ?", (lib["id"],)
+    ).fetchone()["id"]
+    assert docs_db.get_index_state(ver_id)["state"] == INDEX_STATE_RUNNING
+
+
+# ---------------------------------------------------------------------------
+# Defect 1: a fire-and-forget task must be referenced and its failure reported
+# ---------------------------------------------------------------------------
+
+
+async def test_launcher_keeps_a_strong_reference_until_the_task_finishes():
+    """asyncio holds only a weak reference; a discarded task can just vanish."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _work():
+        started.set()
+        await release.wait()
+
+    task = server._launch_background_task(_work(), "unit-test")
+    await started.wait()
+    assert task in server._background_tasks
+
+    release.set()
+    await task
+    await asyncio.sleep(0)
+    assert task not in server._background_tasks, "finished task was never released"
+
+
+async def test_a_raising_background_task_is_reported_with_its_traceback():
+    """The exception must be retrieved and logged, not left for the GC."""
+    records: list[str] = []
+    sink = logger.add(records.append, level="ERROR")
+
+    async def _work():
+        raise ValueError("background work blew up")
+
+    try:
+        task = server._launch_background_task(_work(), "unit-test-failing")
+        with pytest.raises(ValueError):
+            await task
+        await asyncio.sleep(0)
+    finally:
+        logger.remove(sink)
+
+    assert records, "the task's exception was never reported"
+    joined = "".join(records)
+    assert "unit-test-failing" in joined
+    assert "ValueError" in joined
+    assert "background work blew up" in joined
+    assert "Traceback" in joined, "the traceback is what makes the log actionable"
+
+
+async def test_a_cancelled_background_task_is_not_reported_as_a_failure():
+    """Shutdown cancels tasks on purpose; that is not an error to shout about."""
+    records: list[str] = []
+    sink = logger.add(records.append, level="ERROR")
+
+    async def _work():
+        await asyncio.Event().wait()
+
+    try:
+        task = server._launch_background_task(_work(), "unit-test-cancelled")
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+    finally:
+        logger.remove(sink)
+
+    assert records == []
+    assert task not in server._background_tasks

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -18,14 +18,14 @@ _skip_win_iocp = pytest.mark.skipif(
 )
 
 
-def _close_and_dummy_task(coro):
-    """Drop-in for ``asyncio.create_task`` in tests.
+def _close_and_dummy_task(coro, label=None):
+    """Drop-in for ``server._launch_background_task`` in tests.
 
-    The production ``_do_docs_search`` fires the background indexer with
-    ``asyncio.create_task(...)`` and discards the handle. In tests that
-    leaves an orphan Task pending in the event loop; closing the loop at
-    teardown then intermittently hangs on the macOS kqueue / Windows IOCP
-    selectors (caught by pytest-timeout and reddening release-commit CI).
+    The production ``_do_docs_search`` fires the background indexer through
+    ``_launch_background_task(...)``. In tests that leaves an orphan Task
+    pending in the event loop; closing the loop at teardown then
+    intermittently hangs on the macOS kqueue / Windows IOCP selectors
+    (caught by pytest-timeout and reddening release-commit CI).
 
     Closing the coroutine here makes the call a no-op with no scheduled
     Task, so teardown is deterministic on every platform. The return value
@@ -73,6 +73,10 @@ def mock_docs_db():
     server._docs_db.get_library.return_value = None
     server._docs_db.get_best_version.return_value = None
     server._docs_db.search.return_value = []
+    # No indexing attempt on record -> the launch path treats the version as
+    # never attempted, which is what these tests exercise. Left as a MagicMock
+    # it would land in the tool payload and break JSON serialization.
+    server._docs_db.get_index_state.return_value = None
     yield server._docs_db
     server._docs_db = None
 
@@ -390,11 +394,11 @@ async def test_do_docs_search_new():
             "wet_mcp.server._background_index_and_search",
             new_callable=AsyncMock,
         ),
-        # Patch create_task so the fire-and-forget background indexer is
+        # Patch the launcher so the fire-and-forget background indexer is
         # never scheduled as an orphan Task that survives into event-loop
         # teardown (closing the loop with a pending task hangs on the
         # Windows IOCP / macOS kqueue selectors -> pytest-timeout kill).
-        patch("wet_mcp.server.asyncio.create_task", _close_and_dummy_task),
+        patch("wet_mcp.server._launch_background_task", _close_and_dummy_task),
         # Mock the immediate fallback so the test makes no real network IO
         # (the un-mocked searxng_search hit httpx against a junk URL and
         # could hang on a slow/blocked CI runner).
@@ -535,7 +539,7 @@ async def test_do_docs_search_force_reindex():
         patch("wet_mcp.server._background_index_and_search", new_callable=AsyncMock),
         # See test_do_docs_search_new: prevent orphan background Task and
         # mock the immediate fallback so the test is fully hermetic.
-        patch("wet_mcp.server.asyncio.create_task", _close_and_dummy_task),
+        patch("wet_mcp.server._launch_background_task", _close_and_dummy_task),
         patch(
             "wet_mcp.server._do_immediate_fallback_search",
             new_callable=AsyncMock,


### PR DESCRIPTION
## The defect, as observed

On the deployed Cloudflare container (backend `cf-d1`), `config(action="status")` reported:

```
docs_indexed: {libraries: 8, chunks: 0}
```

Eight libraries attempted, not one produced a chunk. The identical code path locally produces 24 pages / 242 chunks for the same library.

Instrumented with `wrangler tail`:

- the container was demonstrably awake for 6 continuous minutes (keepalive every 30s, no `Activity expired`);
- during those 6 minutes the background indexer issued **zero** D1 writes -- only the 6 synchronous launch upserts and the 2 count queries from the operator's own `config status`;
- egress worked: `extract` on the exact same docs URL succeeded in 235 ms via `basic_http`.

So the background task produced no effect and left **no trace whatsoever outside the container**. That unobservability is what this PR fixes. It deliberately does not guess at the CF-specific root cause: it makes the outcome durable and self-reporting, so the cause reports itself on the next run.

## Three defects

### 1. Background task outcomes were discarded

`asyncio.create_task(...)` at the docs-index launch site in `search` and at the `ingest_tier2` site dropped the returned handle. CPython's event loop holds only a **weak** reference to a running task, so a task whose handle is discarded can be garbage-collected mid-flight and simply stop; and an exception nobody retrieves surfaces only as a GC-time `Task exception was never retrieved` written to a container stderr that nothing collects.

`_launch_background_task(coro, label)` now keeps a strong reference in a module-level `set[asyncio.Task]` and attaches a done-callback that discards it from the set and logs any exception at ERROR with its traceback (formatted via `traceback`, not `logger.opt(exception=True)`, because the stderr sink runs with loguru's default `diagnose=True`).

**Decision on the other `create_task` sites.** `_init_backends_task()` was tracked: it already logs its own exceptions, so the ERROR-logging half is redundant there, but the strong-reference half is not -- its handle was discarded, and a GC of that task would silently abort embedding/reranker init, which is the same class of bug. The warmup task and the `_with_timeout` task were left alone: both already keep a strong local reference, and `_with_timeout` retrieves `task.result()`.

### 2. Failure wrote nothing durable

`_background_index_and_search` had `if not all_chunks: logger.error(...); return`. That log reaches nobody inside the container, so `chunks: 0` was one number covering four different states: never attempted, currently running, failed permanently, succeeded with no extractable content.

`versions` now carries `index_state` / `index_error` / `index_state_at` on **both** storage backends -- SQLite via Alembic `docs_006_version_index_state`, D1 via `migrations/0003_version_index_state.sql` -- written by `set_index_state()` and read back through `get_index_state()` / `index_status()`. The state is set to `running` before the launch and updated to `done` / `failed` by the indexer, including from an `except` around the whole body so an unexpected exception leaves the same readable trace as the empty-chunks case.

Then it is surfaced:

- `config(action="status")` reports `database.indexing` (`counts` per state plus the most recent attempts, newest first) alongside `docs_indexed`;
- a docs search that finds no chunks now says what actually happened -- "has been indexing since `<T>`; no second run was launched" or "the previous attempt failed at `<T>`: `<reason>`; a fresh attempt has started" -- instead of the unconditional "indexing in progress, this may take 3-5 minutes";
- the machine-readable record rides along as `last_index_attempt`.

Notes on the schema choice:

- `index_state` is deliberately **not** the existing `status` column. `status` gates what `get_best_version` serves, so a version has to stay `indexed` (still serving its old chunks) while its newest re-index attempt reads `failed`.
- `set_index_state` deliberately does not touch `page_count` / `chunk_count`. Those describe the last **successful** index and are owned by `mark_version_indexed`; zeroing them on failure would break "existing chunks survive a failed re-index".
- D1 writes use a fixed **four** bound parameters per statement, never scaled by row count -- the ceiling #1601 addressed. `test_index_state_writes_use_a_fixed_parameter_count` measures this at the real call site.

### 3. Every poll destroyed good data and restarted failing work

The launch sequence was `upsert_library` -> `upsert_version` -> `clear_version_chunks(ver_id)` -> launch -> return `indexing_in_progress`. A failed re-index therefore lost the previously good chunks, and every subsequent search re-ran the same failing work against an emptied store.

Both halves are fixed:

- the clear moved into the indexer, immediately before the `add_chunks` that replaces the content -- so the old chunks are dropped only once their replacement is in hand;
- a search whose version is already `running` returns the current state instead of launching a second indexer.

A `running` record older than `_INDEX_RUNNING_STALE_AFTER` (900s) counts as abandoned. Without that, a container evicted mid-index would lock its library out of indexing forever -- a worse bug than the one being fixed. The pipeline's own sub-timeouts (`_DISCOVERY_TIMEOUT` + `_FETCH_TIMEOUT` + `_SEARXNG_TIMEOUT` + `_FALLBACK_TIMEOUT` + `_EMBED_TIMEOUT`) sum to well under 900s, so a live run is never mistaken for an abandoned one.

## Where the brief did not match the code

Defect 3's "each docs search on an already-indexed library wipes its existing chunks first" is **not unconditional**. `_do_docs_search` first calls `_search_cached_index`, which returns early when the library is indexed and `_docs_db.search(...)` finds matches. The destructive clear only fired when that cached search came back empty -- a query with no keyword/vector match, a stale `discovery_version`, or a version not at `status='indexed'`. The data-destruction path is real and is fixed, but it was query-dependent rather than firing on every poll.

## Verification

`uv run ruff check . && uv run ruff format --check . && uv run ty check`:

```
All checks passed!
204 files already formatted
All checks passed!
```

`uv run pytest`:

```
2275 passed, 35 skipped, 140 deselected, 16 warnings in 155.70s (0:02:35)
```

(baseline on `main` before these changes: `2252 passed, 35 skipped, 140 deselected`)

The new tests exercise the failure paths, not the happy path:

- a background task that **raises** leaves a readable `failed` record carrying `RuntimeError` and the error text;
- a background task that yields **zero chunks** leaves a `failed` record with the reason;
- a second docs search while the state is `running` does **not** relaunch and does **not** clear chunks;
- existing chunks **survive** a failed re-index (`stats()["chunks"]` unchanged, `get_best_version` still reports them, `search` still returns them);
- a stale `running` record does not lock the library out;
- a store that rejects the state write logs loudly and does **not** mask the original failure;
- a raising tracked task is logged with its traceback; a cancelled one is not reported as a failure; the launcher holds a strong reference until the task finishes and releases it after.

Plus the CF half in `tests/test_db_cf_contract.py`: roundtrip through D1, absent-until-first-attempt, `index_status` counts/recent, a failed state leaving `page_count` / `chunk_count` / `status` alone, and the fixed parameter count.

`_guard_embedding_identity` in `db.py` is untouched.

## Deploy note

`README.md`'s Cloudflare setup applied only `migrations/0001_init_wet.sql`; `0002_project_context.sql` was already missing there, and `0003` is required for this fix to have anywhere to write. All three are now listed. Existing D1 databases need `0003` applied before deploying this change.
