### PR TITLE
fix: align cf-d1 get_best_version with DocsDB and heal un-normalised library names

### DIFF
--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -110,9 +110,15 @@ class DocsDBCfBackend:
             # Mirrors DocsDB._update_library_inner: a field left None keeps its
             # stored value (assigning it unconditionally erased the docs URL of
             # an indexed library on any metadata-only re-upsert), while
-            # discovery_version and updated_at are rewritten every time.
-            sets = ["discovery_version = ?", "updated_at = ?"]
-            params: list = [DISCOVERY_VERSION, now]
+            # discovery_version, name and updated_at are rewritten every time.
+            #
+            # `name` is rewritten for the same reason discovery_version is: the
+            # UPDATE path, not the INSERT, is what repairs rows that are
+            # already stored. A row written un-normalised by an older container
+            # is healed in place here, so it keeps its id and its chunks stay
+            # reachable instead of being orphaned behind a second row.
+            sets = ["discovery_version = ?", "name = ?", "updated_at = ?"]
+            params: list = [DISCOVERY_VERSION, norm_name, now]
             for col, value in optional:
                 if value is not None:
                     sets.append(f"{col} = ?")
@@ -154,10 +160,34 @@ class DocsDBCfBackend:
                 raise ValueError(f"Unauthorized library column: {col}")
 
     def get_library(self, name: str) -> dict | None:
