### PR TITLE
feat: lock wet tool names through protocol

### DIFF
--- a/tests/test_live_protocol.py
+++ b/tests/test_live_protocol.py
@@ -83,7 +83,14 @@ class TestMeta:
     async def test_list_tools(self, mcp_session: ClientSession):
         result = await mcp_session.list_tools()
         tool_names = sorted(t.name for t in result.tools)
-        expected = ["config", "extract", "help", "media", "search"]
+        expected = [
+            "config",
+            "config__open_relay",
+            "extract",
+            "help",
+            "media",
+            "search",
+        ]
         assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 

--- a/tests/test_tool_names.py
+++ b/tests/test_tool_names.py
@@ -1,0 +1,49 @@
+"""Protocol contract for the tool names exposed by wet-mcp."""
+
+import os
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+pytestmark = pytest.mark.timeout(60)
+
+EXPECTED_NAMES = [
+    "config",
+    "config__open_relay",
+    "extract",
+    "help",
+    "media",
+    "search",
+]
+RETIRED_NAMES: list[str] = []
+
+
+async def _list_tool_names() -> list[str]:
+    params = StdioServerParameters(
+        command="uv",
+        args=["run", "wet-mcp"],
+        env={
+            **os.environ,
+            "LOG_LEVEL": "WARNING",
+            "DISABLE_LOCAL_EMBED": "true",
+            "DISABLE_LOCAL_RERANK": "true",
+            "DISABLE_LOCAL_SEARCH": "true",
+            "WET_AUTO_SEARXNG": "false",
+        },
+    )
+    async with stdio_client(params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            return sorted(tool.name for tool in (await session.list_tools()).tools)
+
+
+@pytest.mark.asyncio
+async def test_exposes_exactly_the_names_from_the_protocol_contract():
+    assert await _list_tool_names() == EXPECTED_NAMES
+
+
+@pytest.mark.asyncio
+async def test_no_retired_name_is_still_exposed():
+    names = await _list_tool_names()
+    assert not [name for name in RETIRED_NAMES if name in names]


### PR DESCRIPTION
The protocol surface exposes six names: config, config__open_relay, extract, help, media, and search. The shared config__open_relay tool is documented as a common-layer STANDARD_GAPS exception and is intentionally unchanged. This surgical branch is based on current main and only updates the stale protocol expectation plus an exact-name/no-retired-name contract test. Local pre-commit passed with the full repository gate.