### PR TITLE
fix: stamp discovery_version and the dropped metadata in cf-d1 upsert_library

### DIFF
--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -16,9 +16,20 @@ from loguru import logger
 from mcp_core.storage.d1 import D1Backend
 from mcp_core.storage.vectorize import VectorizeBackend
 
-# Reuse the exact ranking helpers and the chunk-id generator from the SQLite
-# implementation -- both backends must mint identity the same way.
-from wet_mcp.db import _build_fts_queries, _chunk_quality_score, new_chunk_id
+# Reuse the exact ranking helpers, the chunk-id generator and the column
+# allowlist from the SQLite implementation -- both backends must mint identity
+# and validate dynamic column names the same way.
+from wet_mcp.db import (
+    _LIBRARIES_COLUMNS,
+    _build_fts_queries,
+    _chunk_quality_score,
+    new_chunk_id,
+)
+
+# Stamped onto every library row, exactly as db.py does it. `_search_cached_index`
+# re-indexes any library whose stored value trails this constant, so a backend
+# that does not write it can never serve a cached index (issue #1624).
+from wet_mcp.sources.docs import DISCOVERY_VERSION
 
 
 class DocsDBCfBackend:
@@ -42,25 +53,111 @@ class DocsDBCfBackend:
 
     # --- relational CRUD (parameterized D1) ---
 
-    def upsert_library(self, name: str, docs_url: str | None = None, **extra) -> str:
-        existing = self.get_library(name)
+    def upsert_library(
+        self,
+        name: str,
+        docs_url: str | None = None,
+        registry: str | None = None,
+        description: str | None = None,
+        tier: int | None = None,
+        package_managers: list[str] | None = None,
+        homepage: str | None = None,
+        github_url: str | None = None,
+        canonical_name: str | None = None,
+    ) -> str:
+        """Create or update a library. Returns library ID.
+
+        Column-for-column mirror of ``wet_mcp.db.DocsDB.upsert_library`` over
+        the ``libraries`` table in ``migrations/0001_init_wet.sql`` +
+        ``0002_project_context.sql``. The signature is explicit rather than
+        ``**extra`` on purpose: it used to swallow every keyword past
+        ``docs_url`` and write none of them, so ``registry`` / ``description``
+        from the docs index path and ``tier`` / ``canonical_name`` /
+        ``homepage`` / ``github_url`` / ``package_managers`` from the Tier 1
+        warmup all vanished, and the next column added would have vanished
+        too. An unknown field must now raise TypeError, as it does on SQLite.
+
+        ``discovery_version`` is stamped on BOTH paths. Insert-only stamping
+        would leave every row already written at 0 re-indexing forever, since
+        an existing library is only ever updated (issue #1624).
+
+        ``last_indexed_at`` stays untouched here, matching DocsDB: writing
+        metadata says nothing about whether chunks landed.
+        """
+        norm_name = name.lower().strip()
         now = time.time()
+        pkg_json = (
+            json.dumps(package_managers, ensure_ascii=False)
+            if package_managers is not None
+            else None
+        )
+        # Both stores key on the normalised name. Storing it raw meant a search
+        # for "FastAPI" and one for "fastapi" minted two library rows on D1 and
+        # indexed the same docs twice.
+        optional = (
+            ("docs_url", docs_url),
+            ("registry", registry),
+            ("description", description),
+            ("canonical_name", canonical_name),
+            ("homepage", homepage),
+            ("github_url", github_url),
+            ("package_managers", pkg_json),
+            ("tier", None if tier is None else int(tier)),
+        )
+
+        existing = self.get_library(norm_name)
         if existing:
+            # Mirrors DocsDB._update_library_inner: a field left None keeps its
+            # stored value (assigning it unconditionally erased the docs URL of
+            # an indexed library on any metadata-only re-upsert), while
+            # discovery_version and updated_at are rewritten every time.
+            sets = ["discovery_version = ?", "updated_at = ?"]
+            params: list = [DISCOVERY_VERSION, now]
+            for col, value in optional:
+                if value is not None:
+                    sets.append(f"{col} = ?")
+                    params.append(value)
+            params.append(existing["id"])
+            self._assert_library_columns(s.split("=")[0].strip() for s in sets)
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
             self._d1.execute(
-                "UPDATE libraries SET docs_url = ?, updated_at = ? WHERE id = ?",
-                [docs_url, now, existing["id"]],
+                "UPDATE libraries SET " + ", ".join(sets) + " WHERE id = ?",
+                params,
             )
             return existing["id"]
