### PR TITLE
fix: disable legacy sync on Cloudflare docs backend

### DIFF
--- a/docs/passport.md
+++ b/docs/passport.md
@@ -35,6 +35,11 @@ Resolution rule (`wet_mcp.sync.resolve_active_backend`):
 - `SYNC_S3_BUCKET` is set (env var or pydantic `settings.sync_s3_bucket`)
   → active backend = **S3**. GDrive Device Code OAuth is **disabled** at
   startup; the relay form does NOT prompt for a Google account.
+- `DOCS_DB_BACKEND=cf-d1` → active backend = **disabled** for legacy DB-file
+  sync. Cloudflare D1 + Vectorize already hold the durable docs store, so
+  this override wins even if an old bucket or bundled Google client remains
+  in the container environment. Set `SYNC_ENABLED=false` to disable sync in
+  any deployment mode.
 - Otherwise → active backend = **GDrive**. The relay form drives the
   Device Code flow for the end-user's Google account on first config.
 
@@ -102,7 +107,7 @@ see the bucket name and never authenticate with Google.
 | `SYNC_INTERVAL` | `300` | Seconds between push ticks (0 = manual only) |
 | `SYNC_FOLDER` | `wet-mcp` | GDrive folder name (gdrive mode only) |
 | `GOOGLE_DRIVE_CLIENT_ID` | `<bundled>` | Desktop OAuth client (public per Google docs) |
-| `SYNC_S3_BUCKET` | `` | **Setting this switches to S3 mode** |
+| `SYNC_S3_BUCKET` | `` | **Setting this switches to S3 mode** (unless `DOCS_DB_BACKEND=cf-d1`) |
 | `SYNC_S3_REGION` | `us-east-1` | Region (`auto` for R2) |
 | `SYNC_S3_ENDPOINT` | `` | Custom endpoint for R2 / B2 / MinIO (empty = AWS) |
 | `SYNC_S3_ACCESS_KEY_ID` | `` | Static access key |

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -462,7 +462,7 @@ async def _lifespan_startup() -> asyncio.Task | None:
         from wet_mcp.sync import start_s3_auto_sync
 
         start_s3_auto_sync(_docs_db)
-    elif settings.google_drive_client_id:
+    elif active_backend == "gdrive" and settings.google_drive_client_id:
         logger.info("Sync backend: gdrive (Device Code OAuth via relay)")
         from wet_mcp.sync import start_auto_sync
 
@@ -494,7 +494,7 @@ async def _lifespan_shutdown(warmup_task: asyncio.Task | None) -> None:
         from wet_mcp.sync import stop_s3_auto_sync
 
         stop_s3_auto_sync()
-    elif settings.google_drive_client_id:
+    elif active_backend == "gdrive" and settings.google_drive_client_id:
         from wet_mcp.sync import stop_auto_sync
 
         stop_auto_sync()
@@ -2091,6 +2091,9 @@ async def _handle_config_status() -> dict[str, Any]:
     # the account/database ids in MCP_D1_BASE_URL name the target a leaked
     # token would open, while answering nothing the operator asked.
     docs_backend = _active_docs_backend()
