### PR TITLE
fix: bind single-user http to MCP_HOST/MCP_PORT when set

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -3198,8 +3198,9 @@ async def run_http_server(port: int = 0) -> None:
     """Run wet-mcp as HTTP server. Local single-user (default) or remote
     multi-user (when ``PUBLIC_URL`` env set).
 
-    Local mode binds 127.0.0.1 with a single shared
-    ``~/.wet-mcp/config.json`` (PerPluginStore). Remote
+    Local mode binds 127.0.0.1 on an auto-picked port with a single shared
+    ``~/.wet-mcp/config.json`` (PerPluginStore); ``MCP_HOST`` and
+    ``MCP_PORT`` override that bind when the operator sets them. Remote
     multi-user mode binds 0.0.0.0:8080, requires ``MCP_DCR_SERVER_SECRET``
     as proof of intentional multi-user deployment, and scopes credentials
     per JWT ``sub`` (see ``credential_state.store_for_sub`` and the
@@ -3222,7 +3223,31 @@ async def run_http_server(port: int = 0) -> None:
         host = os.environ.get("MCP_HOST", "0.0.0.0")  # nosec B104
         port = int(os.environ.get("MCP_PORT", "8080"))
     else:
-        host = "127.0.0.1"
+        # Single-user mode honours MCP_HOST / MCP_PORT too, but only when the
+        # operator sets them; unset keeps loopback + auto-port so the desktop
+        # flow (browser setup form opened on this same machine) is untouched.
+        # Without this, wet-mcp deployed as an HTTP service in a container is
+        # unreachable from sibling containers: it binds loopback on a port
+        # picked at random, so no published port maps to it -- and the `http`
+        # Docker target's own MCP_PORT=8080 / EXPOSE 8080 were dead letters.
+        # int() is left unguarded, as in the multi-user branch above: a typo'd
+        # MCP_PORT must abort startup rather than silently degrade back to a
+        # random port the operator never published.
+        host = os.environ.get("MCP_HOST", "127.0.0.1")
+        port_env = os.environ.get("MCP_PORT")
+        if port_env is not None:
+            port = int(port_env)
+        if host not in ("127.0.0.1", "localhost", "::1"):
+            # Single-user mode keeps ONE credential set for the whole server,
+            # so reaching the port is enough to use it. Warn rather than
+            # refuse: the operator asked for this bind explicitly, and the
+            # reachability may already be fenced off (compose network, etc).
+            logger.warning(
+                f"MCP_HOST={host} binds wet-mcp beyond loopback while in "
+                "single-user mode: anything that can reach this port shares "
+                "the one credential set stored for this server. Set PUBLIC_URL "
+                "(with MCP_DCR_SERVER_SECRET) to scope credentials per user."
+            )
 
     # MCP_AUTH_DISABLE=1 skips Bearer JWT verification on /mcp -- for
     # deployments behind an external auth boundary (reverse proxy / API

--- a/tests/test_server_main_dispatch.py
+++ b/tests/test_server_main_dispatch.py
@@ -18,6 +18,10 @@ class TestRunHttpServer:
 
     async def test_delegates_to_run_http_server(self, monkeypatch):
         monkeypatch.delenv("PUBLIC_URL", raising=False)
+        # Single-user now reads these too, so an ambient value would decide
+        # the assertion below instead of the default this test is guarding.
+        monkeypatch.delenv("MCP_HOST", raising=False)
+        monkeypatch.delenv("MCP_PORT", raising=False)
         from wet_mcp.server import run_http_server
 
         with (
@@ -38,6 +42,8 @@ class TestRunHttpServer:
 
     async def test_custom_port_passed_through(self, monkeypatch):
         monkeypatch.delenv("PUBLIC_URL", raising=False)
+        monkeypatch.delenv("MCP_HOST", raising=False)
+        monkeypatch.delenv("MCP_PORT", raising=False)
         from wet_mcp.server import run_http_server
 
         with patch(
@@ -93,6 +99,136 @@ class TestRunHttpServer:
             _, kwargs = mock_run_http.call_args
             assert kwargs["host"] == "0.0.0.0"
             assert kwargs["port"] == 9090
+
+
+class TestSingleUserBindOverride:
+    """Single-user HTTP (no ``PUBLIC_URL``) honours MCP_HOST / MCP_PORT.
+
+    Issue #1611: run as an HTTP service in a container, wet-mcp bound
+    loopback on a randomly picked port, so no published port reached it
+    from a sibling container -- even though the ``http`` Docker target
+    ships ``MCP_PORT=8080`` + ``EXPOSE 8080``. Setting either variable is
+    the operator's explicit intent; leaving them unset must keep the
+    loopback + auto-port default the desktop setup flow relies on.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _single_user_env(self, monkeypatch):
+        """No PUBLIC_URL, no bind overrides -- each test opts in."""
+        monkeypatch.delenv("PUBLIC_URL", raising=False)
+        monkeypatch.delenv("MCP_HOST", raising=False)
+        monkeypatch.delenv("MCP_PORT", raising=False)
+
+    async def test_unset_keeps_loopback_and_auto_port(self):
+        """Regression guard: bare single-user HTTP still binds 127.0.0.1:auto.
+
+        ``port=0`` is mcp-core's "find a free port" sentinel, so this
+        asserts the pre-#1611 default is untouched when nothing is set.
+        """
+        from wet_mcp.server import run_http_server
+
+        with patch(
+            "mcp_core.transport.local_server.run_http_server",
+            new_callable=AsyncMock,
+        ) as mock_run_http:
+            await run_http_server()
+
+            _, kwargs = mock_run_http.call_args
+            assert kwargs["host"] == "127.0.0.1"
+            assert kwargs["port"] == 0
+
+    async def test_mcp_port_alone_pins_port_on_loopback(self, monkeypatch):
+        """MCP_PORT without MCP_HOST pins the port but stays on loopback."""
+        from wet_mcp.server import run_http_server
+
+        monkeypatch.setenv("MCP_PORT", "8080")
+
+        with patch(
+            "mcp_core.transport.local_server.run_http_server",
+            new_callable=AsyncMock,
+        ) as mock_run_http:
+            await run_http_server()
+
+            _, kwargs = mock_run_http.call_args
+            assert kwargs["host"] == "127.0.0.1"
+            assert kwargs["port"] == 8080
+
+    async def test_mcp_host_and_port_bind_all_interfaces(self, monkeypatch):
+        """The reporter's scenario: MCP_HOST=0.0.0.0 + MCP_PORT=8080."""
+        from wet_mcp.server import run_http_server
+
+        monkeypatch.setenv("MCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("MCP_PORT", "8080")
+
+        with patch(
+            "mcp_core.transport.local_server.run_http_server",
+            new_callable=AsyncMock,
+        ) as mock_run_http:
+            await run_http_server()
+
+            _, kwargs = mock_run_http.call_args
+            assert kwargs["host"] == "0.0.0.0"
+            assert kwargs["port"] == 8080
+
+    async def test_non_loopback_host_warns_about_shared_credentials(self, monkeypatch):
+        """Binding past loopback single-user exposes one shared cred set."""
+        from wet_mcp.server import run_http_server
+
+        monkeypatch.setenv("MCP_HOST", "0.0.0.0")
+
+        with (
+            patch(
+                "mcp_core.transport.local_server.run_http_server",
+                new_callable=AsyncMock,
+            ),
+            patch("wet_mcp.server.logger.warning") as mock_warning,
+        ):
+            await run_http_server()
+
+        assert mock_warning.call_count == 1
+        assert "single-user mode" in mock_warning.call_args[0][0]
+
+    async def test_loopback_host_does_not_warn(self):
+        """The untouched default must stay quiet -- no new boot noise."""
+        from wet_mcp.server import run_http_server
+
+        with (
+            patch(
+                "mcp_core.transport.local_server.run_http_server",
+                new_callable=AsyncMock,
+            ),
+            patch("wet_mcp.server.logger.warning") as mock_warning,
+        ):
+            await run_http_server()
+
+        mock_warning.assert_not_called()
+
+    async def test_invalid_mcp_port_fails_loudly(self, monkeypatch):
+        """A typo'd MCP_PORT aborts startup, never falls back to auto-port."""
+        from wet_mcp.server import run_http_server
+
+        monkeypatch.setenv("MCP_PORT", "not-a-port")
+
+        with patch(
+            "mcp_core.transport.local_server.run_http_server",
+            new_callable=AsyncMock,
+        ) as mock_run_http:
+            with pytest.raises(ValueError, match="not-a-port"):
+                await run_http_server()
+
+        mock_run_http.assert_not_called()
+
+    async def test_public_url_guard_survives_bind_overrides(self, monkeypatch):
+        """MCP_HOST / MCP_PORT do not become a way around the DCR guard."""
+        from wet_mcp.server import run_http_server
+
+        monkeypatch.setenv("PUBLIC_URL", "https://wet.example.com")
+        monkeypatch.delenv("MCP_DCR_SERVER_SECRET", raising=False)
+        monkeypatch.setenv("MCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("MCP_PORT", "8080")
+
+        with pytest.raises(SystemExit, match="MCP_DCR_SERVER_SECRET missing"):
+            await run_http_server()
 
 
 class TestMainDispatch:


### PR DESCRIPTION
## Reporter's scenario

@csgka1 runs wet-mcp as an HTTP service in Docker so their own app, in a
sibling container, can reach it. That is single-user usage, so no
`PUBLIC_URL` is set. The server then binds loopback on a randomly picked
port:

```
Configuration incomplete. Opening http://127.0.0.1:38429/ in browser to configure
Starting local MCP server on 127.0.0.1:38429
Uvicorn running on http://127.0.0.1:38429 (Press CTRL+C to quit)
```

Nothing outside the container can reach that, and no `-p` mapping can be
written for a port that changes every boot.

Root cause is here in wet, not in mcp-core: `run_http_server` read
`MCP_HOST` / `MCP_PORT` only on the `PUBLIC_URL` branch. In the
single-user branch `host` was hardcoded to `127.0.0.1` and `port` was
left at the auto-port sentinel, so mcp-core called `find_free_port()`.
mcp-core's `run_http_server` already takes both `host` and `port`, so
nothing changes there.

A side effect of the same gap: the `http` Docker target sets
`MCP_PORT=8080` and declares `EXPOSE 8080` (Dockerfile), and both were
dead letters in single-user mode.

## The change

The single-user branch now reads `MCP_HOST` and `MCP_PORT` too.

**What did NOT change about the default bind:** with neither variable
set, the behaviour is byte-for-byte what it was — host `127.0.0.1`,
port left at the auto-port sentinel so mcp-core still picks a free port,
and no new log line. The zero-config desktop flow, where the browser
setup form is opened on the same machine, is untouched. There is a
dedicated regression test pinning this.

**What changed:** an explicitly set `MCP_HOST` and/or `MCP_PORT` is now
honoured. `MCP_PORT=8080` alone pins the port but stays on loopback;
`MCP_HOST=0.0.0.0 MCP_PORT=8080` gives the reporter a reachable service.

Two guards come with it:

- A non-loopback `MCP_HOST` logs a warning. Single-user mode keeps one
  credential set for the whole server, so anything that can reach the
  port can use those credentials. It warns rather than refuses — the
  operator asked for that bind explicitly, and the port may already be
  fenced off by the compose network.
- An unparsable `MCP_PORT` aborts startup instead of silently degrading
  back to a random port the operator never published. This matches the
  existing unguarded `int()` on the multi-user branch.

**Not touched:** the `PUBLIC_URL` path, including the
`MCP_DCR_SERVER_SECRET` guard. `MCP_HOST` / `MCP_PORT` are not a way
around it — there is a test asserting the guard still fires when both
are set. The Dockerfile is also unchanged: baking `MCP_HOST=0.0.0.0`
into the `http` image would expose that shared credential set by
default, which has to stay the operator's explicit choice.

## Tests

New `TestSingleUserBindOverride` in `tests/test_server_main_dispatch.py`,
alongside the existing `PUBLIC_URL` cases:

| test | asserts |
|---|---|
| `test_unset_keeps_loopback_and_auto_port` | default is still `127.0.0.1` + auto port |
| `test_mcp_port_alone_pins_port_on_loopback` | `MCP_PORT=8080` -> `127.0.0.1:8080` |
| `test_mcp_host_and_port_bind_all_interfaces` | reporter's case -> `0.0.0.0:8080` |
| `test_non_loopback_host_warns_about_shared_credentials` | warning fires once |
| `test_loopback_host_does_not_warn` | default stays quiet |
| `test_invalid_mcp_port_fails_loudly` | bad `MCP_PORT` raises, server never starts |
| `test_public_url_guard_survives_bind_overrides` | DCR guard intact |

Red-green checked: with the production hunk reverted and the tests kept,
the four behaviour tests fail (`assert 0 == 8080`,
`assert '127.0.0.1' == '0.0.0.0'`, `assert 0 == 1`,
`DID NOT RAISE ValueError`) while the three "must not change" guards
still pass. Full suite green: 2290 passed, 33 skipped.

Closes #1611
