### PR TITLE
fix: copy the DocsDB chunk-column fallbacks into the cf-d1 backend

### DIFF
--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -119,23 +119,30 @@ class DocsDBCfBackend:
         # uses, so the two stores agree on id shape. Generated once and reused
         # below -- the vector must carry its own chunk row's id.
         chunk_ids = [new_chunk_id() for _ in chunks]
+        # Fallbacks are copied from DocsDB._prepare_chunk_rows, not chosen here:
+        # `content` is the only key add_chunks requires of a caller, so every
+        # other column is a default that both stores have to pick the same way
+        # or the same batch lands as two different documents. chunk_index in
+        # particular defaults to the chunk's position in the batch -- a constant
+        # 0 flattens the batch, and _build_results_cf then looks for a hit's
+        # neighbours at index +/-1 and never finds them.
         rows = [
             [
                 cid,
                 version_id,
                 library_id,
-                c.get("url"),
-                c.get("title"),
-                c.get("chunk_index", 0),
+                c.get("url", ""),
+                c.get("title", ""),
+                c.get("chunk_index", i),
                 c["content"],
-                c.get("heading_path"),
+                c.get("heading_path", ""),
                 c.get("section"),
                 c.get("topic"),
                 c.get("content_hash"),
                 c.get("token_count"),
                 now,
             ]
-            for cid, c in zip(chunk_ids, chunks, strict=True)
+            for i, (cid, c) in enumerate(zip(chunk_ids, chunks, strict=True))
         ]
         # section/topic/content_hash/token_count exist in migrations/0001_init_wet.sql
         # and search() reads them back, so persist them like DocsDB.add_chunks does.
@@ -154,10 +161,12 @@ class DocsDBCfBackend:
                         "library_id": library_id,
                         "version_id": version_id,
                         "url": c.get("url", ""),
-                        "chunk_index": c.get("chunk_index", 0),
+                        "chunk_index": c.get("chunk_index", i),
                     },
                 }
-                for cid, c, emb in zip(chunk_ids, chunks, embeddings, strict=False)
+                for i, (cid, c, emb) in enumerate(
+                    zip(chunk_ids, chunks, embeddings, strict=False)
+                )
             ]
             self._vec.upsert(vectors)
             # Upsert is eventual; block until index is ready so an immediate

--- a/tests/test_db_cf_contract.py
+++ b/tests/test_db_cf_contract.py
@@ -443,6 +443,128 @@ def test_cf_vector_ids_match_the_chunk_rows_they_belong_to():
     assert row_ids == set(cf._vec._http.vectors)
 
 