+    from wet_mcp.sync import resolve_active_backend
+
+    sync_backend = resolve_active_backend()
     status = {
         "database": {
             "backend": docs_backend,
@@ -2121,11 +2124,15 @@ async def _handle_config_status() -> dict[str, Any]:
             "path": (str(settings.get_cache_db_path()) if settings.wet_cache else None),
         },
         "sync": {
-            "enabled": settings.sync_enabled,
-            "provider": "google_drive",
+            "enabled": sync_backend != "disabled",
+            "provider": sync_backend,
             "folder": settings.sync_folder,
             "interval": settings.sync_interval,
-            "google_drive_client_id": bool(settings.google_drive_client_id),
+            "google_drive_client_id": (
+                bool(settings.google_drive_client_id)
+                if sync_backend == "gdrive"
+                else False
+            ),
         },
         "settings": {
             "log_level": settings.log_level,

--- a/src/wet_mcp/sync/__init__.py
+++ b/src/wet_mcp/sync/__init__.py
@@ -32,6 +32,7 @@ Backend selection (XOR semantics):
 
 from __future__ import annotations
 
+import os
 import sys
 from types import ModuleType
 
@@ -159,7 +160,13 @@ def reset_registry() -> None:
 def resolve_active_backend() -> str:
     """Resolve the active sync backend name from environment.
 
-    Returns ``"s3"`` when ``SYNC_S3_BUCKET`` is non-empty (operator deploy
+    Cloudflare D1 + Vectorize is the durable docs store, so legacy DB-file
+    sync is disabled there even when old bucket/client settings are still
+    present in the container environment. ``SYNC_ENABLED=false`` is also a
+    hard off switch for every backend.
+
+    Returns ``"disabled"`` for the CF D1 store or when ``SYNC_ENABLED`` is
+    false, ``"s3"`` when ``SYNC_S3_BUCKET`` is non-empty (operator deploy
     mode: HTTP / Docker), otherwise ``"gdrive"`` (default uvx Method 1
     local-relay mode with per-user OAuth Device Code).
 
@@ -170,6 +177,9 @@ def resolve_active_backend() -> str:
     """
     from wet_mcp.config import settings
 
+    docs_backend = os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+    if docs_backend.strip().lower() == "cf-d1" or not settings.sync_enabled:
+        return "disabled"
     if settings.sync_s3_bucket:
         return "s3"
     return "gdrive"
@@ -195,6 +205,10 @@ async def _s3_auto_sync_loop(db) -> None:  # type: ignore[no-untyped-def]
     from loguru import logger
 
     from wet_mcp.config import settings as _settings
+
+    if resolve_active_backend() != "s3":
+        logger.info("S3 auto-sync disabled by the effective sync backend")
+        return
 
     interval = _settings.sync_interval
     if interval <= 0:
@@ -244,6 +258,9 @@ async def _s3_auto_sync_loop(db) -> None:  # type: ignore[no-untyped-def]
     while True:
         try:
             await asyncio.sleep(interval)
+            if resolve_active_backend() != "s3":
+                logger.info("S3 auto-sync stopped by the effective sync backend")
+                return
             # Flush WAL into docs.db first: the backend only ships the
             # main file, so an un-checkpointed sidecar means an empty push.
             await checkpoint_wal(db_path)
@@ -264,7 +281,7 @@ def start_s3_auto_sync(db) -> None:  # type: ignore[no-untyped-def]
     global _s3_sync_task
     from wet_mcp.config import settings as _settings
 
-    if not _settings.sync_s3_bucket:
+    if resolve_active_backend() != "s3":
         return
     if _settings.sync_interval <= 0:
         return

--- a/src/wet_mcp/sync/gdrive.py
+++ b/src/wet_mcp/sync/gdrive.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -507,7 +508,8 @@ async def sync_full(db: DocsDB) -> dict:
     """
     from wet_mcp.db import DocsDB
 
-    if not settings.sync_enabled:
+    docs_backend = os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+    if not settings.sync_enabled or docs_backend.strip().lower() == "cf-d1":
         return {"status": "disabled", "message": "Sync not configured"}
 
     if not settings.google_drive_client_id:
@@ -788,7 +790,12 @@ def start_auto_sync(db: DocsDB) -> None:
     """Start background auto-sync task."""
     global _sync_task
 
-    if not settings.sync_enabled or settings.sync_interval <= 0:
+    docs_backend = os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+    if (
+        not settings.sync_enabled
+        or docs_backend.strip().lower() == "cf-d1"
+        or settings.sync_interval <= 0
+    ):
         return
 
     if _sync_task and not _sync_task.done():

--- a/tests/test_cf_sync_gate.py
+++ b/tests/test_cf_sync_gate.py
@@ -1,0 +1,61 @@
+"""Regression tests for the Cloudflare docs-store sync cutover."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _enable_legacy_sync_settings(monkeypatch) -> None:
+    from wet_mcp.config import settings
+
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    monkeypatch.setattr(settings, "sync_enabled", True)
+    monkeypatch.setattr(settings, "sync_s3_bucket", "legacy-bucket")
+    monkeypatch.setattr(settings, "google_drive_client_id", "bundled-client")
+
+
+def test_cf_d1_disables_every_sync_backend(monkeypatch) -> None:
+    """D1 + Vectorize is authoritative even when legacy sync env is present."""
+    _enable_legacy_sync_settings(monkeypatch)
+
+    from wet_mcp.sync import resolve_active_backend
+
+    assert resolve_active_backend() == "disabled"
+
+
+async def test_gdrive_sync_full_is_disabled_on_cf_d1(monkeypatch) -> None:
+    """A direct sync call must not write after the CF cutover."""
+    _enable_legacy_sync_settings(monkeypatch)
+
+    from wet_mcp.sync.gdrive import sync_full
+
+    result = await sync_full(MagicMock())
+
+    assert result["status"] == "disabled"
+
+
+async def test_config_status_reports_effective_sync_state(monkeypatch) -> None:
+    """Operator status must expose the effective writer, not the raw flag."""
+    _enable_legacy_sync_settings(monkeypatch)
+
+    import wet_mcp.server as server
+
+    monkeypatch.setattr(server, "_docs_db", None)
+    with (
+        patch("wet_mcp.embedder.resolve_embed_backend_for_request", return_value=None),
+        patch("wet_mcp.reranker.resolve_rerank_backend_for_request", return_value=None),
+    ):
+        status = await server._handle_config_status()
+
+    assert status["sync"]["enabled"] is False
+    assert status["sync"]["provider"] == "disabled"
+
+
+def test_cloudflare_wrangler_templates_disable_legacy_sync() -> None:
+    """The deployment contract must remain explicit if env defaults change."""
+    root = Path(__file__).resolve().parents[1]
+    for relative in ("wrangler.jsonc", "wrangler.deploy.template.jsonc"):
+        content = (root / relative).read_text(encoding="utf-8")
+        assert '"DOCS_DB_BACKEND": "cf-d1"' in content
+        assert '"SYNC_ENABLED": "false"' in content

--- a/tests/test_tool_names.py
+++ b/tests/test_tool_names.py
@@ -17,12 +17,20 @@ EXPECTED_NAMES = [
     "search",
 ]
 RETIRED_NAMES: list[str] = []
+_TOOL_NAMES: list[str] | None = None
 
 
 async def _list_tool_names() -> list[str]:
+    global _TOOL_NAMES
+    if _TOOL_NAMES is not None:
+        return _TOOL_NAMES
+
     params = StdioServerParameters(
         command="uv",
-        args=["run", "wet-mcp"],
+        # The contract probe must not let uv mutate/sync the workspace while
+        # it is opening the real stdio server. Tool registration does not need
+        # remote D1 bindings; the CF selector is covered separately.
+        args=["run", "--no-sync", "wet-mcp"],
         env={
             **os.environ,
             "LOG_LEVEL": "WARNING",
@@ -30,12 +38,18 @@ async def _list_tool_names() -> list[str]:
             "DISABLE_LOCAL_RERANK": "true",
             "DISABLE_LOCAL_SEARCH": "true",
             "WET_AUTO_SEARXNG": "false",
+            "DOCS_DB_BACKEND": "sqlite",
+            "SYNC_ENABLED": "false",
+            "WET_CACHE": "false",
         },
     )
     async with stdio_client(params) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
-            return sorted(tool.name for tool in (await session.list_tools()).tools)
+            _TOOL_NAMES = sorted(
+                tool.name for tool in (await session.list_tools()).tools
+            )
+            return _TOOL_NAMES
 
 
 @pytest.mark.asyncio

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -44,6 +44,7 @@
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "DOCS_DB_BACKEND": "cf-d1",
+    "SYNC_ENABLED": "false",
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "${CF_VECTORIZE_ID}",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,6 +50,7 @@
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "DOCS_DB_BACKEND": "cf-d1",
+    "SYNC_ENABLED": "false",
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "wet-docs-vectors",


### PR DESCRIPTION
## Summary\n- disable legacy GDrive/S3 DB-file sync when DOCS_DB_BACKEND=cf-d1 or SYNC_ENABLED=false\n- make runtime status report the effective sync backend\n- enforce SYNC_ENABLED=false in Cloudflare Wrangler templates\n- add regression coverage and make the stdio tool-name probe deterministic\n\n## Verification\n- pre-commit: gitleaks, ruff, format, ty, full pytest passed\n- targeted CF/sync, relay/coverage, and server lifecycle tests passed