-        """Get library by name. Normalises like ``DocsDB.get_library`` does."""
-        return self._d1.fetchone(
-            "SELECT * FROM libraries WHERE name = ?", [name.lower().strip()]
-        )
+        """Get library by name. Normalises like ``DocsDB.get_library`` does.
+
+        Unlike DocsDB, this falls back to normalising the STORED name on a
+        miss. Normalising the lookup changes the key of a table that is
+        already populated: a row an older container wrote as "FastAPI" would
+        stop being found, the next upsert would mint a second row, and the
+        first row's chunks would become unreachable. Losing an index that was
+        built correctly is worse than the bug this fix exists for. DocsDB
+        needs no such fallback -- its writer has always normalised, so no
+        SQLite store can hold a raw name.
+
+        The exact match runs first so the common case still uses
+        ``idx_libraries_name``; the scan only happens when a library is
+        genuinely absent or still un-normalised. ``upsert_library`` then
+        rewrites the name in place, so each legacy row is repaired the first
+        time it is touched and the scan stops being reachable for it.
+
+        Measured on prod ``wet-docs`` before shipping: 0 of 10 library rows
+        had a name differing from ``lower(trim(name))``, so this covers the
+        mixed-version rollout window rather than a known-bad row.
+        """
+        norm_name = name.lower().strip()
+        row = self._d1.fetchone("SELECT * FROM libraries WHERE name = ?", [norm_name])
+        if row is None:
+            row = self._d1.fetchone(
+                "SELECT * FROM libraries WHERE lower(trim(name)) = ?", [norm_name]
+            )
+        return row
 
     def upsert_version(
         self,
@@ -171,8 +201,17 @@ class DocsDBCfBackend:
         both production index call sites pass ``docs_url=``, and an existing row
         gets the new ``docs_url`` written back onto it (a missing one leaves the
         stored value alone).
+
+        The existence check is its own direct, UNFILTERED lookup, exactly as
+        ``DocsDB.upsert_version`` does it -- deliberately not
+        ``get_best_version``, which only considers rows that reached
+        ``status='indexed'``. Reusing it here would miss a ``pending`` row and
+        INSERT a duplicate against ``UNIQUE(library_id, version)``.
         """
-        existing = self.get_best_version(library_id, version)
+        existing = self._d1.fetchone(
+            "SELECT id FROM versions WHERE library_id = ? AND version = ?",
+            [library_id, version],
+        )
         if existing:
             ver_id = existing["id"]
             if docs_url:
@@ -191,13 +230,34 @@ class DocsDBCfBackend:
     def get_best_version(
         self, library_id: str, target: str | None = None
     ) -> dict | None:
+        """Get the best SERVABLE version for a library. Mirrors DocsDB.
+
+        "Best" means indexed. A version that exists but never finished
+        indexing has no chunks behind it, so returning it tells the caller
+        the library is unservable when another version could in fact have
+        answered: ``_search_cached_index`` reads ``chunk_count`` off this row
+        and re-indexes when it is 0, which on cf-d1 meant asking for an
+        explicit ``version=`` that happened to be mid-index re-indexed the
+        library instead of serving the copy already on disk.
+
+        So both branches filter ``status = 'indexed'``, and an exact target
+        that is not indexed falls through to the newest version that is --
+        the same two-step DocsDB.get_best_version performs.
+
+        Callers that need a row REGARDLESS of status (``upsert_version``'s
+        existence check) must query directly; that is not what "best" means.
+        """
         if target:
-            return self._d1.fetchone(
-                "SELECT * FROM versions WHERE library_id = ? AND version = ?",
+            row = self._d1.fetchone(
+                "SELECT * FROM versions WHERE library_id = ? AND version = ?"
+                " AND status = 'indexed'",
                 [library_id, target],
             )
+            if row:
+                return row
         return self._d1.fetchone(
-            "SELECT * FROM versions WHERE library_id = ? ORDER BY indexed_at DESC LIMIT 1",
+            "SELECT * FROM versions WHERE library_id = ? AND status = 'indexed'"
+            " ORDER BY indexed_at DESC LIMIT 1",
             [library_id],
         )
 

--- a/tests/test_cf_e2e.py
+++ b/tests/test_cf_e2e.py
@@ -52,10 +52,12 @@ def test_search_with_cf_db_eventual_consistency():
     db = _cf_db(d1, vec)
     db.upsert_library("alpha", docs_url="https://a")
     lib = db.get_library("alpha")
-    db.upsert_version(lib["id"], "1.0")
-    ver = db.get_best_version(lib["id"], "1.0")
+    # upsert_version returns the id directly. get_best_version means "best
+    # INDEXED version", and this row does not reach status='indexed' until
+    # mark_version_indexed runs, so it is the wrong way to fetch a fresh row.
+    ver_id = db.upsert_version(lib["id"], "1.0")
     db.add_chunks(
-        ver["id"],
+        ver_id,
         lib["id"],
         [
             {
@@ -114,10 +116,12 @@ def test_outbound_latency_under_budget():
     db = _cf_db(d1, vec)
     db.upsert_library("alpha")
     lib = db.get_library("alpha")
-    db.upsert_version(lib["id"], "1.0")
-    ver = db.get_best_version(lib["id"], "1.0")
+    # upsert_version returns the id directly. get_best_version means "best
+    # INDEXED version", and this row does not reach status='indexed' until
+    # mark_version_indexed runs, so it is the wrong way to fetch a fresh row.
+    ver_id = db.upsert_version(lib["id"], "1.0")
     db.add_chunks(
-        ver["id"],
+        ver_id,
         lib["id"],
         [
             {

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -28,10 +28,12 @@ def test_add_chunks_then_fts_search():
     db = _backend()
     db.upsert_library("alpha", docs_url="https://a")
     lib = db.get_library("alpha")
-    db.upsert_version(lib["id"], "1.0")
-    ver = db.get_best_version(lib["id"], "1.0")
+    # upsert_version returns the id directly. get_best_version means "best
+    # INDEXED version", and this row does not reach status='indexed' until
+    # mark_version_indexed runs, so it is the wrong way to fetch a fresh row.
+    ver_id = db.upsert_version(lib["id"], "1.0")
     db.add_chunks(
-        ver["id"],
+        ver_id,
         lib["id"],
         [
             {
@@ -58,10 +60,12 @@ def test_stats_reports_counts():
     assert db.stats() == {"libraries": 0, "chunks": 0, "vec_enabled": True}
     db.upsert_library("alpha", docs_url="https://a")
     lib = db.get_library("alpha")
-    db.upsert_version(lib["id"], "1.0")
-    ver = db.get_best_version(lib["id"], "1.0")
+    # upsert_version returns the id directly. get_best_version means "best
+    # INDEXED version", and this row does not reach status='indexed' until
+    # mark_version_indexed runs, so it is the wrong way to fetch a fresh row.
+    ver_id = db.upsert_version(lib["id"], "1.0")
     db.add_chunks(
-        ver["id"],
+        ver_id,
         lib["id"],
         [
             {
@@ -85,8 +89,7 @@ def test_hybrid_search_applies_rrf_and_url_diversity():
     db = _backend()
     db.upsert_library("alpha", docs_url="https://a")
     lib = db.get_library("alpha")
-    db.upsert_version(lib["id"], "1.0")
-    ver = db.get_best_version(lib["id"], "1.0")
+    ver_id = db.upsert_version(lib["id"], "1.0")
     chunks = [
         {
             "id": f"c{i}",
@@ -99,7 +102,7 @@ def test_hybrid_search_applies_rrf_and_url_diversity():
         for i in range(5)
     ]
     embeddings = [[1.0, 0.0, 0.0] + [0.0] * 765 for _ in chunks]
-    db.add_chunks(ver["id"], lib["id"], chunks, embeddings=embeddings)
+    db.add_chunks(ver_id, lib["id"], chunks, embeddings=embeddings)
     results = db.search(
         "vector search", limit=10, query_embedding=[1.0, 0.0, 0.0] + [0.0] * 765
     )
@@ -122,9 +125,8 @@ def test_cf_search_matches_sqlite_golden(cf_corpus, cf_golden_topk):
     for d in cf_corpus:
         db.upsert_library(d["library"], docs_url=d["url"])
         lib = db.get_library(d["library"])
-        db.upsert_version(lib["id"], d["version"])
-        ver = db.get_best_version(lib["id"], d["version"])
-        db.add_chunks(ver["id"], lib["id"], [d], embeddings=None)  # FTS-only parity
+        ver_id = db.upsert_version(lib["id"], d["version"])
+        db.add_chunks(ver_id, lib["id"], [d], embeddings=None)  # FTS-only parity
     for q in QUERIES:
         cf_top = [r["content"][:40] for r in db.search(q, limit=10)]
         golden = cf_golden_topk[q]
@@ -152,7 +154,9 @@ def test_upsert_version_accepts_docs_url_kwarg():
     ver_id = db.upsert_version(
         library_id=lib_id, version="1.0", docs_url="https://a/docs"
     )
-    row = db.get_best_version(lib_id, "1.0")
+    # Read the row itself: this asserts what upsert_version WROTE, which is a
+    # different question from what get_best_version chooses to SERVE.
+    row = db._d1.fetchone("SELECT * FROM versions WHERE id = ?", [ver_id])
     assert row["id"] == ver_id
     assert row["docs_url"] == "https://a/docs"
 
@@ -164,15 +168,22 @@ def test_upsert_version_updates_docs_url_on_existing_row():
     db = _backend()
     lib_id = db.upsert_library("alpha", docs_url="https://a")
 
+    def stored_docs_url(ver_id):
+        # The stored row, not get_best_version: a 'pending' version is exactly
+        # what this test is about, and "best version" no longer includes one.
+        return db._d1.fetchone("SELECT * FROM versions WHERE id = ?", [ver_id])[
+            "docs_url"
+        ]
+
     first = db.upsert_version(lib_id, "1.0")
-    assert db.get_best_version(lib_id, "1.0")["docs_url"] is None
+    assert stored_docs_url(first) is None
 
     again = db.upsert_version(lib_id, "1.0", docs_url="https://a/docs")
     assert again == first
-    assert db.get_best_version(lib_id, "1.0")["docs_url"] == "https://a/docs"
+    assert stored_docs_url(first) == "https://a/docs"
 
     db.upsert_version(lib_id, "1.0")
-    assert db.get_best_version(lib_id, "1.0")["docs_url"] == "https://a/docs"
+    assert stored_docs_url(first) == "https://a/docs"
 
 
 def test_upsert_version_defaults_to_latest():
@@ -181,16 +192,29 @@ def test_upsert_version_defaults_to_latest():
     db = _backend()
     lib_id = db.upsert_library("alpha", docs_url="https://a")
     ver_id = db.upsert_version(lib_id)
-    assert db.get_best_version(lib_id, "latest")["id"] == ver_id
+    row = db._d1.fetchone("SELECT * FROM versions WHERE id = ?", [ver_id])
+    assert row["version"] == "latest"
 
 
 def test_get_best_version_target_is_optional():
     """``config(action="clear")`` and ``cli.py`` call ``get_best_version(lib_id)``
     with no target. ``DocsDB`` defaults it to ``None``; the CF backend required a
-    second argument and named it ``version``, so the same call raised TypeError."""
+    second argument and named it ``version``, so the same call raised TypeError.
+
+    The fixture now indexes the version before reading it back. This test used
+    to pass against a bare 'pending' row, which quietly pinned a second
+    property the signature fix never intended to assert: that "best version"
+    includes versions that were never indexed. `DocsDB.get_best_version`
+    filters `status = 'indexed'` on both of its branches, so that reading made
+    the two backends disagree about which version a library can serve (#1626).
+    What this test is for -- `target` being optional and keyword-addressable --
+    is unchanged and still asserted; only the fixture gained the
+    `mark_version_indexed` that makes the row servable in the first place.
+    """
     db = _backend()
     lib_id = db.upsert_library("alpha", docs_url="https://a")
     ver_id = db.upsert_version(lib_id, "1.0")
+    db.mark_version_indexed(ver_id, 1, 1)
     assert db.get_best_version(lib_id)["id"] == ver_id
     assert db.get_best_version(lib_id, target="1.0")["id"] == ver_id
 

--- a/tests/test_db_cf_contract.py
+++ b/tests/test_db_cf_contract.py
@@ -704,6 +704,48 @@ def test_both_backends_normalise_the_library_name(tmp_path):
     assert cf.stats()["libraries"] == 1
 
 
+def test_a_legacy_unnormalised_row_is_healed_not_orphaned():
+    """Normalising the lookup must not strand rows written before the change.
+
+    `libraries` is already populated in production. If the normalised lookup
+    simply missed a row stored as "FastAPI", the next upsert would mint a
+    second row and the first one's chunks would become unreachable -- a fix
+    that loses indexed data is worse than the bug. So the read falls back to
+    the raw name and the UPDATE rewrites it in place, keeping the id.
+
+    Measured on prod `wet-docs` before shipping: 0 of 10 library rows had a
+    name differing from `lower(trim(name))`, so this covers the mixed-version
+    rollout window rather than a known-bad row.
+    """
+    from wet_mcp.sources.docs import DISCOVERY_VERSION
+
+    cf = _backend()
+    # A row exactly as an older container would have written it.
+    legacy_id = "legacy-row"
+    now = 1.0
+    cf._d1.execute(
+        "INSERT INTO libraries (id, name, docs_url, created_at, updated_at)"
+        " VALUES (?,?,?,?,?)",
+        [legacy_id, "  FastAPI  ", "https://f.dev", now, now],
+    )
+    ver_id = cf.upsert_version(legacy_id, "latest", docs_url="https://f.dev")
+    cf.add_chunks(ver_id, legacy_id, [{"content": "fastapi dependency injection"}])
+    cf.mark_version_indexed(ver_id, 1, 1)
+
+    # The normalised lookup still reaches it...
+    assert cf.get_library("fastapi")["id"] == legacy_id
+
+    # ...and touching it repairs the row rather than replacing it.
+    assert cf.upsert_library("FastAPI", docs_url="https://f.dev") == legacy_id
+    assert cf.stats()["libraries"] == 1, "a second row was minted; chunks orphaned"
+
+    healed = cf.get_library("fastapi")
+    assert healed["id"] == legacy_id
+    assert healed["name"] == "fastapi"
+    assert healed["discovery_version"] == DISCOVERY_VERSION
+    assert cf.get_best_version(legacy_id, "latest")["chunk_count"] == 1
+
+
 def test_upsert_library_rejects_an_unknown_field(tmp_path):
     """Silently swallowing kwargs is how this bug survived three releases.
 
@@ -797,6 +839,83 @@ async def test_search_cached_index_serves_a_library_indexed_on_cf(monkeypatch):
     )
     assert payload["source"] == "cached_index"
     assert payload["results"], "served an empty result set for an indexed library"
+
+
+# ---------------------------------------------------------------------------
+# `get_best_version` parity (#1626).
+#
+# "Best" means best SERVABLE, i.e. indexed. `_search_cached_index` reads
+# `chunk_count` off whatever this returns and re-indexes when it is 0, so a
+# backend that hands back a half-finished version reports a library as
+# unservable while another version could have answered.
+#
+# cf-d1 filtered no status on either branch and never fell back, so the two
+# backends disagreed about which version a library can serve. Same class as
+# #1618 / #1623 / #1624: the shape gate matches method names, not answers.
+# ---------------------------------------------------------------------------
+
+
+def _version_case(db, lib_name, rows):
+    """Build one library with `rows` = [(version, indexed?)]; return its id."""
+    lib_id = db.upsert_library(lib_name, docs_url="https://alpha.dev")
+    for version, indexed in rows:
+        ver_id = db.upsert_version(lib_id, version, docs_url="https://alpha.dev")
+        if indexed:
+            db.add_chunks(ver_id, lib_id, [{"content": f"body of {version}"}])
+            db.mark_version_indexed(ver_id, 1, 1)
+    return lib_id
+
+
+def _best(db, lib_id, target):
+    row = db.get_best_version(lib_id, target)
+    return None if row is None else (row["version"], row["status"])
+
+
+@pytest.mark.parametrize(
+    ("rows", "target", "expected"),
+    [
+        # The exact target is indexed -- serve exactly it.
+        ([("1.0", True)], "1.0", ("1.0", "indexed")),
+        # The exact target exists but never finished indexing, while another
+        # version did. Returning the pending row reports "needs indexing" for a
+        # library that can be served right now; DocsDB falls back instead.
+        ([("1.0", True), ("2.0", False)], "2.0", ("1.0", "indexed")),
+        # Nothing is indexed -- both backends must say so rather than hand back
+        # a row with no chunks behind it.
+        ([("1.0", False)], "1.0", None),
+        # No target: newest indexed version, never a pending one.
+        ([("1.0", True), ("2.0", False)], None, ("1.0", "indexed")),
+    ],
+    ids=["target-indexed", "target-pending-other-indexed", "none-indexed", "no-target"],
+)
+def test_both_backends_pick_the_same_best_version(tmp_path, rows, target, expected):
+    local = DocsDB(tmp_path / "docs.db")
+    local_lib = _version_case(local, "alpha", rows)
+
+    cf = _backend()
+    cf_lib = _version_case(cf, "alpha", rows)
+
+    assert _best(local, local_lib, target) == expected, "SQLite is the reference here"
+    assert _best(cf, cf_lib, target) == expected
+
+
+def test_upsert_version_still_finds_a_pending_row(tmp_path):
+    """`upsert_version` must not be filtered by "best" -- it would duplicate.
+
+    Its existence check is a direct unfiltered lookup on both backends. Routing
+    it through `get_best_version` once the status filter exists would miss a
+    `pending` row and INSERT a second one against
+    `UNIQUE(library_id, version)`, which is why the decoupling lands with the
+    filter rather than after it.
+    """
+    for db in (_backend(), DocsDB(tmp_path / "docs.db")):
+        lib_id = db.upsert_library("alpha", docs_url="https://alpha.dev")
+        first = db.upsert_version(lib_id, "1.0", docs_url="https://alpha.dev")
+
+        # The row is 'pending', so it is invisible to get_best_version...
+        assert db.get_best_version(lib_id, "1.0") is None
+        # ...and must still be reused rather than duplicated.
+        assert db.upsert_version(lib_id, "1.0", docs_url="https://alpha.dev") == first
 
 
 @pytest.mark.parametrize("method", ["export_jsonl", "import_jsonl"])


### PR DESCRIPTION
Closes #1626. Rebased onto `dce4334` (#1628).

Two changes, both the same "cf-d1 answers differently from SQLite for the same store" class as #1618 / #1623 / #1624 / #1625.

## Scope, stated up front

**This does not fix the `fastapi` outage.** It is a correctness/parity fix that closes a real class of failure — an un-indexed or half-indexed version being served, and `upsert_version` colliding on `UNIQUE(library_id, version)` — but the live `indexing_in_progress` symptom was not caused by it. Prod evidence for that claim is at the bottom rather than asserted.

---

## 1. `get_best_version` parity

`DocsDB.get_best_version` (`db.py:1109-1130`) filters `status = 'indexed'` on **both** branches and falls back to the newest indexed version when an exact target is not servable. The cf-d1 one filtered nothing and never fell back.

"Best" has to mean best **servable**. `_search_cached_index` (`server.py:2921-2923`) reads `chunk_count` off whatever this returns and returns `None` — meaning "no cached index", which makes the caller launch a background index — when it is 0. So handing back a version that never finished indexing reports a library as unservable when a different version could have answered it.

### The decoupling has to land *with* the filter, not after it

`db_cf.upsert_version` reused `get_best_version` as its existence check. Adding the status filter alone would make it miss a `pending` row and INSERT a duplicate against `UNIQUE(library_id, version)`. It now issues its own direct **unfiltered** lookup, matching `DocsDB.upsert_version` (`db.py:986-989`):

```python
existing = self._d1.fetchone(
    "SELECT id FROM versions WHERE library_id = ? AND version = ?",
    [library_id, version],
)
```

`test_upsert_version_still_finds_a_pending_row` pins that the two concerns stay separate on both backends, and is RED without the decoupling.

### `test_get_best_version_target_is_optional` — what changed and why

This was **not** a junk test and it is not deleted. It pins a real regression: `config(action="clear")` and `cli.py` call `get_best_version(lib_id)` with no target, and the CF backend once required a second positional argument named `version`, so that call raised `TypeError`. That property is still asserted — both the no-target call and the `target=` keyword call.

What changed is the **fixture**: it now calls `mark_version_indexed` before reading back.

The old fixture created a bare `pending` version and asserted `get_best_version` returned it. That quietly pinned a *second* property the signature fix never intended to assert — that "best version" includes versions which were never indexed. That reading is precisely what made the two backends disagree, and it could only ever have held on cf-d1, since `DocsDB.get_best_version` has always filtered. So the test keeps asserting the thing it was written for and stops asserting the thing it was accidentally holding in place.

### Nine other call sites

They used `get_best_version` as "fetch the row I just created", which is not what the method means. Repaired by intent:

- 6 sites now use the id `upsert_version` already returns.
- 3 sites asserting what `upsert_version` **wrote** (`docs_url`, `version`) read the row directly by id — a different question from what `get_best_version` chooses to **serve**.

### Parity test

`test_both_backends_pick_the_same_best_version` runs one fixture through both backends, asserting SQLite as the reference:

| scenario | expected |
|---|---|
| exact target is indexed | serve exactly it |
| exact target `pending`, another version indexed | fall back to the indexed one |
| nothing indexed | `None` on both |
| no target at all | newest indexed, never a pending row |

RED against the pre-fix `get_best_version` (verified by reverting only that method):

```
FAILED test_both_backends_pick_the_same_best_version[target-pending-other-indexed]
FAILED test_both_backends_pick_the_same_best_version[none-indexed]
FAILED test_upsert_version_still_finds_a_pending_row
3 failed, 2 passed
```

GREEN after: `5 passed`.

---

## 2. Un-normalised library names — closing a data-loss hole opened by #1625

#1625 normalised the lookup key of a table that **is already populated**. On its own that strands any row an older container wrote as `FastAPI`: the normalised read misses it, the next upsert mints a second row, and the first row's chunks become unreachable. A fix that loses a correctly-built index is worse than the bug it fixes.

Chosen remediation: **fallback read + heal-in-place on UPDATE**, no data migration.

- `get_library` tries the exact (indexed) match first, then falls back to `WHERE lower(trim(name)) = ?`.
- `upsert_library`'s UPDATE path rewrites `name = ?` normalised, so a legacy row is repaired the first time it is touched and **keeps its id** — its chunks stay attached.

Why not a `UPDATE libraries SET name = lower(trim(name))` migration: it would also have to merge rows where both variants already exist. `libraries.name` carries only a plain `idx_libraries_name`, not a UNIQUE constraint, so such a migration would silently leave two rows sharing a normalised name rather than failing loudly. Heal-in-place needs no merge step, cannot half-apply, and repairs lazily. It is also the principle #1625 already established: **the UPDATE path is what repairs production, not the INSERT.**

The exact match runs first, so the common path still uses `idx_libraries_name`; the scan is only reached for a library that is genuinely absent or still un-normalised.

`test_a_legacy_unnormalised_row_is_healed_not_orphaned` pins it end-to-end: a row inserted as `"  FastAPI  "` with chunks attached is still found, is healed in place, keeps its id, does not mint a second row, and its chunks stay reachable.

---

## Prod evidence (read live from D1 `wet-docs` before shipping)

Every `libraries` row joined to its `versions` rows and its real `doc_chunks` count:

```
library             dv ver      status     cc chunks   idx_at state    err
cloudflare-d1        0 None     None        -      0     null None
fastapi             27 latest   indexed    50     50 1785732468 running
fastapi:python       0 latest   pending     0      0     null failed   ModuleNotFoundError: No module named 'qwen3_embed'
hermes               0 None     None        -      0     null None
httpx                0 latest   pending     0      0     null running
httpx:python         0 latest   pending     0      0     null None
milvus               0 None     None        -      0     null None
polars               0 None     None        -      0     null None
qdrant               0 None     None        -      0     null None
renovate             0 None     None        -      0     null None
```

**`fastapi` has exactly one version row, and it is `status='indexed'` with `chunk_count=50`.** There is no second version row to shadow it, so `get_best_version(lib_id, None)` returns that indexed row under both the old unfiltered implementation and the new filtered one. **This PR does not change `fastapi`'s behaviour and is not the cause of that outage.**

Two things the same read did establish:

- **`name` normalisation carries no live risk.** 0 of 10 library rows have a name differing from `lower(trim(name))`, so no row needs repair and no migration is required. The heal-in-place path covers the mixed-version rollout window, where an old container can still write a raw name while a new one reads normalised.
- **The metadata loss #1625 fixed was real, not theoretical.** All 10 rows still have NULL `registry` and NULL `canonical_name`. Only `fastapi` has been restamped to `discovery_version = 27`; the other nine are still at 0 and will be healed by #1625's UPDATE path on first touch.

Separately, and outside this PR: `fastapi:python` is a **distinct library row** from `fastapi` (`_do_docs_search` builds `lib_key = f"{library}:{language}"`), and its indexing fails with `ModuleNotFoundError: No module named 'qwen3_embed'`. Any request passing `language=` therefore cannot index on CF at all today. That is an unrelated live defect, filed on its own rather than folded in here.

---

## Verification

- Full suite on top of `dce4334`: `2338 passed, 33 skipped, 140 deselected`
- `ruff check` / `ruff format --check` / `ty check`: clean
- Pre-commit hooks run, none bypassed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