+
         lib_id = str(uuid.uuid4())
+        cols = ["id", "name", "discovery_version", "created_at", "updated_at"]
+        vals: list = [lib_id, norm_name, DISCOVERY_VERSION, now, now]
+        for col, value in optional:
+            # canonical_name is the one field DocsDB writes even when absent:
+            # it is the display label and defaults to the library's own name.
+            if col == "canonical_name":
+                value = value or norm_name
+            if value is not None:
+                cols.append(col)
+                vals.append(value)
+        self._assert_library_columns(cols)
+        # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
         self._d1.execute(
-            "INSERT INTO libraries (id, name, docs_url, created_at, updated_at)"
-            " VALUES (?,?,?,?,?)",
-            [lib_id, name, docs_url, now, now],
+            f"INSERT INTO libraries ({', '.join(cols)})"
+            f" VALUES ({', '.join('?' * len(cols))})",
+            vals,
         )
         return lib_id
 
+    @staticmethod
+    def _assert_library_columns(cols) -> None:
+        """Gate dynamic column names against the same allowlist db.py uses."""
+        for col in cols:
+            if col not in _LIBRARIES_COLUMNS:
+                raise ValueError(f"Unauthorized library column: {col}")
+
     def get_library(self, name: str) -> dict | None:
-        return self._d1.fetchone("SELECT * FROM libraries WHERE name = ?", [name])
+        """Get library by name. Normalises like ``DocsDB.get_library`` does."""
+        return self._d1.fetchone(
+            "SELECT * FROM libraries WHERE name = ?", [name.lower().strip()]
+        )
 
     def upsert_version(
         self,

--- a/tests/test_db_cf_contract.py
+++ b/tests/test_db_cf_contract.py
@@ -565,6 +565,240 @@ def test_cf_vector_metadata_repeats_the_chunk_index_of_its_own_row():
         assert meta["chunk_index"] == by_id[cid]
 
 
+# ---------------------------------------------------------------------------
+# Column parity: `libraries`.
+#
+# The libraries row is not a label, it is control state. `_search_cached_index`
+# reads `discovery_version` off it and forces a full re-index whenever the
+# stored value trails `sources.docs.DISCOVERY_VERSION`. `db_cf.upsert_library`
+# never wrote the column and took the rest of DocsDB's metadata as `**extra`,
+# which it dropped -- so a cf-d1 store answered `indexing_in_progress` forever,
+# re-indexing on every call, with 50 perfectly good chunks already in D1.
+#
+# Same failure class as #1618 (chunk id) and #1623 (chunk column fallbacks):
+# `_missing_docs_db_methods` only matches method NAMES, so what a method
+# actually writes drifts unseen. Compare whole rows, not one column.
+# ---------------------------------------------------------------------------
+
+# Every `libraries` column both stores own and either writer can set. `id` /
+# `created_at` / `updated_at` are excluded (opaque or wall-clock), as are the
+# columns owned by mark_library_indexed / mark_metadata_seeded.
+_LIBRARY_PARITY_COLUMNS = (
+    "name",
+    "docs_url",
+    "registry",
+    "description",
+    "canonical_name",
+    "homepage",
+    "github_url",
+    "package_managers",
+    "tier",
+    "discovery_version",
+)
+
+# Exactly what `sources.docs._index_library` passes in production.
+_FULL_LIBRARY_KWARGS = {
+    "docs_url": "https://alpha.dev",
+    "registry": "pypi",
+    "description": "Alpha reads and writes configuration files.",
+    "tier": 1,
+    "package_managers": ["pip", "uv"],
+    "homepage": "https://alpha.dev/home",
+    "github_url": "https://github.com/alpha/alpha",
+    "canonical_name": "Alpha",
+}
+
+
+def _library_rows(tmp_path, name, calls):
+    """Apply the same upsert sequence to both backends; return both rows."""
+    local = DocsDB(tmp_path / "docs.db")
+    cf = _backend()
+    for kwargs in calls:
+        local.upsert_library(name, **kwargs)
+        cf.upsert_library(name, **kwargs)
+    lookup = name.lower().strip()
+    return local.get_library(lookup), cf.get_library(lookup)
+
+
+def _parity(row):
+    assert row is not None, "the library row is missing entirely"
+    return {c: row.get(c) for c in _LIBRARY_PARITY_COLUMNS}
+
+
+def test_both_backends_insert_the_same_library_row(tmp_path):
+    """A first upsert must land the same metadata in D1 as in SQLite.
+
+    `db_cf.upsert_library` accepted `registry` / `description` / `tier` /
+    `package_managers` / `homepage` / `github_url` / `canonical_name` as
+    `**extra` and wrote none of them, so the Tier 1 warmup seeded rows on
+    cf-d1 that held nothing but a name.
+    """
+    local_row, cf_row = _library_rows(tmp_path, "alpha", [_FULL_LIBRARY_KWARGS])
+    assert _parity(cf_row) == _parity(local_row)
+
+
+def test_both_backends_stamp_discovery_version_on_insert(tmp_path):
+    """The stamp itself, named, because it is what breaks the search path."""
+    from wet_mcp.sources.docs import DISCOVERY_VERSION
+
+    local_row, cf_row = _library_rows(
+        tmp_path, "alpha", [{"docs_url": "https://alpha.dev"}]
+    )
+    assert local_row["discovery_version"] == DISCOVERY_VERSION
+    assert cf_row["discovery_version"] == DISCOVERY_VERSION
+
+
+def test_reupsert_restamps_discovery_version_on_an_existing_row(tmp_path):
+    """The UPDATE path is the one that heals production.
+
+    Prod D1 already holds rows written at `discovery_version = 0`. Stamping
+    only on INSERT would leave every one of them re-indexing forever, because
+    the row is never re-inserted -- only ever updated.
+    """
+    from wet_mcp.sources.docs import DISCOVERY_VERSION
+
+    cf = _backend()
+    lib_id = cf.upsert_library("alpha", docs_url="https://alpha.dev")
+    cf._d1.execute("UPDATE libraries SET discovery_version = 0 WHERE id = ?", [lib_id])
+    assert cf.get_library("alpha")["discovery_version"] == 0
+
+    cf.upsert_library("alpha", docs_url="https://alpha.dev")
+    assert cf.get_library("alpha")["discovery_version"] == DISCOVERY_VERSION
+
+
+def test_both_backends_update_the_same_library_columns(tmp_path):
+    """A second upsert must write the same columns -- and blank the same none.
+
+    DocsDB's UPDATE skips every field the caller left as None; the CF UPDATE
+    assigned `docs_url` unconditionally, so a metadata-only re-upsert erased
+    the stored docs URL of an already-indexed library.
+    """
+    local_row, cf_row = _library_rows(
+        tmp_path,
+        "alpha",
+        [
+            _FULL_LIBRARY_KWARGS,
+            {"registry": "npm", "description": "Alpha, restated."},
+        ],
+    )
+    assert _parity(cf_row) == _parity(local_row)
+
+
+def test_both_backends_normalise_the_library_name(tmp_path):
+    """`get_library` must find what `upsert_library` just wrote, in any casing.
+
+    DocsDB lowercases and strips on both read and write. db_cf did neither, so
+    a search for "FastAPI" followed by one for "fastapi" minted two library
+    rows and indexed the same docs twice -- the same unbounded re-index this
+    module exists to prevent.
+    """
+    local_row, cf_row = _library_rows(
+        tmp_path, "  FastAPI  ", [{"docs_url": "https://f.dev"}]
+    )
+    assert _parity(cf_row) == _parity(local_row)
+
+    cf = _backend()
+    first = cf.upsert_library("FastAPI", docs_url="https://f.dev")
+    again = cf.upsert_library("fastapi", docs_url="https://f.dev")
+    assert again == first
+    assert cf.stats()["libraries"] == 1
+
+
+def test_upsert_library_rejects_an_unknown_field(tmp_path):
+    """Silently swallowing kwargs is how this bug survived three releases.
+
+    `**extra` made every future column addition a no-op on cf-d1 that nothing
+    would report. An unknown field must fail the same way DocsDB fails it.
+
+    Dispatched by name because a literal keyword is a static type error on the
+    SQLite side -- which is exactly the report the CF side owed us and did not
+    give. Here we want the runtime error, so the call has to get past `ty`.
+    """
+    method = "upsert_library"
+    for db in (_backend(), DocsDB(tmp_path / "docs.db")):
+        with pytest.raises(TypeError):
+            getattr(db, method)("alpha", not_a_column="x")
+
+
+def test_both_backends_insert_the_same_version_row(tmp_path):
+    """`versions` INSERT parity: a fresh version is 'pending' with zero counts."""
+    cols = ("version", "docs_url", "status", "page_count", "chunk_count")
+
+    local = DocsDB(tmp_path / "docs.db")
+    local_lib = local.upsert_library("alpha", docs_url="https://alpha.dev")
+    local_ver = local.upsert_version(local_lib, "1.0", docs_url="https://alpha.dev")
+    local_row = dict(
+        local._conn.execute(
+            "SELECT * FROM versions WHERE id = ?", (local_ver,)
+        ).fetchone()
+    )
+
+    cf = _backend()
+    cf_lib = cf.upsert_library("alpha", docs_url="https://alpha.dev")
+    cf_ver = cf.upsert_version(cf_lib, "1.0", docs_url="https://alpha.dev")
+    cf_row = cf._d1.fetchone("SELECT * FROM versions WHERE id = ?", [cf_ver])
+
+    assert {c: cf_row[c] for c in cols} == {c: local_row[c] for c in cols}
+
+
+async def test_search_cached_index_serves_a_library_indexed_on_cf(monkeypatch):
+    """The whole point: an indexed cf-d1 library must be answered, not re-indexed.
+
+    Verified live on prod D1 2026-08-03 -- library `fastapi` held 50
+    doc_chunks, `versions.index_state='done'`, `chunk_count=50`, FTS synced
+    50/50, and `search(action="docs")` still replied `indexing_in_progress`
+    on every call because `discovery_version` read back 0 against a code
+    constant of 27.
+    """
+    from wet_mcp import server
+
+    cf = _backend()
+    lib_id = cf.upsert_library(
+        "alpha",
+        docs_url="https://alpha.dev",
+        registry="pypi",
+        description="Alpha reads config files.",
+    )
+    ver_id = cf.upsert_version(lib_id, "latest", docs_url="https://alpha.dev")
+    cf.add_chunks(
+        ver_id,
+        lib_id,
+        [
+            {
+                "url": "https://alpha.dev/retry",
+                "title": "Retry",
+                "content": "alpha retries a failed request with exponential backoff",
+                "heading_path": "Usage > Retry",
+            }
+        ],
+    )
+    cf.mark_version_indexed(ver_id, 1, 1)
+
+    async def _no_embedding(*_a, **_k):
+        return None
+
+    async def _no_hyde(*_a, **_k):
+        return None
+
+    async def _passthrough_rerank(_query, results, limit):
+        return results[:limit]
+
+    monkeypatch.setattr(server, "_docs_db", cf)
+    monkeypatch.setattr(server, "_embed", _no_embedding)
+    monkeypatch.setattr(server, "_rerank_results", _passthrough_rerank)
+    monkeypatch.setattr(
+        "wet_mcp.sources.search_strategies.generate_hyde_query", _no_hyde
+    )
+
+    payload = await server._search_cached_index("alpha", "retry backoff", None, 5)
+
+    assert payload is not None, (
+        "an indexed cf-d1 library was reported as needing indexing again"
+    )
+    assert payload["source"] == "cached_index"
+    assert payload["results"], "served an empty result set for an indexed library"
+
+
 @pytest.mark.parametrize("method", ["export_jsonl", "import_jsonl"])
 def test_jsonl_sync_degrades_loudly(method):
     """File-based DB sync is meaningless on CF -- say so, do not return empties.


### PR DESCRIPTION
Closes #1624.

## What was broken

`server.py::_search_cached_index` forces a re-index of any library whose stored `discovery_version` trails `sources.docs.DISCOVERY_VERSION` (currently 27). `db_cf.upsert_library` never wrote that column, so on the Cloudflare backend it read back as the schema default `0` forever -- `0 < 27` always -- and `search(action="docs", library=...)` answered `indexing_in_progress` on every call while re-indexing a library that was already fully indexed.

Verified live on prod D1 (2026-08-03): library `fastapi` held 50 `doc_chunks`, `versions.index_state='done'`, `chunk_count=50`, FTS synced 50/50 with all three triggers present -- and was still never served. All 9 prod library rows sat at `discovery_version = 0`.

The stamp goes on **both** the INSERT and the UPDATE path. Insert-only stamping would leave every row already written at 0 looping forever, because an existing library is only ever updated, never re-inserted.

## Column-by-column parity pass

This is the third instance of the same class after #1618 (chunk `id`) and #1623 (chunk column fallbacks), so it is a systematic pass over the `libraries` and `versions` writers rather than a point fix. `_missing_docs_db_methods` only compares method NAMES, so what a method actually writes has been drifting unseen.

### `libraries` -- INSERT

| column | `DocsDB._insert_library_inner` | `db_cf.upsert_library` before | after |
|---|---|---|---|
| `id` | `uuid4().hex[:12]` | `str(uuid4())` | unchanged -- see "deliberately left" |
| `name` | `name.lower().strip()` | raw `name` | **fixed** -- normalised |
| `docs_url` | written | written | unchanged |
| `registry` | written | **dropped by kwargs catch-all** | **fixed** |
| `description` | written | **dropped by kwargs catch-all** | **fixed** |
| `canonical_name` | `canonical_name or norm_name`, always written | **dropped** | **fixed**, same default |
| `homepage` | written when not None | **dropped** | **fixed** |
| `github_url` | written when not None | **dropped** | **fixed** |
| `package_managers` | `json.dumps(...)` when not None | **dropped** | **fixed**, same encoding |
| `tier` | `int(tier)` when not None | **dropped** | **fixed** |
| `discovery_version` | `DISCOVERY_VERSION` | **never written (= 0)** | **fixed** |
| `created_at` / `updated_at` | `now` | `now` | unchanged |
| `last_indexed_at` | not touched | not touched | unchanged (owned by `mark_library_indexed`) |
| `metadata_seeded_at` | not touched | not touched | unchanged (owned by `mark_metadata_seeded`) |
| `total_versions` | not touched | not touched | unchanged (owned by `mark_library_indexed`) |

### `libraries` -- UPDATE

| column | `DocsDB._update_library_inner` | `db_cf.upsert_library` before | after |
|---|---|---|---|
| `docs_url` | only when not None | **assigned unconditionally** (erased the stored URL on a metadata-only re-upsert) | **fixed** -- skipped when None |
| `registry` | only when not None | **dropped** | **fixed** |
| `description` | only when not None | **dropped** | **fixed** |
| `canonical_name` | only when not None | **dropped** | **fixed** |
| `homepage` | only when not None | **dropped** | **fixed** |
| `github_url` | only when not None | **dropped** | **fixed** |
| `package_managers` | only when not None | **dropped** | **fixed** |
| `tier` | only when not None | **dropped** | **fixed** |
| `discovery_version` | **always** | **never written** | **fixed** -- always |
| `updated_at` | always | always | unchanged |

### `versions` -- INSERT / UPDATE

| column | `DocsDB.upsert_version` | `db_cf.upsert_version` | verdict |
|---|---|---|---|
| `id` | `uuid4().hex[:12]` | `str(uuid4())` | left -- see below |
| `library_id`, `version`, `docs_url` | written | written | match |
| `status` | explicit `'pending'` | omitted, schema `DEFAULT 'pending'` | equivalent -- now pinned by a test |
| `page_count` / `chunk_count` | schema default 0 | schema default 0 | match |
| `indexed_at`, `release_date`, `source_url` | not written | not written | match |
| UPDATE `docs_url` | only when truthy | only when truthy | match |
| `mark_version_indexed` | `status`/`indexed_at`/`page_count`/`chunk_count` | identical | match |
| `set_index_state` | `index_state`/`index_error`/`index_state_at` | identical | match |
| `mark_library_indexed` | `last_indexed_at` + `total_versions` when given | identical | match |
| `mark_metadata_seeded` | `metadata_seeded_at` | identical | match |

### Deliberately left

- **`libraries.id` / `versions.id` shape** -- SQLite mints `uuid4().hex[:12]`, cf-d1 mints a full `str(uuid4())`. These are opaque primary keys: nothing parses them, they are never compared across backends, and unlike the chunk `id` of #1618 no caller supplies one. Changing the generator would give a live store a mix of two id shapes for no behavioural gain.
- **`get_best_version` status filter** -- a genuine divergence, but a READ path, outside this fix's INSERT/UPDATE scope. `DocsDB.get_best_version` filters `status = 'indexed'` on both branches and falls back to the latest indexed version; the cf-d1 one filters nothing and does not fall back. Aligning it is not a drop-in: `db_cf.upsert_version` reuses `get_best_version` as its existence check, so adding the filter makes it miss a `pending` row and insert a duplicate against `UNIQUE(library_id, version)`. Measured cost of doing it here: 10 failing tests across `test_db_cf.py` and `test_cf_e2e.py`, one of which (`test_get_best_version_target_is_optional`) explicitly pins the current unfiltered semantics as intended. That is a separate behaviour decision with its own review surface, so it is filed separately rather than folded into a prod-blocking fix.

## Note on the name normalisation

Prod rows written before this change hold whatever casing the caller used. `fastapi` and the other eight are already lowercase, so they are found unchanged. Any mixed-case row would now miss and be re-indexed once under its normalised name -- self-healing, not a loop.

## Tests

Follows the existing `tests/test_db_cf_contract.py` style: compare whole rows written through each backend, since the shape gate cannot see what a method writes.

8 new tests, 7 of which fail on `main`:

- `test_both_backends_insert_the_same_library_row` -- full-column INSERT parity
- `test_both_backends_stamp_discovery_version_on_insert`
- `test_reupsert_restamps_discovery_version_on_an_existing_row` -- the path that heals prod
- `test_both_backends_update_the_same_library_columns` -- UPDATE parity, incl. not erasing `docs_url`
- `test_both_backends_normalise_the_library_name` -- and no duplicate row on a casing change
- `test_upsert_library_rejects_an_unknown_field` -- no more silent kwargs catch-all
- `test_both_backends_insert_the_same_version_row` -- `versions` INSERT parity (passes on `main`; pins it)
- `test_search_cached_index_serves_a_library_indexed_on_cf` -- the end-to-end regression

RED on `main` reproduces the prod log line exactly:

```
Library 'alpha' cached with discovery v0 (current v27), forcing re-index
```

```
FAILED tests/test_db_cf_contract.py::test_both_backends_insert_the_same_library_row
FAILED tests/test_db_cf_contract.py::test_both_backends_stamp_discovery_version_on_insert
FAILED tests/test_db_cf_contract.py::test_reupsert_restamps_discovery_version_on_an_existing_row
FAILED tests/test_db_cf_contract.py::test_both_backends_update_the_same_library_columns
FAILED tests/test_db_cf_contract.py::test_both_backends_normalise_the_library_name
FAILED tests/test_db_cf_contract.py::test_upsert_library_rejects_an_unknown_field
FAILED tests/test_db_cf_contract.py::test_search_cached_index_serves_a_library_indexed_on_cf
7 failed, 27 passed
```

GREEN after: `8 passed, 26 deselected`. Full suite: `2331 passed, 33 skipped, 140 deselected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
