### PR TITLE
fix: honour disable-local flags in per-request embed/rerank resolution

### DIFF
--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -532,8 +532,22 @@ def resolve_embed_backend_for_request() -> EmbeddingBackend | None:
       sub's credential bucket. If the sub has a cloud embedding chain whose
       provider key is present, build a fresh request-scoped
       :class:`CloudEmbeddingBackend` carrying that sub's key explicitly (so the
-      key flows down the call, never into ``os.environ``). Otherwise fall back
-      to the process-shared local ONNX backend.
+      key flows down the call, never into ``os.environ``). With no such chain,
+      fall back to the process-shared local ONNX backend -- unless
+      ``DISABLE_LOCAL_EMBED`` turned that leg off, in which case embedding is
+      ``None``: gracefully unavailable.
+
+    That last exit is the same three-way resolution
+    :meth:`Settings.resolve_embedding_backend` performs at startup, where it
+    is spelled ``'unavailable'``. Keeping the two in step is the whole point:
+    the flag is what a slim deployment sets when the local ONNX extras were
+    never installed, so handing back a backend that raises
+    ``ModuleNotFoundError`` on first use fails the entire index instead of
+    storing keyword-searchable chunks without vectors.
+
+    ``None`` here, specifically -- NOT the startup singleton. That one was
+    resolved from the OPERATOR's process env, and lending it to an arbitrary
+    sub bills the operator's provider account for that sub's traffic.
 
     A per-sub request NEVER rebinds the module-level ``_backend`` singleton —
     that would let one user's cloud model/key serve another concurrent user
@@ -554,7 +568,39 @@ def resolve_embed_backend_for_request() -> EmbeddingBackend | None:
     if chain:
         model = chain[0]
         return CloudEmbeddingBackend(model, api_key=api_key_for_model(model))
+    if settings.disable_local_embed:
+        return None
     return _shared_local_embed_backend()
