### PR TITLE
fix: mint cf-d1 chunk ids in the backend instead of reading c["id"]

### DIFF
--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -44,6 +44,19 @@ def _now_ts() -> float:
     return time.time()
 
 
+def new_chunk_id() -> str:
+    """Mint a doc_chunks primary key.
+
+    Chunk identity belongs to the DB layer, not to the caller: the chunkers in
+    wet_mcp.sources.docs emit content only, and server._background_index_and_search
+    hands their output to add_chunks untouched. Both backends call this so a
+    chunk written to D1 and the same chunk written to SQLite are shaped alike --
+    db_cf.DocsDBCfBackend used to read c["id"] instead, which the chunker never
+    supplies (issue #1618).
+    """
+    return uuid.uuid4().hex[:12]
+
+
 # Patterns for chunk quality scoring
 _CODE_BLOCK_RE = re.compile(r"```")
 _LINK_LINE_RE = re.compile(r"^\s*[-*]?\s*\[.+?\]\(.+?\)\s*$|^\s*https?://\S+\s*$")
@@ -1230,7 +1243,7 @@ class DocsDB:
         now: float,
     ) -> tuple[list[str], list[tuple]]:
         """Generate chunk IDs and prepare rows for database insertion."""
-        chunk_ids = [uuid.uuid4().hex[:12] for _ in chunks]
+        chunk_ids = [new_chunk_id() for _ in chunks]
         chunk_rows = []
         for i, chunk in enumerate(chunks):
             row = [

--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -16,8 +16,9 @@ from loguru import logger
 from mcp_core.storage.d1 import D1Backend
 from mcp_core.storage.vectorize import VectorizeBackend
 
-# Reuse the exact ranking helpers from the SQLite implementation.
-from wet_mcp.db import _build_fts_queries, _chunk_quality_score
+# Reuse the exact ranking helpers and the chunk-id generator from the SQLite
+# implementation -- both backends must mint identity the same way.
+from wet_mcp.db import _build_fts_queries, _chunk_quality_score, new_chunk_id
 
 
 class DocsDBCfBackend:
@@ -111,9 +112,16 @@ class DocsDBCfBackend:
         embeddings: list[list[float]] | None = None,
     ) -> None:
         now = time.time()
+        # Minted here, not read off the chunk: the chunkers in sources.docs emit
+        # content only and server._background_index_and_search forwards their
+        # dicts untouched, so a c["id"] subscript raised KeyError on every cf-d1
+        # index. new_chunk_id() is the same generator DocsDB._prepare_chunk_rows
+        # uses, so the two stores agree on id shape. Generated once and reused
+        # below -- the vector must carry its own chunk row's id.
+        chunk_ids = [new_chunk_id() for _ in chunks]
         rows = [
             [
-                c["id"],
+                cid,
                 version_id,
                 library_id,
                 c.get("url"),
@@ -127,7 +135,7 @@ class DocsDBCfBackend:
                 c.get("token_count"),
                 now,
             ]
-            for c in chunks
+            for cid, c in zip(chunk_ids, chunks, strict=True)
         ]
         # section/topic/content_hash/token_count exist in migrations/0001_init_wet.sql
         # and search() reads them back, so persist them like DocsDB.add_chunks does.
