### PR TITLE
fix: guard slim image local backend fallback

### DIFF
--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -35,6 +35,32 @@ def _has_gguf_support() -> bool:
     return importlib.util.find_spec("llama_cpp") is not None
 
 
+def local_onnx_installed() -> bool:
+    """Whether both local ONNX extras exist in this image.
+
+    The slim container build uninstalls ``qwen3-embed`` and ``onnxruntime``
+    (see ``Dockerfile``), so on that image the local embed/rerank leg is simply
+    absent. Resolving that leg from ``DISABLE_LOCAL_EMBED`` /
+    ``DISABLE_LOCAL_RERANK`` alone made a slim deployment correct only for as
+    long as somebody remembered to set those vars; miss one and the first index
+    attempt died inside the lazy ``from qwen3_embed import ...``, recorded in
+    D1 as ``ModuleNotFoundError: No module named 'qwen3_embed'`` with zero
+    chunks (#1630) -- a hard failure where a keyword-only degrade was available.
+
+    The image is the ground truth, the flag is only a promise about it, so ask
+    the image. ``find_spec`` answers without importing: a full install pays a
+    path lookup and a slim one never touches the missing package.
+    """
+
+    def _package_present(package: str) -> bool:
+        try:
+            return importlib.util.find_spec(package) is not None
+        except (ImportError, ValueError):
+            return False
+
+    return all(_package_present(package) for package in ("qwen3_embed", "onnxruntime"))
+
+
 def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
     """Choose local model variant: GGUF if GPU + llama-cpp, else ONNX."""
     if _detect_gpu() and _has_gguf_support():
@@ -553,15 +579,30 @@ class Settings(BaseSettings):
             "n24q02m/Qwen3-Embedding-0.6B-GGUF",
         )
 
+    def local_embed_available(self) -> bool:
+        """Whether the local ONNX embedding leg is both allowed AND present.
+
+        One predicate for both resolution paths (startup and per-request), so
+        they cannot drift apart again. ``DISABLE_LOCAL_EMBED`` is the operator's
+        answer; :func:`local_onnx_installed` is the image's, and the image gets
+        a veto -- a leg the build removed is not available however the config
+        reads.
+        """
+        return not self.disable_local_embed and local_onnx_installed()
+
+    def local_rerank_available(self) -> bool:
+        """Whether the local ONNX rerank leg is both allowed AND present."""
+        return not self.disable_local_rerank and local_onnx_installed()
+
     def resolve_embedding_backend(self) -> str:
         """Resolve embedding backend: 'cloud', 'local', or 'unavailable'.
 
         3-way resolution via the shared mcp-core primitive:
         - 'cloud'       -- a non-empty EMBEDDING_MODELS chain (with keys).
-        - 'local'       -- empty chain AND the local leg is enabled.
-        - 'unavailable' -- empty chain AND DISABLE_LOCAL_EMBED is set (the
-          local qwen3 ONNX download is skipped and no cloud chain is
-          configured, so embedding is gracefully unavailable -- NOT forced).
+        - 'local'       -- empty chain AND the local leg is enabled and present.
+        - 'unavailable' -- empty chain AND no usable local leg, i.e.
+          DISABLE_LOCAL_EMBED is set OR the slim image has no ``qwen3-embed``
+          installed. Embedding is then gracefully unavailable -- NOT forced.
 
         The deprecated EMBEDDING_BACKEND env var is honored for one release.
         """
@@ -577,7 +618,7 @@ class Settings(BaseSettings):
             )
         return resolve_backend(
             has_cloud_chain=bool(self.embedding_chain()),
-            local_enabled=not self.disable_local_embed,
+            local_enabled=self.local_embed_available(),
         ).value
 
     # --- Reranking resolution ---
