### PR TITLE
fix: batch D1 neighbour prefetch by parameters, not rows

### DIFF
--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -13,7 +13,7 @@ import time
 import uuid
 
 from loguru import logger
-from mcp_core.storage.d1 import D1Backend
+from mcp_core.storage.d1 import D1_MAX_BOUND_PARAMS, D1Backend
 from mcp_core.storage.vectorize import VectorizeBackend
 
 # Reuse the exact ranking helpers, the chunk-id generator and the column
@@ -30,6 +30,26 @@ from wet_mcp.db import (
 # re-indexes any library whose stored value trails this constant, so a backend
 # that does not write it can never serve a cached index (issue #1624).
 from wet_mcp.sources.docs import DISCOVERY_VERSION
+
+
+def _d1_param_batches(items: list, params_per_item: int):
+    """Slice ``items`` so no single D1 statement binds more than D1's cap.
+
+    D1's ceiling counts BOUND PARAMETERS, not rows. The cap itself is imported
+    from ``mcp_core.storage.d1`` rather than restated here, so the read path
+    and the write path (``D1Backend.executemany``, which derives its
+    rows-per-INSERT the same way) can never drift apart on the number.
+
+    Batching a multi-column key list by ROWS is what killed the deployed
+    worker: 100 three-column keys bind 300 parameters, D1 answers
+    ``D1_ERROR: too many SQL variables``, and the container dies mid-request so
+    the client only sees "Server disconnected without sending a response".
+    Dividing the cap by the per-item width means widening a key tuple shrinks
+    the batch automatically instead of silently overflowing it.
+    """
+    per_batch = max(1, D1_MAX_BOUND_PARAMS // params_per_item)
+    for i in range(0, len(items), per_batch):
+        yield items[i : i + per_batch]
 
 
 class DocsDBCfBackend:
@@ -585,14 +605,22 @@ class DocsDBCfBackend:
                     missing_ids.append(cid)
 
             if missing_ids:
-                placeholders = ",".join(["?"] * len(missing_ids))
-                sql = (
-                    "SELECT c.*, l.name AS _library_name FROM doc_chunks c "
-                    "LEFT JOIN libraries l ON c.library_id = l.id "
-                    f"WHERE c.id IN ({placeholders})"
-                )
-                for row in self._d1.execute(sql, missing_ids):
-                    fts_chunks[row["id"]] = row
+                # One bound parameter per id. Today this cannot reach D1's cap
+                # on its own -- top_k above clamps vec_results to 50 -- but that
+                # is a property of a number written elsewhere, not of this
+                # statement. Routing it through the same helper as the
+                # neighbour prefetch means raising candidate_limit or that
+                # clamp can never silently reintroduce the "too many SQL
+                # variables" crash that takes the whole container down.
+                for batch in _d1_param_batches(missing_ids, 1):
+                    placeholders = ",".join(["?"] * len(batch))
+                    sql = (
+                        "SELECT c.*, l.name AS _library_name FROM doc_chunks c "
+                        "LEFT JOIN libraries l ON c.library_id = l.id "
+                        f"WHERE c.id IN ({placeholders})"
+                    )
+                    for row in self._d1.execute(sql, batch):
+                        fts_chunks[row["id"]] = row
                 for cid in missing_ids:
                     if cid not in fts_chunks:
                         fts_chunks[cid] = {}
@@ -649,10 +677,12 @@ def _build_results_cf(scored, fts_chunks, d1: D1Backend, limit: int):
     adj_map: dict[tuple[str, str, int], str] = {}
     if adj_keys:
         unique_keys = sorted(adj_keys)
-        batch_size = 100
-        for i in range(0, len(unique_keys), batch_size):
-            batch = unique_keys[i : i + batch_size]
-            placeholders = ",".join(["(?,?,?)"] * len(batch))
+        # The key width drives BOTH the ?-tuple and the batch size, so the two
+        # cannot disagree: adding a column to the key re-derives each of them.
+        key_width = len(unique_keys[0])
+        key_tuple = "(" + ",".join(["?"] * key_width) + ")"
+        for batch in _d1_param_batches(unique_keys, key_width):
+            placeholders = ",".join([key_tuple] * len(batch))
             params = [v for k in batch for v in k]
             sql = (
                 "SELECT url, version_id, chunk_index, content "

--- a/tests/test_db_cf_contract.py
+++ b/tests/test_db_cf_contract.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 from conftest_cf import FakeD1Http, FakeVectorizeHttp
-from mcp_core.storage.d1 import D1Backend
+from mcp_core.storage.d1 import D1_MAX_BOUND_PARAMS, D1Backend
 from mcp_core.storage.vectorize import VectorizeBackend
 
 from wet_mcp.db import DocsDB
@@ -315,6 +315,80 @@ def test_add_chunks_stays_inside_the_d1_parameter_cap():
     # 13 columns against a 100-parameter cap: 7 rows / 91 params per statement.
     assert widths == [91, 91, 91, 91, 26]
     assert db.stats()["chunks"] == 30
+
+
+def test_neighbour_prefetch_stays_inside_the_d1_parameter_cap():
+    """The read path's turn at the bug PR #1601 fixed for the write path.
+
+    Reproduces the crash captured from the deployed worker by `wrangler tail`
+    on 2026-08-03: `search(action="docs", library="fastapi")` came back as
+    "Server disconnected without sending a response" because this prefetch
+    batched by ROWS (100) while D1 caps PARAMETERS (100), so a full batch of
+    three-column keys sent 300 and D1 answered `D1_ERROR: too many SQL
+    variables at offset 376`, killing the container mid-request.
+
+    Asserts the parameter count actually bound per statement, not merely that
+    search() returns -- the fake D1 is real sqlite, whose own variable limit is
+    far higher, so a row-batched statement passes right through it.
+    """
+    import json as _json
+
+    captured = []
+
+    class RecordingHttp:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def request(self, method, url, data=None, headers=None):
+            if url.endswith(("/query", "/batch")):
+                captured.append(_json.loads(data.decode()))
+            return self._inner.request(method, url, data, headers)
+
+    d1 = D1Backend("http://d1.internal", http=RecordingHttp(FakeD1Http(DDL)))
+    vec = VectorizeBackend(
+        "http://vectorize.internal", idx="wet", http=FakeVectorizeHttp()
+    )
+    db = DocsDBCfBackend(d1, vec, embedding_dims=768)
+    lib_id, ver_id = _seeded(db)
+    # 60 distinct urls -> each hit asks for its idx-1 and idx+1 neighbour ->
+    # 120 distinct keys, which needs several batches even after the fix.
+    db.add_chunks(
+        ver_id,
+        lib_id,
+        [
+            {
+                "url": f"https://a/p{i}",
+                "title": "T",
+                "chunk_index": 0,
+                "content": f"widget documentation page {i}",
+                "heading_path": "T",
+            }
+            for i in range(60)
+        ],
+        embeddings=None,
+    )
+
+    captured.clear()
+    db.search("widget", limit=40)
+
+    prefetch = [
+        s
+        for p in captured
+        for s in (p if isinstance(p, list) else [p])
+        if "IN (VALUES" in s["sql"]
+    ]
+    assert prefetch, "no neighbour-context prefetch was captured"
+    widths = [len(s["params"]) for s in prefetch]
+    assert max(widths) <= D1_MAX_BOUND_PARAMS, (
+        f"prefetch bound {max(widths)} parameters in one statement; D1 caps a "
+        f"query at {D1_MAX_BOUND_PARAMS} and drops the container over it"
+    )
+    assert len(prefetch) > 1, "corpus too small to have exercised batching at all"
+    # 3 columns against a 100-parameter cap: 33 keys / 99 params per statement.
+    assert widths == [99, 99, 99, 63]
+    # Every key still got looked up -- the cap is respected by splitting the
+    # work, not by dropping any of it.
+    assert sum(widths) == 120 * 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1627.

## What broke

`search(action="docs", library="fastapi")` against the deployed CF worker killed the container -- the client saw only `Server disconnected without sending a response`. `wrangler tail` showed D1 rejecting the neighbour-context prefetch with `D1_ERROR: too many SQL variables at offset 376`.

`_build_results_cf` batched the `(url, version_id, chunk_index)` lookup by **rows** (100) while D1 caps **bound parameters** (100), so a full batch sent 300. Offset 376 lands in the 34th tuple -- 34 x 3 = 102 -- exactly where the count crosses the cap.

This is the read-path twin of the write-path bug fixed in mcp-core 1.22.0.

## The fix

- Cap is **imported** from `mcp_core.storage.d1.D1_MAX_BOUND_PARAMS`, not restated -- the read path and `D1Backend.executemany` can no longer drift on the number. (mcp-core exposes the constant but no read-path helper; `executemany` is INSERT-specific, so only the constant was reusable.)
- New `_d1_param_batches(items, params_per_item)` slices by `cap // params_per_item`.
- The key width drives **both** the `?`-tuple and the batch size, so widening the key shrinks the batch instead of overflowing it.
- The vector-hit hydration site is routed through the same helper. It was safe only because `top_k` clamps to 50 -- a number written elsewhere. Raising `candidate_limit` or that clamp can no longer silently bring the crash back.

## Per-site parameter audit (`db_cf.py`)

Only 3 of the 28 D1 call sites assemble SQL dynamically; the other 25 bind fixed-length parameter lists (1-5 params).

| Site | Max params | Safe? |
|---|---|---|
| `_build_results_cf` neighbour prefetch, `IN (VALUES ...)` | was **300**, now **99** | **was the crash**; now `cap // 3 = 33` keys/stmt |
| `search()` vector-hit hydration, `c.id IN (...)` | 50 (`top_k` clamp), now hard-capped at 100 | was safe only by an off-site number; now structural |
| `search()` FTS query, `sql +=` filters | 4 | bounded by a fixed set of optional filters, not by row count |
| `add_chunks` -> `D1Backend.executemany` | 91 | mcp-core 1.22.0 derives `100 // 13 cols = 7` rows/stmt |
| all 25 static statements | 5 | fixed-length literal parameter lists |

## Test

`test_neighbour_prefetch_stays_inside_the_d1_parameter_cap` asserts the parameters **actually bound per D1 call**, captured at the real call site through a recording http double.

The fake D1 is backed by real sqlite, whose own variable limit is far higher than 100 -- so asserting that `search()` merely returns would **not** have caught this. Only counting bound parameters does.

RED (before the fix):

```
AssertionError: prefetch bound 300 parameters in one statement; D1 caps a query at 100 and drops the container over it
assert 300 <= 100
 +  where 300 = max([300, 60])
```

GREEN (after): 120 keys now go out as four statements of 99/99/99/63, and `sum(widths) == 120 * 3` pins that batching split the work rather than dropping any of it.

Full suite: **2324 passed, 33 skipped**. `ruff check`, `ruff format --check`, `ty check` all clean.