@@ -140,7 +148,7 @@ class DocsDBCfBackend:
         if embeddings:
             vectors = [
                 {
-                    "id": c["id"],
+                    "id": cid,
                     "values": emb,
                     "metadata": {
                         "library_id": library_id,
@@ -149,7 +157,7 @@ class DocsDBCfBackend:
                         "chunk_index": c.get("chunk_index", 0),
                     },
                 }
-                for c, emb in zip(chunks, embeddings, strict=False)
+                for cid, c, emb in zip(chunk_ids, chunks, embeddings, strict=False)
             ]
             self._vec.upsert(vectors)
             # Upsert is eventual; block until index is ready so an immediate

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -208,7 +208,6 @@ def test_add_chunks_persists_every_column_the_sqlite_backend_writes():
         lib_id,
         [
             {
-                "id": "c1",
                 "url": "https://a/p1",
                 "title": "Routing",
                 "chunk_index": 0,
@@ -223,7 +222,9 @@ def test_add_chunks_persists_every_column_the_sqlite_backend_writes():
         embeddings=None,
     )
 
-    stored = db._d1.fetchone("SELECT * FROM doc_chunks WHERE id = ?", ["c1"])
+    # Looked up by version, not by a caller-chosen id: add_chunks mints the id
+    # itself (like DocsDB does), so the caller never knows one.
+    stored = db._d1.fetchone("SELECT * FROM doc_chunks WHERE version_id = ?", [ver_id])
     assert stored["section"] == "guide"
     assert stored["topic"] == "routing"
     assert stored["content_hash"] == "deadbeef"
@@ -243,10 +244,10 @@ def test_add_chunks_leaves_optional_columns_null_when_absent():
     db.add_chunks(
         ver_id,
         lib_id,
-        [{"id": "c1", "content": "hello world", "url": "https://a/p1"}],
+        [{"content": "hello world", "url": "https://a/p1"}],
         embeddings=None,
     )
-    stored = db._d1.fetchone("SELECT * FROM doc_chunks WHERE id = ?", ["c1"])
+    stored = db._d1.fetchone("SELECT * FROM doc_chunks WHERE version_id = ?", [ver_id])
     assert stored["section"] is None
     assert stored["topic"] is None
     assert stored["content_hash"] is None

--- a/tests/test_db_cf_contract.py
+++ b/tests/test_db_cf_contract.py
@@ -8,6 +8,8 @@ boot-time gate; this module keeps it satisfied and pins the behaviour of the
 methods that gate only proves are *present*.
 """
 
+import copy
+import re
 from pathlib import Path
 
 import pytest
@@ -15,8 +17,10 @@ from conftest_cf import FakeD1Http, FakeVectorizeHttp
 from mcp_core.storage.d1 import D1Backend
 from mcp_core.storage.vectorize import VectorizeBackend
 
+from wet_mcp.db import DocsDB
 from wet_mcp.db_cf import DocsDBCfBackend
 from wet_mcp.server import _missing_docs_db_methods
+from wet_mcp.sources.docs import chunk_markdown
 
 DDL = "\n".join(
     p.read_text(encoding="utf-8") for p in sorted(Path("migrations").glob("*.sql"))
@@ -311,6 +315,132 @@ def test_add_chunks_stays_inside_the_d1_parameter_cap():
     # 13 columns against a 100-parameter cap: 7 rows / 91 params per statement.
     assert widths == [91, 91, 91, 91, 26]
     assert db.stats()["chunks"] == 30
+
+
+# ---------------------------------------------------------------------------
+# Shape parity: both backends must accept the *same* chunker output.
+#
+# `_missing_docs_db_methods` proves the two classes expose the same method
+# NAMES. It cannot prove they accept the same INPUTS, and they did not: the CF
+# row builder read `c["id"]`, a key `chunk_markdown` has never emitted, so
+# `server._background_index_and_search` -- which passes the chunker's list
+# straight through -- raised KeyError on every cf-d1 index.
+# ---------------------------------------------------------------------------
+
+CHUNKER_INPUT = """# Alpha
+
+Alpha is a small library for reading and writing configuration files.
+It ships a single entry point and keeps its dependency list empty.
+
+## Installation
+
+Install the package from PyPI with your package manager of choice.
+The wheel is pure Python and needs no compiler on any supported platform.
+
+```bash
+pip install alpha
+```
+
+## Usage
+
+Load a document, mutate it in place, then write it back to disk.
+Every value keeps the type it had in the source file, so round-tripping
+a document never rewrites unrelated keys.
+
+```python
+import alpha
+
+doc = alpha.load("config.toml")
+doc["timeout"] = 30
+alpha.dump(doc, "config.toml")
+```
+
+### Error handling
+
+A malformed document raises `alpha.ParseError` with the byte offset of the
+first token that could not be read, which is enough to point an editor at
+the offending line without re-parsing the file.
+"""
+
+
+def _chunker_output() -> list[dict]:
+    """Real `chunk_markdown` output -- not a hand-written stand-in.
+
+    A hand-written fixture is what let this bug through: every existing CF
+    test spells `"id"` into its chunks, so none of them exercised the shape
+    production actually produces.
+    """
+    chunks = chunk_markdown(CHUNKER_INPUT, url="https://alpha.dev/guide")
+    assert len(chunks) > 1, "fixture must exercise the real chunker"
+    assert all("id" not in c for c in chunks), (
+        "the chunker mints no ids -- if that changes, identity ownership moved "
+        "and both backends need revisiting"
+    )
+    return chunks
+
+
+def test_both_backends_accept_raw_chunker_output(tmp_path):
+    """The exact call `server._background_index_and_search` makes, on both."""
+    chunks = _chunker_output()
+
+    local = DocsDB(tmp_path / "docs.db")
+    local_lib = local.upsert_library("alpha", docs_url="https://alpha.dev")
+    local_ver = local.upsert_version(local_lib, "1.0", docs_url="https://alpha.dev")
+    assert local.add_chunks(local_ver, local_lib, copy.deepcopy(chunks)) == len(chunks)
+
+    cf = _backend()
+    cf_lib, cf_ver = _seeded(cf)
+    cf.add_chunks(cf_ver, cf_lib, copy.deepcopy(chunks))
+    assert cf.stats()["chunks"] == len(chunks)
+
+
+def test_cf_generated_chunk_ids_match_the_sqlite_scheme(tmp_path):
+    """Identity is owned by the backend, and both mint it the same way.
+
+    Asserted against ids the SQLite backend actually produced rather than a
+    copied literal, so a change to `db._prepare_chunk_rows` fails here instead
+    of leaving the two stores quietly disagreeing on id shape.
+    """
+    chunks = _chunker_output()
+
+    local = DocsDB(tmp_path / "docs.db")
+    local_lib = local.upsert_library("alpha", docs_url="https://alpha.dev")
+    local_ver = local.upsert_version(local_lib, "1.0", docs_url="https://alpha.dev")
+    local.add_chunks(local_ver, local_lib, copy.deepcopy(chunks))
+    local_ids = [r[0] for r in local._conn.execute("SELECT id FROM doc_chunks")]
+
+    cf = _backend()
+    cf_lib, cf_ver = _seeded(cf)
+    cf.add_chunks(cf_ver, cf_lib, copy.deepcopy(chunks))
+    cf_ids = [r["id"] for r in cf._d1.execute("SELECT id FROM doc_chunks", [])]
+
+    assert len(cf_ids) == len(local_ids) == len(chunks)
+    assert len(set(cf_ids)) == len(cf_ids), "a duplicate id overwrites a chunk"
+    assert {len(i) for i in cf_ids} == {len(i) for i in local_ids}
+    assert all(re.fullmatch(r"[0-9a-f]+", i) for i in cf_ids)
+
+
+def test_cf_vector_ids_match_the_chunk_rows_they_belong_to():
+    """One id per chunk, shared by its D1 row and its vector.
+
+    The row and the vector are built in two separate comprehensions; minting
+    an id independently in each would store vectors that no chunk row claims,
+    which `clear_version_chunks` then cannot delete and `search` returns as
+    hits with no content behind them.
+    """
+    chunks = _chunker_output()
+    cf = _backend()
+    cf_lib, cf_ver = _seeded(cf)
+
+    cf.add_chunks(cf_ver, cf_lib, chunks, embeddings=[[0.1] * 768 for _ in chunks])
+
+    row_ids = {
+        r["id"]
+        for r in cf._d1.execute(
+            "SELECT id FROM doc_chunks WHERE version_id = ?", [cf_ver]
+        )
+    }
+    assert row_ids == set(cf._vec._http.vectors)
 
 
 @pytest.mark.parametrize("method", ["export_jsonl", "import_jsonl"])


### PR DESCRIPTION
Closes #1618

## The bug

`DocsDBCfBackend.add_chunks` built each D1 row starting with `c["id"]`, a subscript. No chunker emits that key: `chunk_markdown` and `chunk_llms_txt` produce `{content, title, heading_path, url, chunk_index}` (three dict literals in `sources/docs.py`, lines 2371 / 2457 / 2472, all five keys), and `server._background_index_and_search` hands `all_chunks` to `add_chunks` untouched. Every `DOCS_DB_BACKEND=cf-d1` index therefore raised `KeyError: 'id'` before a D1 request was constructed.

It has never been seen in production because the embedding step ahead of it dies first (#1614). Fixing that alone would have moved the failure one line down.

## Every subscript in the row builder, checked

AST walk of `DocsDBCfBackend.add_chunks` on `origin/main`, versus the chunker's actual output keys:

| site | expression | chunker emits it? |
|---|---|---|
| line 116 (D1 row) | `c["id"]` | **no — KeyError** |
| line 122 (D1 row) | `c["content"]` | yes |
| line 143 (vector) | `c["id"]` | **no — same missing key** |

Everything else in the method is a `.get`: `url`, `title`, `chunk_index`, `heading_path`, `section`, `topic`, `content_hash`, `token_count` in the row; `url`, `chunk_index` in the vector metadata. So `id` is the only missing key, but it is missing at **two** sites, which shapes the fix.

## The fix

`DocsDB` already owns chunk identity — `_prepare_chunk_rows` generates `uuid.uuid4().hex[:12]` and ignores whatever the caller put in the dict. The CF backend now does the same, via the same generator: `uuid.uuid4().hex[:12]` is promoted to `db.new_chunk_id()` and imported by `db_cf.py` (which already reuses `_build_fts_queries` / `_chunk_quality_score` from `db.py`), so the two schemes cannot drift apart by copy-paste.

The id is minted **once per batch** and reused: the D1 row and its Vectorize vector are built in two separate comprehensions, and minting independently in each would store vectors that no chunk row claims — `clear_version_chunks` reads its delete list from `doc_chunks`, so those vectors would survive it and come back from `search()` as hits with no content behind them.

No scheme divergence was needed. `uuid4().hex[:12]` is 12 ASCII hex characters, well inside Vectorize's id limit, and the CF collision domain is the same one SQLite has (`doc_chunks.id` primary key, one store per deployment).

## Tests

`_missing_docs_db_methods` is a boot gate over method **names**; it cannot see that two implementations accept different **inputs**, which is exactly how this passed it. Three new contract tests in `tests/test_db_cf_contract.py` close that gap using real `chunk_markdown` output rather than a hand-written fixture (every pre-existing CF test spells `"id"` into its chunks, so none of them exercised the production shape):

- `test_both_backends_accept_raw_chunker_output` — the same chunker list through `DocsDB` and `DocsDBCfBackend`; both must accept it.
- `test_cf_generated_chunk_ids_match_the_sqlite_scheme` — CF id length and alphabet asserted against ids SQLite actually produced for the same input, not against a copied literal.
- `test_cf_vector_ids_match_the_chunk_rows_they_belong_to` — vector ids must equal the D1 row ids.

Red before the fix, green after:

```
FFF
E   KeyError: 'id'
src/wet_mcp/db_cf.py:116: KeyError: 'id'   (x3)
3 failed, 20 deselected
```

```
...
3 passed, 20 deselected
```

Two existing tests in `tests/test_db_cf.py` looked their row up by a caller-supplied `"c1"`; they now select by `version_id`, since the caller no longer knows the id. Full suite: 2293 passed, 33 skipped.