@@ -603,8 +644,9 @@ class Settings(BaseSettings):
 
         '' when rerank_enabled is False. Otherwise 3-way via the shared
         mcp-core primitive (same semantics as resolve_embedding_backend, keyed
-        on RERANK_MODELS + DISABLE_LOCAL_RERANK); the deprecated RERANK_BACKEND
-        env var is honored for one release.
+        on RERANK_MODELS + DISABLE_LOCAL_RERANK + whether the slim image kept
+        ``qwen3-embed``); the deprecated RERANK_BACKEND env var is honored for
+        one release.
         """
         if not self.rerank_enabled:
             return ""
@@ -619,7 +661,7 @@ class Settings(BaseSettings):
             )
         return resolve_backend(
             has_cloud_chain=bool(self.rerank_chain()),
-            local_enabled=not self.disable_local_rerank,
+            local_enabled=self.local_rerank_available(),
         ).value
 
     # --- Provider mode resolution ---

--- a/src/wet_mcp/db.py
+++ b/src/wet_mcp/db.py
@@ -972,6 +972,39 @@ class DocsDB:
         ).fetchone()
         return dict(row) if row else None
 
+    def get_library_by_id(self, library_id: str) -> dict | None:
+        """Get a library row by its stable identifier."""
+        row = self._conn.execute(
+            "SELECT * FROM libraries WHERE id = ?", (library_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    def find_libraries_by_prefix(self, name: str, limit: int = 20) -> list[dict]:
+        """Return libraries whose names start with ``name``, alphabetically."""
+        norm_name = name.lower().strip()
+        if not norm_name or limit <= 0:
+            return []
+        rows = self._conn.execute(
+            "SELECT * FROM libraries "
+            "WHERE name LIKE ? AND name != ? "
+            "ORDER BY length(name) ASC, name ASC LIMIT ?",
+            (f"{norm_name}%", norm_name, limit),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def find_libraries_by_substring(self, name: str, limit: int = 20) -> list[dict]:
+        """Return libraries containing ``name`` beyond a prefix match."""
+        norm_name = name.lower().strip()
+        if not norm_name or limit <= 0:
+            return []
+        rows = self._conn.execute(
+            "SELECT * FROM libraries "
+            "WHERE name LIKE ? AND name NOT LIKE ? AND name != ? "
+            "ORDER BY length(name) ASC, name ASC LIMIT ?",
+            (f"%{norm_name}%", f"{norm_name}%", norm_name, limit),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
     # -----------------------------------------------------------------------
     # Version management
     # -----------------------------------------------------------------------

--- a/src/wet_mcp/db_cf.py
+++ b/src/wet_mcp/db_cf.py
@@ -209,6 +209,34 @@ class DocsDBCfBackend:
             )
         return row
 
+    def get_library_by_id(self, library_id: str) -> dict | None:
+        """Get a library row by its stable identifier."""
+        return self._d1.fetchone("SELECT * FROM libraries WHERE id = ?", [library_id])
+
+    def find_libraries_by_prefix(self, name: str, limit: int = 20) -> list[dict]:
+        """Return libraries whose names start with ``name``, alphabetically."""
+        norm_name = name.lower().strip()
+        if not norm_name or limit <= 0:
+            return []
+        return self._d1.fetchall(
+            "SELECT * FROM libraries "
+            "WHERE name LIKE ? AND name != ? "
+            "ORDER BY length(name) ASC, name ASC LIMIT ?",
+            [f"{norm_name}%", norm_name, limit],
+        )
+
+    def find_libraries_by_substring(self, name: str, limit: int = 20) -> list[dict]:
+        """Return libraries containing ``name`` beyond a prefix match."""
+        norm_name = name.lower().strip()
+        if not norm_name or limit <= 0:
+            return []
+        return self._d1.fetchall(
+            "SELECT * FROM libraries "
+            "WHERE name LIKE ? AND name NOT LIKE ? AND name != ? "
+            "ORDER BY length(name) ASC, name ASC LIMIT ?",
+            [f"%{norm_name}%", f"{norm_name}%", norm_name, limit],
+        )
+
     def upsert_version(
         self,
         library_id: str,

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -533,17 +533,18 @@ def resolve_embed_backend_for_request() -> EmbeddingBackend | None:
       provider key is present, build a fresh request-scoped
       :class:`CloudEmbeddingBackend` carrying that sub's key explicitly (so the
       key flows down the call, never into ``os.environ``). With no such chain,
-      fall back to the process-shared local ONNX backend -- unless
-      ``DISABLE_LOCAL_EMBED`` turned that leg off, in which case embedding is
-      ``None``: gracefully unavailable.
+      fall back to the process-shared local ONNX backend -- unless that leg is
+      unavailable, in which case embedding is ``None``: gracefully unavailable.
 
     That last exit is the same three-way resolution
     :meth:`Settings.resolve_embedding_backend` performs at startup, where it
-    is spelled ``'unavailable'``. Keeping the two in step is the whole point:
-    the flag is what a slim deployment sets when the local ONNX extras were
-    never installed, so handing back a backend that raises
-    ``ModuleNotFoundError`` on first use fails the entire index instead of
-    storing keyword-searchable chunks without vectors.
+    is spelled ``'unavailable'``, and it asks the same predicate
+    (:meth:`Settings.local_embed_available`) so the two cannot drift. Both
+    inputs matter: ``DISABLE_LOCAL_EMBED`` is what a slim deployment sets, and
+    whether ``qwen3-embed`` is installed is what is actually true of the image.
+    Consulting only the flag meant a slim image whose operator forgot it handed
+    back a backend that raises ``ModuleNotFoundError`` on first use, failing the
+    entire index instead of storing keyword-searchable chunks without vectors.
 
     ``None`` here, specifically -- NOT the startup singleton. That one was
     resolved from the OPERATOR's process env, and lending it to an arbitrary
@@ -568,9 +569,33 @@ def resolve_embed_backend_for_request() -> EmbeddingBackend | None:
     if chain:
         model = chain[0]
         return CloudEmbeddingBackend(model, api_key=api_key_for_model(model))
-    if settings.disable_local_embed:
+    if not settings.local_embed_available():
         return None
     return _shared_local_embed_backend()
+
+
+def no_local_embed_clause() -> str:
+    """Name the reason the local ONNX embedding leg is out, for a human.
+
+    Three states, three different actions, so they must not share one string.
+    Saying "DISABLE_LOCAL_EMBED is set" on an image that never shipped
+    ``qwen3-embed`` sends the reader after a var they never set -- and having
+    checked it and found it empty, they conclude the message is wrong. The
+    absent-image wording says instead that this is a property of the build, so
+    the answer is "give this deployment a cloud chain", not "unset a flag".
+    """
+    from wet_mcp.config import local_onnx_installed, settings
+
+    if settings.disable_local_embed:
+        return "this deployment runs with DISABLE_LOCAL_EMBED set"
+    if not local_onnx_installed():
+        return (
+            "this image has no local ONNX leg installed (no qwen3-embed or "
+            "onnxruntime, which the slim Cloudflare container build removes "
+            "on purpose)"
+        )
+    # Enabled and installed, yet nothing was resolved: it broke on load.
+    return "the local ONNX leg failed to load"
 
 
 def embedding_unavailable_reason() -> str | None:
@@ -592,14 +617,15 @@ def embedding_unavailable_reason() -> str | None:
     if get_current_sub() is None:
         return (
             "no embedding backend was initialised at startup: no EMBEDDING_MODELS "
-            "chain with a configured provider key, and the local ONNX leg is "
-            "disabled (DISABLE_LOCAL_EMBED) or failed to load"
+            f"chain with a configured provider key, and {no_local_embed_clause()}"
         )
-    # The only ``None`` exit left for a request that HAS a sub.
+    # The only ``None`` exit left for a request that HAS a sub. (The clause's
+    # "failed to load" state cannot be reached from here: a usable local leg
+    # would have been returned as the backend.)
     return (
         "this session has no cloud embedding model configured (set "
-        "EMBEDDING_MODELS plus the matching provider key) and this deployment "
-        "runs with DISABLE_LOCAL_EMBED set, so there is no local fallback"
+        "EMBEDDING_MODELS plus the matching provider key) and "
+        f"{no_local_embed_clause()}, so there is no local fallback"
     )
 
 

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -513,6 +513,12 @@ def get_backend() -> EmbeddingBackend | None:
     return _backend
 
 
+def clear_backend() -> None:
+    """Clear the startup singleton after backend validation fails."""
+    global _backend
+    _backend = None
+
+
 def _shared_local_embed_backend() -> Qwen3EmbedBackend:
     """Return the process-shared local ONNX embedding backend (lazy)."""
     global _shared_local_backend

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -261,16 +261,19 @@ def resolve_rerank_backend_for_request() -> RerankerBackend | None:
       sub's credential bucket. If the sub has a cloud rerank chain whose
       provider key is present, build a fresh request-scoped
       :class:`CloudReranker` carrying that sub's key explicitly. With no such
-      chain, fall back to the process-shared local ONNX reranker -- unless
-      ``DISABLE_LOCAL_RERANK`` turned that leg off, in which case reranking is
-      ``None``: gracefully unavailable.
+      chain, fall back to the process-shared local ONNX reranker -- unless that
+      leg is unavailable, in which case reranking is ``None``: gracefully
+      unavailable.
 
-    The disable-local exit mirrors :meth:`Settings.resolve_rerank_backend`,
-    which spells it ``'unavailable'`` at startup. It matters more here than the
-    traceback suggests: :meth:`Qwen3Reranker.rerank` swallows its own load
-    failure and returns ``[]``, so a local reranker on an image built without
-    the ONNX extras degrades every search to unranked order behind one log
-    line, quietly, forever. Returning ``None`` says the same thing out loud.
+    The unavailable exit mirrors :meth:`Settings.resolve_rerank_backend`, which
+    spells it ``'unavailable'`` at startup, via the shared
+    :meth:`Settings.local_rerank_available` predicate -- so it covers both
+    ``DISABLE_LOCAL_RERANK`` and an image the slim build stripped
+    ``qwen3-embed`` out of. It matters more here than the traceback suggests:
+    :meth:`Qwen3Reranker.rerank` swallows its own load failure and returns
+    ``[]``, so a local reranker on an image built without the ONNX extras
+    degrades every search to unranked order behind one log line, quietly,
+    forever. Returning ``None`` says the same thing out loud.
 
     ``None``, not the startup singleton -- that one carries the OPERATOR's key
     and must not be spent on an arbitrary sub.
@@ -296,7 +299,7 @@ def resolve_rerank_backend_for_request() -> RerankerBackend | None:
     if chain:
         model = chain[0]
         return CloudReranker(model=model, api_key=api_key_for_model(model))
-    if settings.disable_local_rerank:
+    if not settings.local_rerank_available():
         return None
     return _shared_local_reranker()
 

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -243,6 +243,12 @@ def get_reranker() -> RerankerBackend | None:
     return _backend
 
 
+def clear_reranker() -> None:
+    """Clear the startup singleton after backend validation fails."""
+    global _backend
+    _backend = None
+
+
 def _shared_local_reranker() -> Qwen3Reranker:
     """Return the process-shared local ONNX reranker backend (lazy)."""
     global _shared_local_backend

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -596,7 +596,7 @@ async def _init_embedding_backend(mode: str) -> None:
     """
     global _embedding_dims
     from wet_mcp.credential_state import CredentialState, get_state
