### PR TITLE
fix: apply D1 migrations on every CF deploy path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -397,7 +397,10 @@ jobs:
           python-version: "3.13"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Deploy to Cloudflare (build http-slim + push + deploy + canary)
+      # CF_DEPLOY_TOKEN needs D1:edit on top of Workers/Containers edit: the
+      # script now applies migrations/ to the remote D1 before the worker rolls
+      # (wrangler deploy never did — issue #1617).
+      - name: Deploy to Cloudflare (build http-slim + push + migrate D1 + deploy + canary)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_DEPLOY_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/scripts/cf-deploy.mjs
+++ b/scripts/cf-deploy.mjs
@@ -98,17 +98,39 @@ const tmpDir = mkdtempSync(join(tmpdir(), "wet-cf-deploy-"));
 const tmpConfig = join(process.cwd(), `.wrangler-deploy-${process.pid}.jsonc`);
 writeFileSync(tmpConfig, substituted, "utf8");
 
+// `wrangler deploy` does NOT apply D1 migrations -- `migrations_dir` on the D1
+// binding only tells `wrangler d1 migrations *` where to look. Apply them first
+// so this path can never ship code against a schema that is still behind
+// migrations/ (issue #1617). Schema before code: the reverse order opens a live
+// window where the worker queries columns that do not exist yet.
+const dbNames = [...substituted.matchAll(/"database_name"\s*:\s*"([^"]+)"/g)].map(
+  (m) => m[1],
+);
+
 const cmd = "wrangler";
+const migrateArgs = (db) => ["d1", "migrations", "apply", db, "--remote", "--config", tmpConfig];
 const args = ["deploy", "--config", tmpConfig];
+for (const db of dbNames) console.log(`$ ${cmd} ${migrateArgs(db).join(" ")}`);
 console.log(`$ ${cmd} ${args.join(" ")}`);
 
 try {
   if (dryRun) {
-    console.log("(--dry-run) resolved config written; not invoking wrangler deploy.");
-    process.exit(0);
+    console.log("(--dry-run) resolved config written; not invoking wrangler.");
+  } else {
+    // Stop at the first failed migration: deploying on top of a half-migrated
+    // schema is exactly the breakage this step exists to prevent.
+    let failed = 0;
+    for (const db of dbNames) {
+      const migrated = spawnSync(cmd, migrateArgs(db), { stdio: "inherit", shell: true });
+      if (migrated.status !== 0) {
+        failed = migrated.status ?? 1;
+        console.error(`d1 migrations apply failed for ${db}; not deploying.`);
+        break;
+      }
+    }
+    process.exitCode =
+      failed || (spawnSync(cmd, args, { stdio: "inherit", shell: true }).status ?? 1);
   }
-  const result = spawnSync(cmd, args, { stdio: "inherit", shell: true });
-  process.exitCode = result.status ?? 1;
 } finally {
   rmSync(tmpConfig, { force: true });
   rmSync(tmpDir, { recursive: true, force: true });

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -4,9 +4,18 @@
 Turns the manual CF redeploy recipe into one repeatable command. Reads the
 gitignored ``wrangler.deploy.jsonc`` (real account/KV/D1/Vectorize IDs) for the
 container image name + account, builds the ``http`` target, pushes to the CF
-managed registry, deploys, waits for the container rollout to finish
-(STATE=ready) so you never verify against a half-rolled old image, then runs a
-**credential-free canary gate** and **auto-rolls-back** if it fails.
+managed registry, **applies the D1 migrations in** ``migrations/``, deploys,
+waits for the container rollout to finish (STATE=ready) so you never verify
+against a half-rolled old image, then runs a **credential-free canary gate** and
+**auto-rolls-back** if it fails.
+
+Why the migration step: ``wrangler deploy`` does not apply D1 migrations, and
+the ``migrations_dir`` key on the D1 binding only tells ``wrangler d1
+migrations *`` where to look. Nothing called it, so prod D1 silently drifted
+from ``migrations/`` and a release shipping code that reads a new column failed
+at runtime (issue #1617). It runs before the deploy so the schema is never
+behind the code. The CF API token therefore needs D1:edit in addition to
+Workers/Containers edit.
 
 Set CLOUDFLARE_API_TOKEN in the environment (any secret manager works), then run
 from the repo root:
@@ -139,6 +148,61 @@ def _image_parts(cfg: dict) -> tuple[str, str, str]:
             f"unexpected image ref (need registry.cloudflare.com/<acct>/<name>): {ref}"
         )
     return base, m.group(1), m.group(2)
+
+
+def _d1_database_names(cfg: dict) -> list[str]:
+    """D1 database names to migrate, read from the RENDERED deploy config.
+
+    Never read these from the committed ``wrangler.jsonc``: it carries
+    placeholder resource IDs, so a migration aimed at it would target the wrong
+    (or no) database."""
+    return [
+        str(db["database_name"])
+        for db in (cfg.get("d1_databases") or [])
+        if db.get("database_name")
+    ]
+
+
+def _apply_d1_migrations(repo: Path, cfg: dict, *, dry: bool) -> None:
+    """Apply ``migrations/`` to the remote D1 BEFORE the new worker rolls out.
+
+    ``wrangler deploy`` does not run D1 migrations. The ``migrations_dir`` key on
+    the D1 binding only tells ``wrangler d1 migrations *`` where to look, so
+    before this step existed no deploy path touched the remote schema and prod
+    D1 drifted from ``migrations/`` (issue #1617).
+
+    Order is load-bearing: schema first, then code. Running this after
+    ``wrangler deploy`` opens a live window in which the new container queries
+    columns that do not exist yet.
+
+    Forward-only by design, so ``_rollback`` deliberately does not undo it: every
+    migration here is additive (CREATE / ADD COLUMN), which the previous image
+    tolerates, whereas reverting a column the rolled-back canary already wrote to
+    would lose data.
+
+    ``wrangler d1 migrations apply`` skips its confirmation prompt when it
+    detects a non-interactive/CI environment, so no extra flag is needed here.
+    """
+    names = _d1_database_names(cfg)
+    if not names:
+        print("  no d1_databases in the deploy config; nothing to migrate.")
+        return
+    for db in names:
+        _run(
+            [
+                "bunx",
+                "wrangler",
+                "d1",
+                "migrations",
+                "apply",
+                db,
+                "--remote",
+                "--config",
+                DEPLOY_CONFIG,
+            ],
+            dry=dry,
+            cwd=repo,
+        )
 
 
 def _public_url(cfg: dict) -> str:
@@ -365,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"Deploy {worker}: image {local} -> {full}")
     if not args.skip_build:
-        print("[1/4] docker build --target http")
+        print("[1/5] docker build --target http")
         _run(
             [
                 "docker",
@@ -381,11 +445,15 @@ def main(argv: list[str] | None = None) -> int:
             dry=args.dry_run,
             cwd=repo,
         )
-    print("[2/4] docker tag -> CF registry")
+    print("[2/5] docker tag -> CF registry")
     _run(["docker", "tag", local, full], dry=args.dry_run)
-    print("[3/4] wrangler containers push")
+    print("[3/5] wrangler containers push")
     _run(["bunx", "wrangler", "containers", "push", full], dry=args.dry_run, cwd=repo)
-    print(f"[4/4] wrangler deploy --config {DEPLOY_CONFIG}")
+    # Schema before code, and only once the image is safely pushed: a build or
+    # push failure must not leave prod D1 migrated ahead of any shipped worker.
+    print("[4/5] wrangler d1 migrations apply --remote (schema before code)")
+    _apply_d1_migrations(repo, cfg, dry=args.dry_run)
+    print(f"[5/5] wrangler deploy --config {DEPLOY_CONFIG}")
     if not args.dry_run:
         _set_image_tag(repo, full)
     _run(

--- a/tests/test_deploy_cf_migrations.py
+++ b/tests/test_deploy_cf_migrations.py
@@ -1,0 +1,183 @@
+"""Tests for the D1 migration step in ``scripts/deploy_cf.py``.
+
+``wrangler deploy`` does NOT apply D1 migrations -- ``migrations_dir`` on the D1
+binding only tells ``wrangler d1 migrations *`` where to look. Before this step
+existed, no deploy path touched the remote schema, so prod D1 drifted from
+``migrations/`` and a release shipping code that reads a new column failed at
+runtime (issue #1617).
+
+These tests pin the two properties that make the step correct:
+  1. the migration command runs BEFORE ``wrangler deploy`` (schema before code);
+  2. ``--dry-run`` prints the plan and executes nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "deploy_cf.py"
+_spec = importlib.util.spec_from_file_location("deploy_cf_migrations", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+deploy_cf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deploy_cf)
+
+
+def _fake_cfg() -> dict:
+    """Shape of the RENDERED wrangler.deploy.jsonc (real IDs), not the committed
+    placeholder wrangler.jsonc."""
+    return {
+        "name": "wet-mcp-worker",
+        # account segment must be hex: _image_parts() rejects anything else.
+        "containers": [{"image": "registry.cloudflare.com/abc123/wet-mcp:oldtag"}],
+        "d1_databases": [
+            {
+                "binding": "D1",
+                "database_name": "wet-docs",
+                "database_id": "d1id",
+                "migrations_dir": "migrations",
+            }
+        ],
+        "vars": {"PUBLIC_URL": "PUBLIC-URL-SENTINEL"},
+    }
+
+
+def _record_run(monkeypatch, cfg: dict) -> list[list[str]]:
+    """Drive main() with every side effect stubbed, capturing the argv of each
+    _run() call in order."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(deploy_cf, "_load_deploy_config", lambda repo: cfg)
+    monkeypatch.setattr(deploy_cf, "_run", lambda cmd, **kw: calls.append(list(cmd)))
+    monkeypatch.setattr(deploy_cf, "_wait_ready", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cf, "_set_image_tag", lambda *a, **k: None)
+    return calls
+
+
+def _index_of(calls: list[list[str]], *needle: str) -> int:
+    for i, cmd in enumerate(calls):
+        if all(tok in cmd for tok in needle):
+            return i
+    raise AssertionError(f"no call containing {needle} in {calls}")
+
+
+def test_migrations_apply_runs_before_wrangler_deploy(monkeypatch):
+    """Schema first, then code. Deploying the worker before the columns exist
+    leaves a live window where the new code 500s on a missing column."""
+    calls = _record_run(monkeypatch, _fake_cfg())
+    assert deploy_cf.main(["--skip-build", "--no-canary", "--tag", "t1"]) == 0
+    assert _index_of(calls, "migrations", "apply") < _index_of(calls, "deploy")
+
+
+def test_migrations_command_shape(monkeypatch):
+    """--remote is what makes it hit prod D1 (the default is the local sim), and
+    --config must be the rendered deploy config with the real database id."""
+    calls = _record_run(monkeypatch, _fake_cfg())
+    deploy_cf.main(["--skip-build", "--no-canary", "--tag", "t1"])
+    cmd = calls[_index_of(calls, "migrations", "apply")]
+    assert cmd == [
+        "bunx",
+        "wrangler",
+        "d1",
+        "migrations",
+        "apply",
+        "wet-docs",
+        "--remote",
+        "--config",
+        deploy_cf.DEPLOY_CONFIG,
+    ]
+
+
+def test_no_d1_binding_emits_no_migration_call(monkeypatch):
+    """A fork without a D1 binding must still deploy, not crash on a KeyError."""
+    cfg = _fake_cfg()
+    del cfg["d1_databases"]
+    calls = _record_run(monkeypatch, cfg)
+    assert deploy_cf.main(["--skip-build", "--no-canary", "--tag", "t1"]) == 0
+    assert not any("migrations" in c for c in calls)
+    _index_of(calls, "deploy")  # the deploy itself still happened
+
+
+def test_dry_run_prints_migration_but_executes_nothing(monkeypatch, capsys):
+    """--dry-run must reach the real _run() and still spawn no subprocess, so the
+    printed plan is trustworthy without touching prod D1."""
+    monkeypatch.setattr(deploy_cf, "_load_deploy_config", lambda repo: _fake_cfg())
+
+    def _boom(*a, **k):
+        raise AssertionError(f"--dry-run must not execute a subprocess: {a}")
+
+    monkeypatch.setattr(deploy_cf.subprocess, "run", _boom)
+    assert deploy_cf.main(["--dry-run", "--no-canary", "--tag", "t1"]) == 0
+    out = capsys.readouterr().out
+    assert "wrangler d1 migrations apply wet-docs --remote" in out
+    assert out.index("d1 migrations apply") < out.index("wrangler deploy --config")
+
+
+def test_committed_template_keeps_d1_migrations_wired(monkeypatch):
+    """The step reads database_name from the rendered config; dropping it (or
+    migrations_dir) would silently turn the migration into a no-op."""
+    for k, v in {
+        "CLOUDFLARE_ACCOUNT_ID": "acct",
+        "IMAGE_TAG": "v1",
+        "CF_KV_ID": "kvid",
+        "CF_D1_ID": "d1id",
+        "CF_VECTORIZE_ID": "vecidx",
+        "PUBLIC_URL": "PUBLIC-URL-SENTINEL",
+    }.items():
+        monkeypatch.setenv(k, v)
+    tpl = _SCRIPT.parent.parent / "wrangler.deploy.template.jsonc"
+    cfg = json.loads(deploy_cf._strip_jsonc(deploy_cf.render_template(str(tpl))))
+    binding = cfg["d1_databases"][0]
+    assert binding["database_name"] == "wet-docs"
+    assert binding["migrations_dir"] == "migrations"
+    assert deploy_cf._d1_database_names(cfg) == ["wet-docs"]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_cf_deploy_mjs_migrates_before_deploy(tmp_path):
+    """`npm run cf:deploy` is the second deploy path and carried the same gap.
+
+    Hermetic: the script resolves its config relative to cwd, so a synthetic
+    wrangler.jsonc in tmp_path keeps this off the real repo config."""
+    (tmp_path / "wrangler.jsonc").write_text(
+        '{"name":"w",'
+        '"containers":[{"image":"registry.cloudflare.com/<YOUR_ACCOUNT_ID>/wet-mcp:t"}],'
+        '"d1_databases":[{"binding":"D1","database_name":"wet-docs",'
+        '"database_id":"x","migrations_dir":"migrations"}],'
+        '"vars":{"PUBLIC_URL":"<YOUR_PUBLIC_URL>"}}',
+        encoding="utf-8",
+    )
+    node = shutil.which("node")
+    assert node is not None  # guaranteed by the skipif above; also narrows for ty
+    out = subprocess.run(
+        [node, str(_SCRIPT.parent / "cf-deploy.mjs"), "--dry-run"],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "CLOUDFLARE_API_TOKEN": "token-sentinel",
+            "CLOUDFLARE_ACCOUNT_ID": "abc123",
+            "PUBLIC_URL": "https://example.invalid",
+        },
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert out.returncode == 0, out.stderr
+    assert "d1 migrations apply wet-docs --remote" in out.stdout
+    assert out.stdout.index("d1 migrations apply") < out.stdout.index("deploy --config")
+    # The resolved temp config must be cleaned up even on the dry-run path.
+    assert not list(tmp_path.glob(".wrangler-deploy-*.jsonc"))
+
+
+def test_every_migration_file_is_matched_by_wrangler_glob():
+    """wrangler applies migrations_dir/*.sql in lexical order; a file that does
+    not match (wrong extension / nested) would be skipped silently."""
+    migrations = _SCRIPT.parent.parent / "migrations"
+    files = sorted(p.name for p in migrations.iterdir() if p.is_file())
+    assert files == sorted(p.name for p in migrations.glob("*.sql"))
+    assert files, "migrations/ must not be empty"


### PR DESCRIPTION
Closes #1617.

## Problem

`wrangler deploy` does not run D1 migrations. The `migrations_dir` key on the D1
binding only tells `wrangler d1 migrations *` where to look — nothing called it.
Neither deploy path (`scripts/deploy_cf.py`, used by the `deploy-cf` job in
`cd.yml`, nor `npm run cf:deploy`) touched the remote schema, so prod D1 drifted
from `migrations/` and a release shipping code that reads a new column failed at
runtime.

## Change

- **`scripts/deploy_cf.py`** — new step `[4/5]`:
  `bunx wrangler d1 migrations apply <db> --remote --config wrangler.deploy.jsonc`.
  Placed after the image push and before `wrangler deploy`: schema before code,
  because the reverse order opens a live window where the new container queries
  columns that do not exist yet, and because a build/push failure must not leave
  prod D1 migrated ahead of any shipped worker. Database names come from the
  **rendered** deploy config (real IDs), never the placeholder `wrangler.jsonc`.
  Runs through the existing `_run()` so `--dry-run` prints the plan and executes
  nothing. Forward-only by design — `_rollback` deliberately does not undo it, as
  every migration here is additive and the previous image tolerates the newer
  schema.
- **`scripts/cf-deploy.mjs`** — the same step on the `npm run cf:deploy` path,
  aborting before `wrangler deploy` if a migration fails. Replacing the dry-run
  `process.exit(0)` with an `else` branch also stops the resolved temp config
  leaking, since `process.exit` skips `finally`.
- **`cd.yml`** — records that `CF_DEPLOY_TOKEN` now additionally needs `D1:edit`.

## Tests

`tests/test_deploy_cf_migrations.py` (new, 7 tests) pins:
- the migration command runs **before** `wrangler deploy`;
- its exact argv (`--remote` is what makes it hit prod rather than the local sim);
- `--dry-run` reaches the real `_run()` and still spawns no subprocess;
- a config with no D1 binding deploys instead of raising `KeyError`;
- the committed template keeps `database_name` + `migrations_dir` wired, so the
  step cannot silently become a no-op;
- `npm run cf:deploy` migrates before deploying (hermetic `node --dry-run` run).

## Operator action required BEFORE the next deploy — do not merge-and-dispatch blind

Prod D1 already has the schema (it was created out of band) but has **no
`d1_migrations` bookkeeping table**. So the first `migrations apply` will try to
replay all three files:

| file | idempotent? | replay result on the current prod schema |
|---|---|---|
| `0001_init_wet.sql` | yes — every statement is `CREATE ... IF NOT EXISTS` | no-op, recorded |
| `0002_project_context.sql` | **no** — `ALTER TABLE libraries ADD COLUMN metadata_seeded_at` | **fails**: `duplicate column name` |
| `0003_version_index_state.sql` | **no** — 3x `ALTER TABLE versions ADD COLUMN` | never reached |

SQLite has no `ADD COLUMN IF NOT EXISTS`, so this cannot be fixed by editing the
migration files without a destructive table rebuild. The reconciliation is to
seed the ledger with the three already-applied migrations. Exact steps are in the
issue thread; they must be run by the token holder before the next dispatch.