+def _local_store(tmp_path):
+    db = DocsDB(tmp_path / "docs.db")
+    lib_id = db.upsert_library("alpha", docs_url="https://alpha.dev")
+    ver_id = db.upsert_version(lib_id, "1.0", docs_url="https://alpha.dev")
+    return db, lib_id, ver_id
+
+
+def test_both_backends_default_chunk_index_to_its_place_in_the_batch(tmp_path):
+    """An absent `chunk_index` must resolve identically, not to 0 on one side.
+
+    `DocsDB._prepare_chunk_rows` falls back to the chunk's position in the
+    batch; the CF backend fell back to a constant 0. Nothing raises either
+    way, so a cf-d1 store would simply hold a batch flattened onto index 0
+    while SQLite held 0..n-1 -- and `_build_results_cf` prefetches a hit's
+    neighbours by (url, version_id, chunk_index +/- 1), so `context_before` /
+    `context_after` would silently never resolve on CF alone.
+
+    Latent today: chunk_markdown / chunk_llms_txt always emit the key. It is
+    reachable the moment a caller does what `DocsDB` documents as legal --
+    `test_db.py::test_add_chunks_minimal_fields` passes content and nothing
+    else.
+    """
+    chunks = _chunker_output()
+    for c in chunks:
+        del c["chunk_index"]
+
+    local, local_lib, local_ver = _local_store(tmp_path)
+    local.add_chunks(local_ver, local_lib, copy.deepcopy(chunks))
+    local_idx = [
+        r[0]
+        for r in local._conn.execute(
+            "SELECT chunk_index FROM doc_chunks ORDER BY rowid"
+        )
+    ]
+
+    cf = _backend()
+    cf_lib, cf_ver = _seeded(cf)
+    cf.add_chunks(cf_ver, cf_lib, copy.deepcopy(chunks))
+    cf_idx = [
+        r["chunk_index"]
+        for r in cf._d1.execute(
+            "SELECT chunk_index FROM doc_chunks WHERE version_id = ? ORDER BY rowid",
+            [cf_ver],
+        )
+    ]
+
+    assert local_idx == list(range(len(chunks))), "SQLite is the reference here"
+    assert cf_idx == local_idx
+
+
+def test_both_backends_store_a_content_only_chunk_identically(tmp_path):
+    """Every fallback in the CF row builder, checked against SQLite at once.
+
+    `chunk_index` was not the only default that had drifted: url / title /
+    heading_path fell back to NULL on CF and to '' on SQLite. Comparing the
+    whole row rather than one column keeps the next added column from
+    diverging unnoticed -- the shape gate `_missing_docs_db_methods` only
+    matches method names.
+    """
+    cols = (
+        "url",
+        "title",
+        "chunk_index",
+        "content",
+        "heading_path",
+        "section",
+        "topic",
+        "content_hash",
+        "token_count",
+    )
+    chunks = [{"content": f"paragraph number {i}"} for i in range(3)]
+
+    local, local_lib, local_ver = _local_store(tmp_path)
+    local.add_chunks(local_ver, local_lib, copy.deepcopy(chunks))
+    local_rows = [
+        tuple(r)
+        for r in local._conn.execute(
+            f"SELECT {', '.join(cols)} FROM doc_chunks ORDER BY rowid"
+        )
+    ]
+
+    cf = _backend()
+    cf_lib, cf_ver = _seeded(cf)
+    cf.add_chunks(cf_ver, cf_lib, copy.deepcopy(chunks))
+    cf_rows = [
+        tuple(r[c] for c in cols)
+        for r in cf._d1.execute(
+            f"SELECT {', '.join(cols)} FROM doc_chunks"
+            " WHERE version_id = ? ORDER BY rowid",
+            [cf_ver],
+        )
+    ]
+
+    assert cf_rows == local_rows
+
+
+def test_cf_vector_metadata_repeats_the_chunk_index_of_its_own_row():
+    """Vector metadata and D1 row are built apart; they must still agree.
+
+    `search()` filters and orders on the metadata copy, so a metadata
+    chunk_index that does not match the row it points at reorders results
+    against content that never moved.
+    """
+    chunks = _chunker_output()
+    for c in chunks:
+        del c["chunk_index"]
+
+    cf = _backend()
+    cf_lib, cf_ver = _seeded(cf)
+    cf.add_chunks(cf_ver, cf_lib, chunks, embeddings=[[0.1] * 768 for _ in chunks])
+
+    by_id = {
+        r["id"]: r["chunk_index"]
+        for r in cf._d1.execute(
+            "SELECT id, chunk_index FROM doc_chunks WHERE version_id = ?", [cf_ver]
+        )
+    }
+    assert by_id, "nothing was written"
+    for cid, (_values, meta) in cf._vec._http.vectors.items():
+        assert meta["chunk_index"] == by_id[cid]
+
+
 @pytest.mark.parametrize("method", ["export_jsonl", "import_jsonl"])
 def test_jsonl_sync_degrades_loudly(method):
     """File-based DB sync is meaningless on CF -- say so, do not return empties.


### PR DESCRIPTION
Closes #1622. Same family as #1618, one step quieter.

## What diverged

`DocsDBCfBackend.add_chunks` chose its own defaults for the keys a chunk dict may omit, and they were not `DocsDB._prepare_chunk_rows`' defaults. Every `.get` in the method, audited against the SQLite builder:

| column | `DocsDB` (`db.py:1248-1262`) | `db_cf.add_chunks` before | after | changed |
|---|---|---|---|---|
| `id` | `new_chunk_id()` | `new_chunk_id()` | unchanged | no (#1618) |
| `version_id` / `library_id` | parameter | parameter | unchanged | no |
| `url` | `.get("url", "")` | `.get("url")` -> `None` | `.get("url", "")` | **yes** |
| `title` | `.get("title", "")` | `.get("title")` -> `None` | `.get("title", "")` | **yes** |
| `chunk_index` | `.get("chunk_index", i)` | `.get("chunk_index", 0)` | `.get("chunk_index", i)` | **yes** |
| `content` | `chunk["content"]` | `c["content"]` | unchanged | no |
| `heading_path` | `.get("heading_path", "")` | `.get("heading_path")` -> `None` | `.get("heading_path", "")` | **yes** |
| `section` | `.get(col)` -> `None` | `.get("section")` -> `None` | unchanged | no |
| `topic` | `.get(col)` -> `None` | `.get("topic")` -> `None` | unchanged | no |
| `content_hash` | `.get(col)` -> `None` | `.get("content_hash")` -> `None` | unchanged | no |
| `token_count` | `.get(col)` -> `None` | `.get("token_count")` -> `None` | unchanged | no |
| `created_at` | `now` | `now` | unchanged | no |
| Vectorize metadata `chunk_index` | (no SQLite counterpart) | `.get("chunk_index", 0)` | `.get("chunk_index", i)` | **yes** -- must equal its own row |
| Vectorize metadata `url` | (no SQLite counterpart) | `.get("url", "")` | unchanged | no |

Four of the thirteen columns diverged. The rest were already aligned and are listed so the audit is checkable rather than asserted.

## Impact

Unlike #1618 this raises nothing. Identical input just lands as two different documents depending on `DOCS_DB_BACKEND`:

- `chunk_index` flattened onto `0` breaks the adjacent-chunk prefetch. `_build_results_cf` looks up each hit's neighbours at `(url, version_id, chunk_index +/- 1)`; with the whole batch on index `0` nothing matches, so `context_before` / `context_after` disappear on cf-d1 while SQLite keeps returning them. The `idx >= 0` guard still passes, so the D1 round-trip is still paid for nothing.
- `url` / `title` / `heading_path` stored `NULL` instead of `""` surface as `"url": None` in the `search()` payload where SQLite yields `""`.

**Latent as of this commit** -- `chunk_markdown` and `_split_preserving_code` (`sources/docs.py:2371`, `:2457`, `:2472`) always emit `chunk_index`, `scripts/gen_cf_corpus.py` does too, and `server._background_index_and_search` forwards the chunker list untouched. There is no reachable caller today. It is still a bug: `DocsDB.add_chunks` documents `content` as the only required key and `test_db.py::test_add_chunks_minimal_fields` pins exactly that call, so the CF backend has to honour the same contract.

## The change

`src/wet_mcp/db_cf.py` -- `enumerate` nested around the existing `zip(chunk_ids, chunks, strict=True)` (kept from #1618), and the same `i` reused in the Vectorize metadata comprehension. That second half matters on its own: the row and the vector are built separately, so an independent fallback there would let the metadata `chunk_index` disagree with the row it points at, and `search()` orders on the metadata copy.

## Tests

Three cases added to `tests/test_db_cf_contract.py`, all driving real `chunk_markdown` output with `chunk_index` deleted rather than hand-written fixtures -- hand-written fixtures spelling every key in are what let this through in the first place:

- `test_both_backends_default_chunk_index_to_its_place_in_the_batch` -- index sequence parity. Red before: `assert [0, 0, 0] == [0, 1, 2]`.
- `test_both_backends_store_a_content_only_chunk_identically` -- whole-row parity across all nine content columns for `{"content": ...}` alone. Red before: `(None, None, 0, 'paragraph number 0', None, ...) != ('', '', 0, 'paragraph number 0', '', ...)`. This is the one that caught `url` / `title` / `heading_path`; comparing the whole row also means the next column added to `doc_chunks` cannot diverge unnoticed.
- `test_cf_vector_metadata_repeats_the_chunk_index_of_its_own_row` -- guards the metadata half, which would have gone red had only the row builder been fixed.

Green after: `26 passed` in the contract file, `2316 passed, 33 skipped` for the full suite. `_missing_docs_db_methods` still cannot catch this class -- it compares method names -- so the contract file stays the place where input-shape parity is pinned.