-    from wet_mcp.embedder import init_backend, no_local_embed_clause
+    from wet_mcp.embedder import clear_backend, init_backend, no_local_embed_clause
 
     cred_state = get_state()
 
@@ -638,8 +638,10 @@ async def _init_embedding_backend(mode: str) -> None:
                     f"(native={native_dims}, stored={_embedding_dims})"
                 )
             else:
+                clear_backend()
                 logger.error("Local embedding model not available")
         except Exception as e:
+            clear_backend()
             logger.error(f"Local embedding init failed: {e}")
         return
 
@@ -657,7 +659,9 @@ async def _init_embedding_backend(mode: str) -> None:
                     f"(native={native_dims}, stored={_embedding_dims})"
                 )
                 return
+            clear_backend()
         except Exception as e:
+            clear_backend()
             logger.warning(f"Embedding model {candidate} not available: {e}")
 
     logger.error("Cloud embedding not available and local fallback is disabled")
@@ -690,7 +694,7 @@ async def _init_reranker_backend(mode: str) -> None:
         )
         return
 
-    from wet_mcp.reranker import init_reranker
+    from wet_mcp.reranker import clear_reranker, init_reranker
 
     if cred_state == CredentialState.LOCAL or rerank_backend_type == "local":
         if not settings.local_rerank_available():
@@ -712,8 +716,10 @@ async def _init_reranker_backend(mode: str) -> None:
             if available:
                 logger.info(f"Reranker: local {local_model}")
             else:
+                clear_reranker()
                 logger.error("Local reranker not available")
         except Exception as e:
+            clear_reranker()
             logger.error(f"Local reranker init failed: {e}")
         return
 
@@ -726,7 +732,9 @@ async def _init_reranker_backend(mode: str) -> None:
             if available:
                 logger.info(f"Reranker: {model} (cloud)")
                 return