+
+
+def embedding_unavailable_reason() -> str | None:
+    """Why this request has no embedding backend, or ``None`` if it has one.
+
+    A caller that degrades to keyword-only needs to say WHY in its reply. The
+    degraded result set is shaped exactly like a working hybrid one, so silence
+    reads as "semantic search ran and matched little" when semantic search
+    never ran at all.
+
+    Mirrors :func:`resolve_embed_backend_for_request` rather than re-deriving
+    the decision: it asks that function first, so a reason can only be produced
+    for a request that genuinely has no backend.
+    """
+    from wet_mcp.credential_state import get_current_sub
+
+    if resolve_embed_backend_for_request() is not None:
+        return None
+    if get_current_sub() is None:
+        return (
+            "no embedding backend was initialised at startup: no EMBEDDING_MODELS "
+            "chain with a configured provider key, and the local ONNX leg is "
+            "disabled (DISABLE_LOCAL_EMBED) or failed to load"
+        )
+    # The only ``None`` exit left for a request that HAS a sub.
+    return (
+        "this session has no cloud embedding model configured (set "
+        "EMBEDDING_MODELS plus the matching provider key) and this deployment "
+        "runs with DISABLE_LOCAL_EMBED set, so there is no local fallback"
+    )
 
 
 def init_backend(

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -260,8 +260,20 @@ def resolve_rerank_backend_for_request() -> RerankerBackend | None:
     * **HTTP multi-user** (``_current_sub`` set): resolve PER REQUEST from the
       sub's credential bucket. If the sub has a cloud rerank chain whose
       provider key is present, build a fresh request-scoped
-      :class:`CloudReranker` carrying that sub's key explicitly. Otherwise fall
-      back to the process-shared local ONNX reranker.
+      :class:`CloudReranker` carrying that sub's key explicitly. With no such
+      chain, fall back to the process-shared local ONNX reranker -- unless
+      ``DISABLE_LOCAL_RERANK`` turned that leg off, in which case reranking is
+      ``None``: gracefully unavailable.
+
+    The disable-local exit mirrors :meth:`Settings.resolve_rerank_backend`,
+    which spells it ``'unavailable'`` at startup. It matters more here than the
+    traceback suggests: :meth:`Qwen3Reranker.rerank` swallows its own load
+    failure and returns ``[]``, so a local reranker on an image built without
+    the ONNX extras degrades every search to unranked order behind one log
+    line, quietly, forever. Returning ``None`` says the same thing out loud.
+
+    ``None``, not the startup singleton -- that one carries the OPERATOR's key
+    and must not be spent on an arbitrary sub.
 
     A per-sub request NEVER rebinds the module-level ``_backend`` singleton, so
     one user's cloud reranker/key can't serve another concurrent user.
@@ -284,6 +296,8 @@ def resolve_rerank_backend_for_request() -> RerankerBackend | None:
     if chain:
         model = chain[0]
         return CloudReranker(model=model, api_key=api_key_for_model(model))
+    if settings.disable_local_rerank:
+        return None
     return _shared_local_reranker()
 
 

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -2028,12 +2028,27 @@ def _active_docs_backend() -> str:
 
 
 async def _handle_config_status() -> dict[str, Any]:
-    from wet_mcp.embedder import get_backend
-    from wet_mcp.reranker import get_reranker
+    from wet_mcp.embedder import (
+        embedding_unavailable_reason,
+        resolve_embed_backend_for_request,
+    )
+    from wet_mcp.reranker import resolve_rerank_backend_for_request
     from wet_mcp.sources.x_search import x_search_status
 
-    embed_backend = get_backend()
-    reranker = get_reranker()
+    # Same principle as _active_docs_backend above, one layer up -- with the
+    # part that makes it easier: there is nothing to mirror here, so these call
+    # the resolvers themselves and cannot drift from them.
+    #
+    # What they replaced was `get_backend()` / `get_reranker()`, the startup
+    # singletons. In HTTP multi-user mode those are nobody's backend: they were
+    # resolved from the OPERATOR's process env before any sub existed. A sub
+    # whose request resolves to local ONNX -- or, on a slim image, to nothing --
+    # was still told `CloudEmbeddingBackend available=true`.
+    #
+    # Cheap to call: every branch either hands back an already-built object or
+    # constructs one that loads no model until it is actually used.
+    embed_backend = resolve_embed_backend_for_request()
+    reranker = resolve_rerank_backend_for_request()
 
     # The docs store is either a local SQLite file or Cloudflare D1 + Vectorize.
     # On cf-d1 no local file is opened, so reporting settings.get_db_path()
@@ -2059,6 +2074,11 @@ async def _handle_config_status() -> dict[str, Any]:
             "backend": (type(embed_backend).__name__ if embed_backend else None),
             "dims": _embedding_dims,
             "available": embed_backend is not None,
+            # "available: false" on its own reads as a fault. Most of the time
+            # it is a deployment choice (no cloud chain + DISABLE_LOCAL_EMBED),
+            # and saying which knob produced it is the difference between an
+            # answer and a bug hunt. None whenever embedding IS available.
+            "unavailable_reason": embedding_unavailable_reason(),
         },
         "reranker": {
             "available": reranker is not None,
@@ -2774,9 +2794,24 @@ async def _background_index_and_search(
         # Generate embeddings
         embeddings = None
         if all_chunks:
-            from wet_mcp.embedder import resolve_embed_backend_for_request
+            from wet_mcp.embedder import (
+                embedding_unavailable_reason,
+                resolve_embed_backend_for_request,
+            )
 
-            if resolve_embed_backend_for_request() is not None:
+            if resolve_embed_backend_for_request() is None:
+                # The intended degrade, and the one the version is about to be
+                # stamped 'indexed' for: chunks land keyword-searchable with no
+                # vectors behind them. Same reasoning as the timeout branch
+                # below -- an unremarked swap here is a store that looks
+                # healthy and answers half as well.
+                logger.warning(
+                    f"Embedding unavailable while indexing '{library}' from "
+                    f"{docs_url}: {embedding_unavailable_reason()}. "
+                    f"{len(all_chunks)} chunks are stored WITHOUT vectors, so "
+                    "this version answers keyword-only"
+                )
+            else:
                 embed_texts_list = []
                 for c in all_chunks:
                     parts = []
@@ -2890,6 +2925,23 @@ async def _search_cached_index(
     query_embedding = await _embed(query, is_query=True)
     retrieve_limit = limit * _RERANK_CANDIDATE_MULTIPLIER
 
+    # Without a query vector the hybrid search silently drops its semantic leg
+    # and answers from BM25 alone. The reply is shaped identically either way,
+    # so the caller reads a thin result set as "the docs don't cover this"
+    # rather than "half the retrieval never ran" -- and retries the same query.
+    retrieval_notice: str | None = None
+    if query_embedding is None:
+        from wet_mcp.embedder import embedding_unavailable_reason
+
+        # No reason means a backend exists and the embed call itself failed;
+        # _embed already logged which, and degraded deliberately.
+        why = (
+            embedding_unavailable_reason() or "the embedding call failed for this query"
+        )
+        retrieval_notice = (
+            f"Vector search unavailable ({why}); these results are keyword-only."
+        )
+
     results = _docs_db.search(
         query=query,
         library_name=lib_key,
@@ -2937,6 +2989,8 @@ async def _search_cached_index(
         "results": results,
         "total": len(results),
         "source": "cached_index",
+        "retrieval": ("keyword_only" if query_embedding is None else "hybrid"),
+        "retrieval_notice": retrieval_notice,
     }
 
 

--- a/tests/test_disable_local_per_request_resolution.py
+++ b/tests/test_disable_local_per_request_resolution.py
@@ -1,0 +1,470 @@
+"""The per-request embed/rerank resolvers must honour the disable-local flags.
+
+Two backend-selection paths exist and they disagreed. The startup path
+(``config.resolve_embedding_backend``) returns ``'unavailable'`` when the cloud
+chain is empty and ``DISABLE_LOCAL_EMBED`` is set. The per-request path
+(``embedder.resolve_embed_backend_for_request``) fell through to the local ONNX
+backend unconditionally, so on a deployment built WITHOUT the local extras --
+the http-slim image, which ``Dockerfile`` uninstalls ``qwen3-embed`` and
+``onnxruntime`` from -- every indexing request for a sub with no cloud chain
+died on ``ModuleNotFoundError: No module named 'qwen3_embed'`` raised from the
+lazy import inside ``Qwen3EmbedBackend._get_model``. Live D1 recorded exactly
+that in ``index_state='failed'`` (#1614) while ``config status`` reported the
+startup singleton and claimed embedding was available.
+
+The expected behaviour is the one the startup path already defines: no cloud
+chain + local disabled == gracefully UNAVAILABLE. Not the local backend, and
+not the startup singleton either -- that one carries the OPERATOR's key, and
+spending it on an arbitrary sub is what the resolver's docstring rules out.
+
+``qwen3_embed`` is installed in the dev venv, so these tests intercept the
+import instead of relying on its absence: that both reproduces the slim image
+and makes "the local leg was never reached" assertable. A test that only
+checked the return value would stay green if the import happened first.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+from wet_mcp.credential_state import (
+    CLOUD_KEYS,
+    set_current_sub,
+    store_for_sub,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """sub=None, no provider keys / chains in env, fresh per-sub store."""
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    set_current_sub(None)
+    for k in (*CLOUD_KEYS, "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    for k in ("EMBEDDING_MODELS", "RERANK_MODELS", "LLM_MODELS"):
+        monkeypatch.delenv(k, raising=False)
+
+    # The shared local singletons are process-wide; a leftover from another
+    # test would make "returns the shared local backend" pass for the wrong
+    # reason.
+    from wet_mcp import embedder, reranker
+
+    monkeypatch.setattr(embedder, "_shared_local_backend", None)
+    monkeypatch.setattr(reranker, "_shared_local_backend", None)
+    yield
+    set_current_sub(None)
+
+
+@pytest.fixture
+def slim_image(monkeypatch):
+    """Make ``qwen3_embed`` unimportable, as the http-slim build leaves it.
+
+    Returns the list of import names the code under test asked for, so a test
+    can assert the local leg was never even entered.
+    """
+    real_import = builtins.__import__
+    attempted: list[str] = []
+
+    def _guarded(name, *args, **kwargs):
+        if name == "qwen3_embed" or name.startswith("qwen3_embed."):
+            attempted.append(name)
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _guarded)
+    return attempted
+
+
+@pytest.fixture
+def local_embed_disabled(monkeypatch):
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "disable_local_embed", True)
+
+
+@pytest.fixture
+def local_rerank_disabled(monkeypatch):
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "disable_local_rerank", True)
+
+
+# ---------------------------------------------------------------------------
+# Embedding
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedResolverHonoursDisableLocalEmbed:
+    def test_no_chain_and_local_disabled_resolves_to_none(self, local_embed_disabled):
+        """The exit the slim image actually takes: gracefully unavailable."""
+        from wet_mcp.embedder import resolve_embed_backend_for_request
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})  # no embed provider key
+        set_current_sub("user_a")
+
+        assert resolve_embed_backend_for_request() is None
+
+    async def test_no_chain_and_local_disabled_never_imports_qwen3_embed(
+        self, local_embed_disabled, slim_image
+    ):
+        """End-to-end through the live dispatch helper, on a slim image.
+
+        ``server._embed`` is what the search path calls. With the local leg
+        still reachable this raises ModuleNotFoundError out of the lazy import;
+        the fix has to make the resolver say "none" BEFORE anything touches
+        ``qwen3_embed``, which is why the import list is asserted too.
+        """
+        from wet_mcp import server
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert await server._embed("hello", is_query=True) is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_no_chain_and_local_disabled_degrades_the_index_batch(
+        self, local_embed_disabled, slim_image
+    ):
+        """The batch path the background indexer uses degrades the same way."""
+        from wet_mcp import server
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert await server._embed_batch(["a", "b"]) is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    def test_no_chain_and_local_disabled_does_not_spend_the_operator_key(
+        self, local_embed_disabled, monkeypatch
+    ):
+        """Unavailable means None -- never the startup singleton.
+
+        The singleton was resolved from the OPERATOR's process env. Handing it
+        to an arbitrary sub bills the operator's provider account for that
+        sub's traffic, which the resolver's docstring rules out on purpose.
+        """
+        from wet_mcp import embedder
+        from wet_mcp.embedder import CloudEmbeddingBackend
+
+        operator_singleton = CloudEmbeddingBackend(
+            "jina_ai/jina-embeddings-v5-text-small", api_key="operator_key"
+        )
+        monkeypatch.setattr(embedder, "_backend", operator_singleton)
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert embedder.resolve_embed_backend_for_request() is not operator_singleton
+        assert embedder.resolve_embed_backend_for_request() is None
+
+    def test_no_chain_with_local_enabled_still_returns_shared_local(self):
+        """No regression: the local fallback is untouched when local is on."""
+        from wet_mcp import embedder
+        from wet_mcp.embedder import Qwen3EmbedBackend
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        backend = embedder.resolve_embed_backend_for_request()
+        assert isinstance(backend, Qwen3EmbedBackend)
+        # It is the process-shared instance, not a fresh one per request.
+        assert backend is embedder.resolve_embed_backend_for_request()
+
+    def test_cloud_chain_wins_over_the_flag_and_carries_the_subs_key(
+        self, local_embed_disabled
+    ):
+        """A sub WITH a chain is unaffected: the flag only gates the local leg."""
+        from wet_mcp.embedder import (
+            CloudEmbeddingBackend,
+            resolve_embed_backend_for_request,
+        )
+
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+                "JINA_AI_API_KEY": "jina_a",
+            },
+        )
+        set_current_sub("user_a")
+
+        backend = resolve_embed_backend_for_request()
+        assert isinstance(backend, CloudEmbeddingBackend)
+        assert backend.model == "jina_ai/jina-embeddings-v5-text-small"
+        assert backend.api_key == "jina_a"
+
+    def test_sub_none_still_returns_the_startup_singleton(
+        self, local_embed_disabled, monkeypatch
+    ):
+        """Stdio / single-user is out of scope for the per-sub flag branch."""
+        from wet_mcp import embedder
+        from wet_mcp.embedder import Qwen3EmbedBackend
+
+        sentinel = Qwen3EmbedBackend()
+        monkeypatch.setattr(embedder, "_backend", sentinel)
+        set_current_sub(None)
+
+        assert embedder.resolve_embed_backend_for_request() is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Reranking
+# ---------------------------------------------------------------------------
+
+
+class TestRerankResolverHonoursDisableLocalRerank:
+    def test_no_chain_and_local_disabled_resolves_to_none(self, local_rerank_disabled):
+        from wet_mcp.reranker import resolve_rerank_backend_for_request
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert resolve_rerank_backend_for_request() is None
+
+    async def test_no_chain_and_local_disabled_never_imports_qwen3_embed(
+        self, local_rerank_disabled, slim_image
+    ):
+        """``_rerank_results`` must return the unranked order, importing nothing.
+
+        ``Qwen3Reranker.rerank`` swallows its own exceptions, so the broken
+        local leg shows up here as a silent ``logger.warning`` per search
+        rather than a traceback -- the import list is the only assertion that
+        can tell "reranking was skipped" from "reranking failed quietly".
+        """
+        from wet_mcp import server
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        results = [{"content": "doc-a"}, {"content": "doc-b"}]
+        ranked = await server._rerank_results("q", results, top_n=1)
+        assert ranked == [{"content": "doc-a"}]
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    def test_no_chain_and_local_disabled_does_not_spend_the_operator_key(
+        self, local_rerank_disabled, monkeypatch
+    ):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import CloudReranker
+
+        operator_singleton = CloudReranker(
+            model="cohere/rerank-v3.5", api_key="operator_key"
+        )
+        monkeypatch.setattr(reranker, "_backend", operator_singleton)
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert reranker.resolve_rerank_backend_for_request() is None
+
+    def test_no_chain_with_local_enabled_still_returns_shared_local(self):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import Qwen3Reranker
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        backend = reranker.resolve_rerank_backend_for_request()
+        assert isinstance(backend, Qwen3Reranker)
+        assert backend is reranker.resolve_rerank_backend_for_request()
+
+    def test_cloud_chain_wins_over_the_flag_and_carries_the_subs_key(
+        self, local_rerank_disabled
+    ):
+        from wet_mcp.reranker import (
+            CloudReranker,
+            resolve_rerank_backend_for_request,
+        )
+
+        store_for_sub(
+            "user_a",
+            {"RERANK_MODELS": "cohere/rerank-v3.5", "COHERE_API_KEY": "co_a"},
+        )
+        set_current_sub("user_a")
+
+        backend = resolve_rerank_backend_for_request()
+        assert isinstance(backend, CloudReranker)
+        assert backend.model == "cohere/rerank-v3.5"
+        assert backend.api_key == "co_a"
+
+    def test_sub_none_still_returns_the_startup_singleton(
+        self, local_rerank_disabled, monkeypatch
+    ):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import Qwen3Reranker
+
+        sentinel = Qwen3Reranker()
+        monkeypatch.setattr(reranker, "_backend", sentinel)
+        set_current_sub(None)
+
+        assert reranker.resolve_rerank_backend_for_request() is sentinel
+
+
+# ---------------------------------------------------------------------------
+# config(action="status")
+# ---------------------------------------------------------------------------
+
+
+class TestConfigStatusReflectsPerRequestResolution:
+    """Reported state must be served state, per ``_active_docs_backend``.
+
+    The status handler read the startup singletons, so a sub whose request
+    resolves to "nothing" was told ``CloudEmbeddingBackend available=true`` --
+    the operator's backend, described to a user who will never be served by it.
+    """
+
+    async def test_embedding_reads_unavailable_when_the_request_has_no_backend(
+        self, local_embed_disabled, monkeypatch
+    ):
+        from wet_mcp import embedder
+        from wet_mcp.embedder import CloudEmbeddingBackend
+        from wet_mcp.server import _handle_config_status
+
+        monkeypatch.setattr(
+            embedder,
+            "_backend",
+            CloudEmbeddingBackend("jina_ai/jina-embeddings-v5-text-small"),
+        )
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        status = await _handle_config_status()
+        assert status["embedding"]["available"] is False
+        assert status["embedding"]["backend"] is None
+
+    async def test_embedding_names_the_subs_own_cloud_backend(self, monkeypatch):
+        from wet_mcp import embedder
+        from wet_mcp.server import _handle_config_status
+
+        monkeypatch.setattr(embedder, "_backend", None)
+        store_for_sub(
+            "user_a",
+            {
+                "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+                "JINA_AI_API_KEY": "jina_a",
+            },
+        )
+        set_current_sub("user_a")
+
+        status = await _handle_config_status()
+        assert status["embedding"]["backend"] == "CloudEmbeddingBackend"
+        assert status["embedding"]["available"] is True
+
+    async def test_reranker_reads_unavailable_when_the_request_has_no_backend(
+        self, local_rerank_disabled, monkeypatch
+    ):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import CloudReranker
+        from wet_mcp.server import _handle_config_status
+
+        monkeypatch.setattr(reranker, "_backend", CloudReranker())
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        status = await _handle_config_status()
+        assert status["reranker"]["available"] is False
+        assert status["reranker"]["backend"] is None
+
+    async def test_single_user_still_reports_the_startup_singletons(self, monkeypatch):
+        """Existing readers keep the answer they had on stdio / single-user."""
+        from wet_mcp import embedder, reranker
+        from wet_mcp.embedder import CloudEmbeddingBackend
+        from wet_mcp.reranker import CloudReranker
+        from wet_mcp.server import _handle_config_status
+
+        monkeypatch.setattr(
+            embedder,
+            "_backend",
+            CloudEmbeddingBackend("jina_ai/jina-embeddings-v5-text-small"),
+        )
+        monkeypatch.setattr(reranker, "_backend", CloudReranker())
+        set_current_sub(None)
+
+        status = await _handle_config_status()
+        assert status["embedding"]["backend"] == "CloudEmbeddingBackend"
+        assert status["embedding"]["available"] is True
+        assert status["reranker"]["backend"] == "CloudReranker"
+        assert status["reranker"]["available"] is True
+
+    async def test_status_says_why_embedding_is_unavailable(self, local_embed_disabled):
+        """ "available: false" alone reads as a bug report, not a config answer."""
+        from wet_mcp.server import _handle_config_status
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        reason = (await _handle_config_status())["embedding"]["unavailable_reason"]
+        assert reason and "DISABLE_LOCAL_EMBED" in reason
+
+
+# ---------------------------------------------------------------------------
+# Search-time signal
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSignalsKeywordOnlyRetrieval:
+    """A keyword-only result set must say so.
+
+    Without a vector the hybrid search silently drops to BM25. The reply is
+    shaped identically either way, so the caller reads a thin result set as
+    "semantic search found little" when semantic search never ran at all.
+    """
+
+    @staticmethod
+    def _stub_docs_db(monkeypatch, captured: dict):
+        from unittest.mock import MagicMock
+
+        from wet_mcp import server
+
+        db = MagicMock()
+        db.get_library.return_value = {"id": "lib1", "discovery_version": 10**6}
+        db.get_best_version.return_value = {"id": "ver1", "chunk_count": 3}
+
+        def _search(**kwargs):
+            captured.update(kwargs)
+            return [{"content": "c", "score": 0.9}]
+
+        db.search.side_effect = _search
+        monkeypatch.setattr(server, "_docs_db", db)
+        return db
+
+    async def test_keyword_only_reply_names_the_missing_vector_leg(
+        self, local_embed_disabled, slim_image, monkeypatch
+    ):
+        from wet_mcp import server
+
+        captured: dict = {}
+        self._stub_docs_db(monkeypatch, captured)
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        payload = await server._search_cached_index("fastapi", "routing", None, 10)
+
+        assert payload is not None
+        assert captured["query_embedding"] is None
+        assert payload["retrieval"] == "keyword_only"
+        assert "DISABLE_LOCAL_EMBED" in payload["retrieval_notice"]
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_hybrid_reply_says_hybrid_and_carries_no_notice(self, monkeypatch):
+        from wet_mcp import embedder, server
+
+        class _FakeBackend:
+            async def embed_single(self, text, dimensions=None):
+                return [0.5] * 4
+
+        monkeypatch.setattr(embedder, "_backend", _FakeBackend())
+        set_current_sub(None)
+
+        captured: dict = {}
+        self._stub_docs_db(monkeypatch, captured)
+
+        payload = await server._search_cached_index("fastapi", "routing", None, 10)
+
+        assert payload is not None
+        assert captured["query_embedding"] == [0.5] * 4
+        assert payload["retrieval"] == "hybrid"
+        assert payload["retrieval_notice"] is None

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -34,6 +34,10 @@
     "BROWSERLESS_URL": "https://browserless.n24q02m.com",
     "DISABLE_LOCAL_BROWSER": "true",
     "DISABLE_LOCAL_EMBED": "true",
+    // Paired with the line above: the SLIM image uninstalls qwen3-embed, so the
+    // local leg is absent for rerank too. See wrangler.jsonc for why the
+    // deploy-level RERANK_MODELS does not cover the per-sub case.
+    "DISABLE_LOCAL_RERANK": "true",
     "BROWSER_BACKENDS": "browserless,cf-browser-rendering",
     "CF_ACCOUNT_ID": "${CLOUDFLARE_ACCOUNT_ID}",
     "PUBLIC_URL": "${PUBLIC_URL}",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,6 +36,14 @@
     "DISABLE_LOCAL_SEARCH": "true",
     "DISABLE_LOCAL_BROWSER": "true",
     "DISABLE_LOCAL_EMBED": "true",
+    // The SLIM image this Worker runs uninstalls qwen3-embed outright, so the
+    // local leg is gone for BOTH capabilities -- the rerank flag has to say so
+    // too. Without it a sub whose own bucket carries no RERANK_MODELS resolves
+    // to the local cross-encoder, whose import failure Qwen3Reranker.rerank
+    // swallows into an empty list: every search silently answers in unranked
+    // order. The deploy-level RERANK_MODELS below does not cover that case; it
+    // is process env, and per-sub chains resolve from the sub's bucket.
+    "DISABLE_LOCAL_RERANK": "true",
     "BROWSER_BACKENDS": "browserless,cf-browser-rendering",
     "CF_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
     "PUBLIC_URL": "<YOUR_PUBLIC_URL>",


### PR DESCRIPTION
## The bug

`embedder.py:524 resolve_embed_backend_for_request()` had three exits, and the third ignored `settings.disable_local_embed`: a sub with no cloud chain always fell through to the shared local ONNX backend. The CF image is the http-slim build, and `Dockerfile:80` uninstalls `qwen3-embed` + `onnxruntime`, so `Qwen3EmbedBackend._get_model()`'s lazy `from qwen3_embed import TextEmbedding` raised and took the whole indexing run down. Live D1 recorded it as `index_state='failed'`, `index_error="ModuleNotFoundError: No module named 'qwen3_embed'"`, `doc_chunks` empty.

The startup path never had this problem — `config.py:556 resolve_embedding_backend()` returns `'unavailable'` for exactly that combination via `local_enabled=not self.disable_local_embed`. The two selection paths disagreed; `wrangler.jsonc:38` sets `DISABLE_LOCAL_EMBED=true` and only one of them read it.

## Changes

**1. `resolve_embed_backend_for_request()`** returns `None` when the sub has no cloud chain and `DISABLE_LOCAL_EMBED` is set — the same "gracefully unavailable" semantics the startup resolver already defines. Deliberately not `get_backend()`: that singleton was resolved from the operator's process env, and lending it to an arbitrary sub bills the operator for that sub's traffic, which the function's own docstring rules out. The local fallback is untouched when local embedding is enabled.

**2. `resolve_rerank_backend_for_request()`** had the identical shape against `DISABLE_LOCAL_RERANK` (`config.py:209`, honoured at `config.py:620-623` by `resolve_rerank_backend()`), fixed the same way. It failed more quietly than the embed twin: `Qwen3Reranker.rerank` catches its own load failure and returns `[]`, so on a slim image every search silently answered in unranked order behind one `logger.warning`.

Both CF var blocks now set `DISABLE_LOCAL_RERANK=true` alongside the existing `DISABLE_LOCAL_EMBED`. The deploy-level `RERANK_MODELS` does **not** cover this: `rerank_chain_for_creds()` reads `creds.get("RERANK_MODELS", "")` from the sub's bucket, not process env, so a sub who never submitted a rerank chain still resolved to the (absent) local cross-encoder.

**3. `_handle_config_status()`** read the startup singletons, so a sub was told `CloudEmbeddingBackend available=true` while its own request resolved to something else. It now calls the per-request resolvers — the same class of bug the `_active_docs_backend` comment directly above it was written to prevent, and simpler here, because there is no expression to mirror and therefore nothing to drift. Added `embedding.unavailable_reason`, which names the knob responsible (`available: false` alone reads as a fault when it is usually a deployment choice). Every existing key keeps its meaning; on stdio / single-user the resolvers return those same singletons, so nothing changes there.

**4. Downstream survival of `None` — verified, not assumed.** `server.py:2809` guards with `if resolve_embed_backend_for_request() is None:` and leaves `embeddings = None`. `db_cf.py:135-141` `INSERT`s the `doc_chunks` rows unconditionally and gates only the Vectorize upsert on `if embeddings:`, so the chunk rows land and `chunks > 0` becomes reachable on CF. `db_cf.py:454` gates vector scoring on `if query_embedding:`, so search still answers from FTS. Not a blocker. Added a `logger.warning` on that branch, matching the existing `_EMBED_TIMEOUT` branch below it: the version is about to be stamped `indexed` with a full `chunk_count` and zero vectors, and an unremarked swap there is a store that looks healthy and answers half as well.

**5. Search-time signal.** `_embed` / `_embed_batch` already returned `None` on a `None` backend without raising, but the reply was shaped identically to a working hybrid one, so a thin result set read as "the docs don't cover this" rather than "half the retrieval never ran". Cached-index replies now carry `retrieval` (`hybrid` / `keyword_only`) and `retrieval_notice`.

## Tests

`tests/test_disable_local_per_request_resolution.py`, 20 cases. Written red first: 13 failed / 7 passed before the fix (the 7 being the no-regression cases), 20 pass after. Full suite 2303 passed, 33 skipped.

The disabled-local tests intercept `builtins.__import__` rather than trusting the return value: `qwen3_embed` **is** installed in the dev venv, so a test asserting only `is None` would stay green if the import happened and its result got discarded. The fixture reproduces the slim image (`ModuleNotFoundError`) and records every attempt, and the end-to-end cases assert that list is empty after driving `server._embed`, `server._embed_batch` and `server._rerank_results`.

Covered: empty chain + local disabled -> `None` and no import; empty chain + local enabled -> the shared local backend (no regression); non-empty chain -> `CloudEmbeddingBackend` / `CloudReranker` carrying that sub's key; sub `None` -> the startup singleton; explicitly *not* the operator singleton on the disabled path; config status per-request for both capabilities plus `unavailable_reason`; both `retrieval` states.

Closes #1614