+            clear_reranker()
         except Exception as e:
+            clear_reranker()
             logger.warning(f"Cloud reranker {model} not available: {e}")
 
     logger.error("Cloud reranker not available and local fallback is disabled")

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -596,7 +596,7 @@ async def _init_embedding_backend(mode: str) -> None:
     """
     global _embedding_dims
     from wet_mcp.credential_state import CredentialState, get_state
-    from wet_mcp.embedder import init_backend
+    from wet_mcp.embedder import init_backend, no_local_embed_clause
 
     cred_state = get_state()
 
@@ -613,6 +613,18 @@ async def _init_embedding_backend(mode: str) -> None:
         return
 
     if cred_state == CredentialState.LOCAL or backend_type == "local":
+        if not settings.local_embed_available():
+            # Only reachable through the cred_state disjunct: whenever the
+            # local leg is out and no cloud chain exists, backend_type is
+            # already 'unavailable' and returned above. Building it anyway
+            # installed a singleton whose FIRST USE raises -- and, not being
+            # None, it also defeats the `is None` guard the background indexer
+            # uses to degrade loudly instead of dying (#1630).
+            logger.error(
+                "Embedding: local backend requested but unavailable "
+                f"({no_local_embed_clause()}); none initialised"
+            )
+            return
         local_model = settings.resolve_local_embedding_model()
         _maybe_register_custom_embed(local_model)
         try:
@@ -681,6 +693,17 @@ async def _init_reranker_backend(mode: str) -> None:
     from wet_mcp.reranker import init_reranker
 
     if cred_state == CredentialState.LOCAL or rerank_backend_type == "local":
+        if not settings.local_rerank_available():
+            # Same landmine as the embedding path above: an installed-but-
+            # unusable singleton reads as "reranking is configured" everywhere
+            # downstream, and Qwen3Reranker.rerank swallows its own load
+            # failure, so every search silently returns unranked order.
+            logger.error(
+                "Reranker: local backend requested but unavailable "
+                "(DISABLE_LOCAL_RERANK set, or no qwen3-embed installed in "
+                "this image); none initialised"
+            )
+            return
         local_model = settings.resolve_local_rerank_model()
         _maybe_register_custom_rerank(local_model)
         try:
@@ -2794,6 +2817,12 @@ async def _background_index_and_search(
 
         # Generate embeddings
         embeddings = None
+        # Set when the chunks are about to be stored without vectors. The log
+        # lines below never leave the container -- which is the whole reason
+        # #1630 needed a D1 query to diagnose -- so the reason is recorded on
+        # the version too, where `config(action="status")` and the docs query
+        # path can both read it back.
+        keyword_only_reason: str | None = None
         if all_chunks:
             from wet_mcp.embedder import (
                 embedding_unavailable_reason,
@@ -2806,6 +2835,11 @@ async def _background_index_and_search(
                 # vectors behind them. Same reasoning as the timeout branch
                 # below -- an unremarked swap here is a store that looks
                 # healthy and answers half as well.
+                keyword_only_reason = (
+                    f"indexed keyword-only: {len(all_chunks)} chunks stored "
+                    "WITHOUT vectors because embedding was unavailable "
+                    f"({embedding_unavailable_reason()})"
+                )
                 logger.warning(
                     f"Embedding unavailable while indexing '{library}' from "
                     f"{docs_url}: {embedding_unavailable_reason()}. "
@@ -2833,6 +2867,11 @@ async def _background_index_and_search(
                     # stay keyword-searchable), but the version is then stamped
                     # 'indexed' with a full chunk_count while holding zero
                     # vectors. Without this line that swap is invisible.
+                    keyword_only_reason = (
+                        f"indexed keyword-only: {len(embed_texts_list)} chunks "
+                        "stored WITHOUT vectors because the embedding batch "
+                        f"timed out after {_EMBED_TIMEOUT}s"
+                    )
                     logger.error(
                         f"Embedding batch timed out after {_EMBED_TIMEOUT}s for "
                         f"'{library}' ({len(embed_texts_list)} chunks from "
@@ -2865,7 +2904,12 @@ async def _background_index_and_search(
         # `versions` (the table is UNIQUE(library_id, version)) and a
         # hardcoded 1 would be wrong.
         _docs_db.mark_library_indexed(lib_id)
-        _record_index_state(ver_id, INDEX_STATE_DONE)
+        # 'done' with a note, not 'failed': the chunks ARE there and ARE
+        # served. `set_index_state` writes the note to `index_error`, which the
+        # status payload surfaces for every state -- while `_docs_indexing_message`
+        # only quotes it for 'failed', so a healthy-but-degraded version is
+        # never reported to a caller as a failed one.
+        _record_index_state(ver_id, INDEX_STATE_DONE, keyword_only_reason)
         logger.info(
             f"Background indexing complete for '{library}'. Pages: {page_count}, Chunks: {len(all_chunks)}"
         )

--- a/src/wet_mcp/sources/docs.py
+++ b/src/wet_mcp/sources/docs.py
@@ -3919,12 +3919,7 @@ def resolve_library(db: Any, name: str, limit: int = 5) -> list[dict]:
         return out
 
     # Prefix match — bounded by limit*4 candidate scan to keep query cheap.
-    prefix_rows = db._conn.execute(
-        "SELECT * FROM libraries "
-        "WHERE name LIKE ? AND name != ? "
-        "ORDER BY length(name) ASC, name ASC LIMIT ?",
-        (f"{norm}%", norm, limit * 4),
-    ).fetchall()
+    prefix_rows = db.find_libraries_by_prefix(norm, limit=limit * 4)
     for row in prefix_rows:
         if len(out) >= limit:
             break
@@ -3939,12 +3934,7 @@ def resolve_library(db: Any, name: str, limit: int = 5) -> list[dict]:
 
     # Substring fallback (broad). Skip if exact-only requested via limit=1.
     if limit > 1:
-        substring_rows = db._conn.execute(
-            "SELECT * FROM libraries "
-            "WHERE name LIKE ? AND name NOT LIKE ? AND name != ? "
-            "ORDER BY length(name) ASC, name ASC LIMIT ?",
-            (f"%{norm}%", f"{norm}%", norm, limit * 4),
-        ).fetchall()
+        substring_rows = db.find_libraries_by_substring(norm, limit=limit * 4)
         for row in substring_rows:
             if len(out) >= limit:
                 break
@@ -4006,9 +3996,7 @@ def query_docs(
     opt = options or DocsQueryOptions()
 
     # Hydrate library + version metadata.
-    lib_row = db._conn.execute(
-        "SELECT * FROM libraries WHERE id = ?", (library_id,)
-    ).fetchone()
+    lib_row = db.get_library_by_id(library_id)
     if lib_row is None:
         return []
     library_name = lib_row["name"]

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -8,6 +8,7 @@ from mcp_core.storage.vectorize import VectorizeBackend
 
 from wet_mcp.db import DocsDB
 from wet_mcp.db_cf import DocsDBCfBackend
+from wet_mcp.sources.docs import DocsQueryOptions, query_docs, resolve_library
 
 # The D1 schema now spans more than one migration (0002 adds project_context and
 # libraries.metadata_seeded_at), so apply them all in order rather than pinning 0001.
@@ -83,6 +84,36 @@ def test_stats_reports_counts():
     assert s["libraries"] == 1
     assert s["chunks"] == 1
     assert s["vec_enabled"] is True
+
+
+def test_resolve_library_uses_cf_backend_for_prefix_and_substring():
+    db = _backend()
+    db.upsert_library("next")
+    db.upsert_library("nextflow")
+    db.upsert_library("my-react-lib")
+
+    prefix = resolve_library(db, "next")
+    substring = resolve_library(db, "react")
+
+    assert [item["name"] for item in prefix] == ["next", "nextflow"]
+    assert [item["name"] for item in substring] == ["my-react-lib"]
+
+
+def test_query_docs_hydrates_library_through_cf_backend_api():
+    db = _backend()
+    lib_id = db.upsert_library("alpha")
+    ver_id = db.upsert_version(lib_id, "1.0")
+    db.add_chunks(
+        ver_id,
+        lib_id,
+        [{"url": "https://a/p1", "content": "async function handler"}],
+        embeddings=None,
+    )
+    db.mark_version_indexed(ver_id, page_count=1, chunk_count=1)
+
+    results = query_docs(db, lib_id, "function", options=DocsQueryOptions(limit=1))
+
+    assert results and results[0]["library"] == "alpha"
 
 
 def test_hybrid_search_applies_rrf_and_url_diversity():

--- a/tests/test_embed_rerank_cloud.py
+++ b/tests/test_embed_rerank_cloud.py
@@ -1,3 +1,4 @@
+import importlib.util
 import sys
 import unittest.mock
 
@@ -35,3 +36,13 @@ def test_cloud_config_no_local_model_download(monkeypatch):
     s = Settings()
     assert s.resolve_embedding_backend() == "cloud"
     fake_qwen.assert_not_called()
+
+
+def test_local_onnx_presence_treats_broken_module_specs_as_unavailable(monkeypatch):
+    from wet_mcp.config import local_onnx_installed
+
+    for error in (ValueError("__spec__ is unset"), ImportError()):
+        find_spec = unittest.mock.Mock(side_effect=error)
+        monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+
+        assert local_onnx_installed() is False

--- a/tests/test_slim_image_missing_local_extras.py
+++ b/tests/test_slim_image_missing_local_extras.py
@@ -1,0 +1,418 @@
+"""The local ONNX leg must be resolved from the IMAGE, not only from a flag.
+
+The http-slim build uninstalls ``qwen3-embed`` and ``onnxruntime`` (see
+``Dockerfile``), so on that image the local embed/rerank leg does not exist --
+whatever the configuration says. Every resolver in the codebase decided the
+question from ``DISABLE_LOCAL_EMBED`` / ``DISABLE_LOCAL_RERANK`` alone, which
+makes a slim deployment correct only for as long as somebody remembers to set
+those vars. Forget one, or run the slim image outside the Cloudflare worker
+that supplies them, and the first index attempt dies inside the lazy import in
+``Qwen3EmbedBackend._get_model``. Live prod D1 recorded exactly that (#1630)::
+
+    fastapi:python  pending  0 chunks  failed
+        ModuleNotFoundError: No module named 'qwen3_embed'
+
+-- a hard failure with zero chunks, where the same request had a perfectly good
+keyword-only degrade available to it.
+
+These tests pin the fix at four levels: the per-request resolvers, the reason
+string a caller is told, the durable record the background indexer leaves in
+``versions.index_error``, and the startup path that used to install a backend
+it had already proved could not load.
+
+Both ``qwen3_embed`` and ``onnxruntime`` ARE installed in the dev venv, so the
+slim container cannot be reproduced by simply not having them. The
+``slim_image`` fixture simulates both packages on two channels at once:
+``find_spec`` answers "absent" (what the fix is supposed to consult) and
+``__import__`` raises (what the old code hit). Recording every attempted import
+is what lets these tests assert the local leg was never entered, rather than
+merely that the return value looked right.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+from unittest.mock import AsyncMock
+
+import pytest
+
+from wet_mcp import server
+from wet_mcp.credential_state import CLOUD_KEYS, set_current_sub, store_for_sub
+from wet_mcp.db import INDEX_STATE_DONE, INDEX_STATE_RUNNING, DocsDB
+
+# Captured at collection time, BEFORE conftest's autouse ``_stub_phase2_lifespan_hooks``
+# replaces both factories with MagicMocks that report a healthy backend and never
+# touch the module singleton. Under that stub the startup tests below pass on
+# unfixed code, asserting nothing. Its docstring says as much: "Tests that
+# exercise these init factories patch the same targets themselves."
+from wet_mcp.embedder import init_backend as _REAL_INIT_BACKEND
+from wet_mcp.reranker import init_reranker as _REAL_INIT_RERANKER
+
+DOCS_URL = "https://example.test/alpha"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """No provider keys, no chains, and both disable-local flags OFF.
+
+    The flags being off is the whole point: this module covers the deployment
+    that never set them and is nonetheless running an image without the local
+    extras.
+    """
+    monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CREDENTIAL_SECRET", "s")
+    set_current_sub(None)
+    for k in (*CLOUD_KEYS, "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    for k in ("EMBEDDING_MODELS", "RERANK_MODELS", "LLM_MODELS"):
+        monkeypatch.delenv(k, raising=False)
+
+    from wet_mcp import embedder, reranker
+    from wet_mcp.config import settings
+
+    monkeypatch.setattr(settings, "disable_local_embed", False)
+    monkeypatch.setattr(settings, "disable_local_rerank", False)
+    monkeypatch.setattr(settings, "embedding_models", "")
+    monkeypatch.setattr(settings, "rerank_models", "")
+    # Process-wide singletons; a leftover from another module would make these
+    # assertions pass or fail for the wrong reason.
+    monkeypatch.setattr(embedder, "_shared_local_backend", None)
+    monkeypatch.setattr(reranker, "_shared_local_backend", None)
+    monkeypatch.setattr(embedder, "_backend", None)
+    monkeypatch.setattr(reranker, "_backend", None)
+    yield
+    set_current_sub(None)
+
+
+@pytest.fixture
+def slim_image(monkeypatch):
+    """Make both local ONNX packages absent as the slim build leaves them.
+
+    Returns the list of import names the code under test asked for; an empty
+    list is the assertion that the local leg was never entered at all.
+    """
+    real_import = builtins.__import__
+    real_find_spec = importlib.util.find_spec
+    attempted: list[str] = []
+    missing = ("qwen3_embed", "onnxruntime")
+
+    def _guarded_import(name, *args, **kwargs):
+        if any(
+            name == package or name.startswith(f"{package}.") for package in missing
+        ):
+            attempted.append(name)
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return real_import(name, *args, **kwargs)
+
+    def _guarded_find_spec(name, *args, **kwargs):
+        if any(
+            name == package or name.startswith(f"{package}.") for package in missing
+        ):
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _guarded_import)
+    monkeypatch.setattr(importlib.util, "find_spec", _guarded_find_spec)
+    return attempted
+
+
+# ---------------------------------------------------------------------------
+# Per-request resolution
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedResolutionOnASlimImage:
+    def test_absent_local_extras_resolve_to_none_without_any_flag(self, slim_image):
+        """The flag is unset; the package is gone. That is still 'unavailable'."""
+        from wet_mcp.embedder import resolve_embed_backend_for_request
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert resolve_embed_backend_for_request() is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_index_batch_degrades_instead_of_raising(self, slim_image):
+        """``_embed_batch`` is what the background indexer calls.
+
+        On main this raises ``ModuleNotFoundError`` straight through
+        ``_embed_batch``'s permanent-error branch, which is how the failure
+        reached D1 as the version's ``index_error``.
+        """
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert await server._embed_batch(["a", "b"]) is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_query_embed_degrades_instead_of_raising(self, slim_image):
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert await server._embed("hello", is_query=True) is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    def test_reason_names_the_missing_package_not_a_flag_nobody_set(self, slim_image):
+        """A reason must be true. ``DISABLE_LOCAL_EMBED`` is not set here.
+
+        Telling an operator to look at a flag they never touched sends them
+        after the wrong thing; the actionable fact is that the image has no
+        local extras, so the deployment needs a cloud chain.
+        """
+        from wet_mcp.embedder import embedding_unavailable_reason
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        reason = embedding_unavailable_reason()
+        assert reason is not None
+        assert "qwen3-embed" in reason
+        assert "onnxruntime" in reason
+        # Named as a property of the build, so the reader looks for a cloud
+        # chain rather than a flag to unset.
+        assert "slim" in reason
+        assert "DISABLE_LOCAL_EMBED" not in reason
+
+    def test_reason_still_names_the_flag_when_the_flag_is_what_did_it(
+        self, monkeypatch
+    ):
+        """Control for the branch above: the flag wording must not be lost."""
+        from wet_mcp.config import settings
+        from wet_mcp.embedder import embedding_unavailable_reason
+
+        monkeypatch.setattr(settings, "disable_local_embed", True)
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        reason = embedding_unavailable_reason()
+        assert reason is not None
+        assert "DISABLE_LOCAL_EMBED" in reason
+        assert "qwen3-embed" not in reason
+
+    def test_installed_local_extras_are_still_used(self):
+        """No regression: a full image with the flag off keeps its local leg."""
+        from wet_mcp import embedder
+        from wet_mcp.embedder import Qwen3EmbedBackend
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        backend = embedder.resolve_embed_backend_for_request()
+        assert isinstance(backend, Qwen3EmbedBackend)
+        assert backend is embedder.resolve_embed_backend_for_request()
+
+
+class TestRerankResolutionOnASlimImage:
+    def test_absent_local_extras_resolve_to_none_without_any_flag(self, slim_image):
+        from wet_mcp.reranker import resolve_rerank_backend_for_request
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert resolve_rerank_backend_for_request() is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_rerank_returns_unranked_order_touching_nothing(self, slim_image):
+        """``Qwen3Reranker.rerank`` swallows its own load failure and returns
+        ``[]``, so the broken leg is invisible in the result. The import list is
+        the only thing that can tell "skipped" from "failed quietly"."""
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        results = [{"content": "doc-a"}, {"content": "doc-b"}]
+        assert await server._rerank_results("q", results, top_n=1) == [
+            {"content": "doc-a"}
+        ]
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    def test_installed_local_extras_are_still_used(self):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import Qwen3Reranker
+
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        assert isinstance(reranker.resolve_rerank_backend_for_request(), Qwen3Reranker)
+
+
+# ---------------------------------------------------------------------------
+# The durable record -- the D1 row from the issue
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def docs_db(tmp_path, monkeypatch):
+    """A real store, so the outcome is asserted where an operator reads it."""
+    db = DocsDB(tmp_path / "docs.db", embedding_dims=0)
+    monkeypatch.setattr(server, "_docs_db", db)
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def no_searxng(monkeypatch):
+    """Keep the indexer's alternate-source leg off the network."""
+    monkeypatch.setattr(
+        server,
+        "ensure_searxng",
+        AsyncMock(side_effect=RuntimeError("searxng disabled in tests")),
+    )
+
+
+def _fresh_version(db: DocsDB):
+    """A never-indexed version, as ``fastapi:python`` was in prod."""
+    lib_id = db.upsert_library(name="alpha", docs_url=DOCS_URL)
+    ver_id = db.upsert_version(library_id=lib_id, version="latest", docs_url=DOCS_URL)
+    db.set_index_state(ver_id, INDEX_STATE_RUNNING)
+    return lib_id, ver_id
+
+
+def _chunks(n: int):
+    return [
+        {
+            "url": f"{DOCS_URL}/page",
+            "title": "T",
+            "chunk_index": i,
+            "content": f"chunk body number {i}",
+            "heading_path": "T",
+        }
+        for i in range(n)
+    ]
+
+
+class TestBackgroundIndexerOnASlimImage:
+    async def test_it_stores_keyword_only_chunks_and_records_why(
+        self, docs_db, no_searxng, slim_image, monkeypatch
+    ):
+        """The exact prod row, inverted.
+
+        Before: ``state=failed``, ``error='ModuleNotFoundError: No module named
+        'qwen3_embed''``, ``chunk_count=0`` -- the library unservable forever.
+        After: the chunks land keyword-searchable and the version says, where
+        ``config(action="status")`` and D1 both show it, that it holds no
+        vectors and why. Storing them silently would trade a loud failure for a
+        quiet one, which is the outcome this test exists to forbid.
+        """
+        lib_id, ver_id = _fresh_version(docs_db)
+        monkeypatch.setattr(
+            server, "_fetch_and_chunk_docs", AsyncMock(return_value=(_chunks(2), 3))
+        )
+        store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
+        set_current_sub("user_a")
+
+        await server._background_index_and_search(
+            library="alpha",
+            lib_key="alpha",
+            language=None,
+            docs_url=DOCS_URL,
+            repo_url="",
+            query="how to install",
+            version=None,
+            lib_id=lib_id,
+            ver_id=ver_id,
+        )
+
+        state = docs_db.get_index_state(ver_id)
+        assert state is not None, "the attempt left no record at all"
+        assert state["state"] == INDEX_STATE_DONE
+        assert state["chunk_count"] == 2, "the keyword-searchable chunks were lost"
+        assert docs_db.search("chunk body", library_name="alpha")
+
+        error = state["error"] or ""
+        assert "ModuleNotFoundError" not in error
+        assert "qwen3-embed" in error
+        assert "keyword" in error.lower(), (
+            "the record must say the version holds no vectors, not just that "
+            f"something was off: {error!r}"
+        )
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_a_fully_embedded_index_records_no_complaint(
+        self, docs_db, no_searxng, monkeypatch
+    ):
+        """Control: the happy path must not grow a spurious error string."""
+        from wet_mcp import embedder
+
+        lib_id, ver_id = _fresh_version(docs_db)
+        monkeypatch.setattr(
+            server, "_fetch_and_chunk_docs", AsyncMock(return_value=(_chunks(2), 3))
+        )
+        # A resolvable backend, or the indexer takes the keyword-only branch
+        # before it ever calls _embed_batch.
+        embed_backend = AsyncMock()
+        embed_backend.embed_texts = AsyncMock(return_value=[[0.1] * 4] * 2)
+        monkeypatch.setattr(embedder, "_backend", embed_backend)
+
+        await server._background_index_and_search(
+            library="alpha",
+            lib_key="alpha",
+            language=None,
+            docs_url=DOCS_URL,
+            repo_url="",
+            query="how to install",
+            version=None,
+            lib_id=lib_id,
+            ver_id=ver_id,
+        )
+
+        state = docs_db.get_index_state(ver_id)
+        assert state["state"] == INDEX_STATE_DONE
+        assert state["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# Startup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_backend_factories(monkeypatch):
+    """Undo conftest's blanket stubbing of the two init factories.
+
+    Without this the code under test never runs at all.
+    """
+    from wet_mcp import embedder, reranker
+
+    monkeypatch.setattr(embedder, "init_backend", _REAL_INIT_BACKEND)
+    monkeypatch.setattr(reranker, "init_reranker", _REAL_INIT_RERANKER)
+
+
+class TestStartupNeverInstallsABackendItCannotLoad:
+    async def test_local_backend_is_not_installed_when_the_package_is_absent(
+        self, slim_image, real_backend_factories, monkeypatch
+    ):
+        """``init_backend`` assigns the singleton BEFORE anything validates it.
+
+        With the extras gone, ``check_available()`` fails, the failure is
+        logged -- and the unusable backend stays installed as the process
+        singleton, so every later request resolves to an object whose first use
+        raises. It also defeats the ``is None`` guard in the indexer, which is
+        the one place written to produce a loud, informative degrade.
+        """
+        from wet_mcp import credential_state, embedder
+        from wet_mcp.credential_state import CredentialState
+
+        monkeypatch.setattr(
+            credential_state, "get_state", lambda: CredentialState.LOCAL
+        )
+
+        await server._init_embedding_backend("local")
+
+        assert embedder.get_backend() is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_local_reranker_is_not_installed_when_the_package_is_absent(
+        self, slim_image, real_backend_factories, monkeypatch
+    ):
+        from wet_mcp import credential_state, reranker
+        from wet_mcp.credential_state import CredentialState
+
+        monkeypatch.setattr(
+            credential_state, "get_state", lambda: CredentialState.LOCAL
+        )
+
+        await server._init_reranker_backend("local")
+
+        assert reranker.get_reranker() is None
+        assert slim_image == [], f"local ONNX leg was entered: {slim_image}"

--- a/tests/test_slim_image_missing_local_extras.py
+++ b/tests/test_slim_image_missing_local_extras.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -379,6 +379,22 @@ def real_backend_factories(monkeypatch):
 
 
 class TestStartupNeverInstallsABackendItCannotLoad:
+    @staticmethod
+    def _enable_local_startup(monkeypatch):
+        from wet_mcp.config import settings
+
+        monkeypatch.setattr(type(settings), "local_embed_available", lambda self: True)
+        monkeypatch.setattr(type(settings), "local_rerank_available", lambda self: True)
+
+    @staticmethod
+    def _set_local_credential_state(monkeypatch):
+        from wet_mcp import credential_state
+        from wet_mcp.credential_state import CredentialState
+
+        monkeypatch.setattr(
+            credential_state, "get_state", lambda: CredentialState.LOCAL
+        )
+
     async def test_local_backend_is_not_installed_when_the_package_is_absent(
         self, slim_image, real_backend_factories, monkeypatch
     ):
@@ -402,6 +418,40 @@ class TestStartupNeverInstallsABackendItCannotLoad:
         assert embedder.get_backend() is None
         assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
 
+    async def test_local_backend_is_cleared_when_availability_check_returns_false(
+        self, real_backend_factories, monkeypatch
+    ):
+        from wet_mcp import embedder
+        from wet_mcp.embedder import Qwen3EmbedBackend
+
+        self._enable_local_startup(monkeypatch)
+        self._set_local_credential_state(monkeypatch)
+        monkeypatch.setattr(
+            Qwen3EmbedBackend, "check_available", AsyncMock(return_value=0)
+        )
+
+        await server._init_embedding_backend("local")
+
+        assert embedder.get_backend() is None
+
+    async def test_local_backend_is_cleared_when_availability_check_raises(
+        self, real_backend_factories, monkeypatch
+    ):
+        from wet_mcp import embedder
+        from wet_mcp.embedder import Qwen3EmbedBackend
+
+        self._enable_local_startup(monkeypatch)
+        self._set_local_credential_state(monkeypatch)
+        monkeypatch.setattr(
+            Qwen3EmbedBackend,
+            "check_available",
+            AsyncMock(side_effect=RuntimeError("embedding unavailable")),
+        )
+
+        await server._init_embedding_backend("local")
+
+        assert embedder.get_backend() is None
+
     async def test_local_reranker_is_not_installed_when_the_package_is_absent(
         self, slim_image, real_backend_factories, monkeypatch
     ):
@@ -416,3 +466,35 @@ class TestStartupNeverInstallsABackendItCannotLoad:
 
         assert reranker.get_reranker() is None
         assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
+
+    async def test_local_reranker_is_cleared_when_availability_check_returns_false(
+        self, real_backend_factories, monkeypatch
+    ):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import Qwen3Reranker
+
+        self._enable_local_startup(monkeypatch)
+        self._set_local_credential_state(monkeypatch)
+        monkeypatch.setattr(Qwen3Reranker, "check_available", Mock(return_value=False))
+
+        await server._init_reranker_backend("local")
+
+        assert reranker.get_reranker() is None
+
+    async def test_local_reranker_is_cleared_when_availability_check_raises(
+        self, real_backend_factories, monkeypatch
+    ):
+        from wet_mcp import reranker
+        from wet_mcp.reranker import Qwen3Reranker
+
+        self._enable_local_startup(monkeypatch)
+        self._set_local_credential_state(monkeypatch)
+        monkeypatch.setattr(
+            Qwen3Reranker,
+            "check_available",
+            Mock(side_effect=RuntimeError("reranker unavailable")),
+        )
+
+        await server._init_reranker_backend("local")
+
+        assert reranker.get_reranker() is None


### PR DESCRIPTION
## Summary
- resolve local embedding and reranking only when both qwen3-embed and onnxruntime are present
- degrade missing local extras to keyword-only indexing and persist the reason
- prevent startup from installing unavailable local backend singletons
- route library resolution and docs-query hydration through backend-neutral SQLite/CF-D1 APIs; add CF-D1 regressions

Related to #1630.

## Verification
- local pre-commit: gitleaks, ruff lint/format, ty, pytest, whitespace/conflict/Unicode checks all passed
- local focused regression: 20 passed; full pytest hook: 2349 passed, 35 skipped, 140 deselected
- commits: 2cbd530, f093783, 0e2335c

## Release note
This PR is code-level remediation. Beta, Test B, stable, and post-verify remain gated by the repository-wide mcp-core release gate and will be reported separately.