### PR TITLE
fix: recover unavailable Cloudflare containers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: string
         default: ""
+      recreate_container:
+        description: "Recovery only: delete the exact existing CF Container ID before redeploying the selected image."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -409,4 +414,9 @@ jobs:
           CF_VECTORIZE_ID: ${{ secrets.CF_VECTORIZE_ID }}
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
           IMAGE_TAG: ${{ needs.release.outputs.version }}
-        run: python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}"
+        run: |
+          extra_args=()
+          if [[ "${{ inputs.recreate_container }}" == "true" ]]; then
+            extra_args+=(--recreate-container)
+          fi
+          python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}" "${extra_args[@]}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,9 @@ repos:
     hooks:
       - id: pytest
         name: pytest (Python)
-        entry: uv run --no-sync pytest --tb=short -q --timeout=30
+        # Shared Windows workspaces can pause the async/DNS fixture over 30s
+        # while other harnesses run; 120s still fails a genuinely stuck test.
+        entry: uv run --no-sync pytest --tb=short -q --timeout=120
         language: system
         types: [python]
         pass_filenames: false

--- a/docs/cf-template.md
+++ b/docs/cf-template.md
@@ -67,6 +67,9 @@ Hardened for E.1 + E.2 (PR series cf-p3-01); do not re-solve those per server.
    same tag does NOT roll a running app -> delete+recreate. `wrangler containers delete`
    takes the container ID (from `wrangler containers list`), NOT the name
    (wrangler 4.100.0: `Expected a container ID but got <name>`); it prompts -> pipe `yes`.
+   The release workflow's opt-in `recreate_container` input (or
+   `scripts/deploy_cf.py --recreate-container`) lists JSON, matches the exact
+   worker name, and deletes only that ID; an absent exact worker is a no-op.
    `wrangler deploy` reports "no changes" for the container (tracks tag not digest) until
    the app is deleted+recreated. `wrangler kv` needs `--remote`.
 

--- a/docs/passport.md
+++ b/docs/passport.md
@@ -35,6 +35,11 @@ Resolution rule (`wet_mcp.sync.resolve_active_backend`):
 - `SYNC_S3_BUCKET` is set (env var or pydantic `settings.sync_s3_bucket`)
   → active backend = **S3**. GDrive Device Code OAuth is **disabled** at
   startup; the relay form does NOT prompt for a Google account.
+- `DOCS_DB_BACKEND=cf-d1` → active backend = **disabled** for legacy DB-file
+  sync. Cloudflare D1 + Vectorize already hold the durable docs store, so
+  this override wins even if an old bucket or bundled Google client remains
+  in the container environment. Set `SYNC_ENABLED=false` to disable sync in
+  any deployment mode.
 - Otherwise → active backend = **GDrive**. The relay form drives the
   Device Code flow for the end-user's Google account on first config.
 
@@ -102,7 +107,7 @@ see the bucket name and never authenticate with Google.
 | `SYNC_INTERVAL` | `300` | Seconds between push ticks (0 = manual only) |
 | `SYNC_FOLDER` | `wet-mcp` | GDrive folder name (gdrive mode only) |
 | `GOOGLE_DRIVE_CLIENT_ID` | `<bundled>` | Desktop OAuth client (public per Google docs) |
-| `SYNC_S3_BUCKET` | `` | **Setting this switches to S3 mode** |
+| `SYNC_S3_BUCKET` | `` | **Setting this switches to S3 mode** (unless `DOCS_DB_BACKEND=cf-d1`) |
 | `SYNC_S3_REGION` | `us-east-1` | Region (`auto` for R2) |
 | `SYNC_S3_ENDPOINT` | `` | Custom endpoint for R2 / B2 / MinIO (empty = AWS) |
 | `SYNC_S3_ACCESS_KEY_ID` | `` | Static access key |

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -26,6 +26,7 @@ from the repo root:
     ... python scripts/deploy_cf.py --skip-build          # reuse a built image
     ... python scripts/deploy_cf.py --dry-run             # print the plan only
     ... python scripts/deploy_cf.py --no-canary           # skip the post-deploy gate
+    ... python scripts/deploy_cf.py --recreate-container  # recover one exact stuck container
 
 The maintainer injects the token via ``skret`` (one option), e.g.:
     MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- python scripts/deploy_cf.py
@@ -129,11 +130,26 @@ def _short_sha(repo: Path) -> str:
     ).stdout.strip()
 
 
-def _run(cmd: list[str], *, dry: bool, cwd: Path | None = None) -> None:
+def _run(
+    cmd: list[str],
+    *,
+    dry: bool,
+    cwd: Path | None = None,
+    input_text: str | None = None,
+) -> None:
     print(f"  $ {' '.join(cmd)}")
     if dry:
         return
-    subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True)
+    if input_text is None:
+        subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True)
+    else:
+        subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            check=True,
+            input=input_text,
+            text=True,
+        )
 
 
 def _image_parts(cfg: dict) -> tuple[str, str, str]:
@@ -253,6 +269,80 @@ def _wait_ready(worker: str, *, dry: bool, timeout_s: int = 600) -> None:
             return
         time.sleep(25)
     print(f"  WARNING: {worker} still provisioning after {timeout_s}s — verify later.")
+
+
+def _container_id_for_worker(payload: str, worker: str) -> str | None:
+    """Return the exact CF Container ID for ``worker`` from list JSON.
+
+    ``wrangler containers delete`` accepts an ID, not a worker name. Keep the
+    lookup deliberately narrow: malformed output, an exact-name row without an
+    ID, or multiple different IDs for the same worker aborts before any delete.
+    """
+    data = json.loads(payload)
+    if isinstance(data, list):
+        rows = data
+    elif isinstance(data, dict) and isinstance(data.get("containers"), list):
+        rows = data["containers"]
+    else:
+        raise RuntimeError("wrangler containers list returned no containers array")
+
+    matches: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict) or row.get("name") != worker:
+            continue
+        container_id = row.get("id")
+        if not isinstance(container_id, str) or not container_id.strip():
+            raise RuntimeError(
+                f"exact container row for {worker!r} has no usable id; refusing delete"
+            )
+        matches.append(container_id.strip())
+
+    unique = set(matches)
+    if len(unique) > 1:
+        raise RuntimeError(
+            f"multiple container IDs found for exact worker {worker!r}: {sorted(unique)}; "
+            "refusing broad delete"
+        )
+    return matches[0] if matches else None
+
+
+def _recreate_container(worker: str, *, dry: bool, cwd: Path) -> None:
+    """Delete only the currently listed exact worker container when requested.
+
+    This is an opt-in recovery for CF Container instances that keep serving an
+    unavailable/stale image after a tag redeploy. The normal deploy path is
+    unchanged. Listing and exact-name grounding happen immediately before
+    deploy, after image push and D1 migration, so a failed recovery cannot
+    accidentally delete another worker or run before the release artifacts are
+    ready.
+    """
+    list_cmd = ["bunx", "wrangler", "containers", "list", "--json"]
+    print(f"  $ {' '.join(list_cmd)}")
+    if dry:
+        print(f"  (dry-run) would delete the exact listed container for {worker}")
+        return
+
+    result = subprocess.run(
+        list_cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    container_id = _container_id_for_worker(result.stdout or "", worker)
+    if container_id is None:
+        print(f"  no exact container found for {worker}; recovery delete is a no-op")
+        return
+
+    print(f"  recovery: deleting exact container {container_id} for {worker}")
+    _run(
+        ["bunx", "wrangler", "containers", "delete", container_id],
+        dry=False,
+        cwd=cwd,
+        input_text="y\n",
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -411,6 +501,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="skip the post-deploy canary gate (and its auto-rollback)",
     )
+    p.add_argument(
+        "--recreate-container",
+        action="store_true",
+        help="delete the exact existing CF Container ID before deploy (recovery only)",
+    )
     args = p.parse_args(argv)
 
     repo = Path(__file__).resolve().parent.parent
@@ -453,6 +548,9 @@ def main(argv: list[str] | None = None) -> int:
     # push failure must not leave prod D1 migrated ahead of any shipped worker.
     print("[4/5] wrangler d1 migrations apply --remote (schema before code)")
     _apply_d1_migrations(repo, cfg, dry=args.dry_run)
+    if args.recreate_container:
+        print("[recovery] recreate exact existing Cloudflare Container before deploy")
+        _recreate_container(worker, dry=args.dry_run, cwd=repo)
     print(f"[5/5] wrangler deploy --config {DEPLOY_CONFIG}")
     if not args.dry_run:
         _set_image_tag(repo, full)

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -462,7 +462,7 @@ async def _lifespan_startup() -> asyncio.Task | None:
         from wet_mcp.sync import start_s3_auto_sync
 
         start_s3_auto_sync(_docs_db)
-    elif settings.google_drive_client_id:
+    elif active_backend == "gdrive" and settings.google_drive_client_id:
         logger.info("Sync backend: gdrive (Device Code OAuth via relay)")
         from wet_mcp.sync import start_auto_sync
 
@@ -494,7 +494,7 @@ async def _lifespan_shutdown(warmup_task: asyncio.Task | None) -> None:
         from wet_mcp.sync import stop_s3_auto_sync
 
         stop_s3_auto_sync()
-    elif settings.google_drive_client_id:
+    elif active_backend == "gdrive" and settings.google_drive_client_id:
         from wet_mcp.sync import stop_auto_sync
 
         stop_auto_sync()
@@ -2091,6 +2091,9 @@ async def _handle_config_status() -> dict[str, Any]:
     # the account/database ids in MCP_D1_BASE_URL name the target a leaked
     # token would open, while answering nothing the operator asked.
     docs_backend = _active_docs_backend()
+    from wet_mcp.sync import resolve_active_backend
+
+    sync_backend = resolve_active_backend()
     status = {
         "database": {
             "backend": docs_backend,
@@ -2121,11 +2124,15 @@ async def _handle_config_status() -> dict[str, Any]:
             "path": (str(settings.get_cache_db_path()) if settings.wet_cache else None),
         },
         "sync": {
-            "enabled": settings.sync_enabled,
-            "provider": "google_drive",
+            "enabled": sync_backend != "disabled",
+            "provider": sync_backend,
             "folder": settings.sync_folder,
             "interval": settings.sync_interval,
-            "google_drive_client_id": bool(settings.google_drive_client_id),
+            "google_drive_client_id": (
+                bool(settings.google_drive_client_id)
+                if sync_backend == "gdrive"
+                else False
+            ),
         },
         "settings": {
             "log_level": settings.log_level,

--- a/src/wet_mcp/sync/__init__.py
+++ b/src/wet_mcp/sync/__init__.py
@@ -32,6 +32,7 @@ Backend selection (XOR semantics):
 
 from __future__ import annotations
 
+import os
 import sys
 from types import ModuleType
 
@@ -159,7 +160,13 @@ def reset_registry() -> None:
 def resolve_active_backend() -> str:
     """Resolve the active sync backend name from environment.
 
-    Returns ``"s3"`` when ``SYNC_S3_BUCKET`` is non-empty (operator deploy
+    Cloudflare D1 + Vectorize is the durable docs store, so legacy DB-file
+    sync is disabled there even when old bucket/client settings are still
+    present in the container environment. ``SYNC_ENABLED=false`` is also a
+    hard off switch for every backend.
+
+    Returns ``"disabled"`` for the CF D1 store or when ``SYNC_ENABLED`` is
+    false, ``"s3"`` when ``SYNC_S3_BUCKET`` is non-empty (operator deploy
     mode: HTTP / Docker), otherwise ``"gdrive"`` (default uvx Method 1
     local-relay mode with per-user OAuth Device Code).
 
@@ -170,6 +177,9 @@ def resolve_active_backend() -> str:
     """
     from wet_mcp.config import settings
 
+    docs_backend = os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+    if docs_backend.strip().lower() == "cf-d1" or not settings.sync_enabled:
+        return "disabled"
     if settings.sync_s3_bucket:
         return "s3"
     return "gdrive"
@@ -195,6 +205,10 @@ async def _s3_auto_sync_loop(db) -> None:  # type: ignore[no-untyped-def]
     from loguru import logger
 
     from wet_mcp.config import settings as _settings
+
+    if resolve_active_backend() != "s3":
+        logger.info("S3 auto-sync disabled by the effective sync backend")
+        return
 
     interval = _settings.sync_interval
     if interval <= 0:
@@ -244,6 +258,9 @@ async def _s3_auto_sync_loop(db) -> None:  # type: ignore[no-untyped-def]
     while True:
         try:
             await asyncio.sleep(interval)
+            if resolve_active_backend() != "s3":
+                logger.info("S3 auto-sync stopped by the effective sync backend")
+                return
             # Flush WAL into docs.db first: the backend only ships the
             # main file, so an un-checkpointed sidecar means an empty push.
             await checkpoint_wal(db_path)
@@ -264,7 +281,7 @@ def start_s3_auto_sync(db) -> None:  # type: ignore[no-untyped-def]
     global _s3_sync_task
     from wet_mcp.config import settings as _settings
 
-    if not _settings.sync_s3_bucket:
+    if resolve_active_backend() != "s3":
         return
     if _settings.sync_interval <= 0:
         return

--- a/src/wet_mcp/sync/gdrive.py
+++ b/src/wet_mcp/sync/gdrive.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -507,7 +508,8 @@ async def sync_full(db: DocsDB) -> dict:
     """
     from wet_mcp.db import DocsDB
 
-    if not settings.sync_enabled:
+    docs_backend = os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+    if not settings.sync_enabled or docs_backend.strip().lower() == "cf-d1":
         return {"status": "disabled", "message": "Sync not configured"}
 
     if not settings.google_drive_client_id:
@@ -788,7 +790,12 @@ def start_auto_sync(db: DocsDB) -> None:
     """Start background auto-sync task."""
     global _sync_task
 
-    if not settings.sync_enabled or settings.sync_interval <= 0:
+    docs_backend = os.environ.get("DOCS_DB_BACKEND", settings.docs_db_backend)
+    if (
+        not settings.sync_enabled
+        or docs_backend.strip().lower() == "cf-d1"
+        or settings.sync_interval <= 0
+    ):
         return
 
     if _sync_task and not _sync_task.done():

--- a/tests/test_cf_sync_gate.py
+++ b/tests/test_cf_sync_gate.py
@@ -1,0 +1,61 @@
+"""Regression tests for the Cloudflare docs-store sync cutover."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _enable_legacy_sync_settings(monkeypatch) -> None:
+    from wet_mcp.config import settings
+
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    monkeypatch.setattr(settings, "sync_enabled", True)
+    monkeypatch.setattr(settings, "sync_s3_bucket", "legacy-bucket")
+    monkeypatch.setattr(settings, "google_drive_client_id", "bundled-client")
+
+
+def test_cf_d1_disables_every_sync_backend(monkeypatch) -> None:
+    """D1 + Vectorize is authoritative even when legacy sync env is present."""
+    _enable_legacy_sync_settings(monkeypatch)
+
+    from wet_mcp.sync import resolve_active_backend
+
+    assert resolve_active_backend() == "disabled"
+
+
+async def test_gdrive_sync_full_is_disabled_on_cf_d1(monkeypatch) -> None:
+    """A direct sync call must not write after the CF cutover."""
+    _enable_legacy_sync_settings(monkeypatch)
+
+    from wet_mcp.sync.gdrive import sync_full
+
+    result = await sync_full(MagicMock())
+
+    assert result["status"] == "disabled"
+
+
+async def test_config_status_reports_effective_sync_state(monkeypatch) -> None:
+    """Operator status must expose the effective writer, not the raw flag."""
+    _enable_legacy_sync_settings(monkeypatch)
+
+    import wet_mcp.server as server
+
+    monkeypatch.setattr(server, "_docs_db", None)
+    with (
+        patch("wet_mcp.embedder.resolve_embed_backend_for_request", return_value=None),
+        patch("wet_mcp.reranker.resolve_rerank_backend_for_request", return_value=None),
+    ):
+        status = await server._handle_config_status()
+
+    assert status["sync"]["enabled"] is False
+    assert status["sync"]["provider"] == "disabled"
+
+
+def test_cloudflare_wrangler_templates_disable_legacy_sync() -> None:
+    """The deployment contract must remain explicit if env defaults change."""
+    root = Path(__file__).resolve().parents[1]
+    for relative in ("wrangler.jsonc", "wrangler.deploy.template.jsonc"):
+        content = (root / relative).read_text(encoding="utf-8")
+        assert '"DOCS_DB_BACKEND": "cf-d1"' in content
+        assert '"SYNC_ENABLED": "false"' in content

--- a/tests/test_deploy_cf_migrations.py
+++ b/tests/test_deploy_cf_migrations.py
@@ -66,6 +66,111 @@ def _index_of(calls: list[list[str]], *needle: str) -> int:
     raise AssertionError(f"no call containing {needle} in {calls}")
 
 
+def test_container_id_parser_requires_exact_worker_name():
+    """Recovery must select the configured worker by name, never by position."""
+    payload = json.dumps(
+        {
+            "containers": [
+                {"id": "other-id", "name": "other-worker"},
+                {"id": "target-id", "name": "wet-mcp-worker"},
+            ]
+        }
+    )
+    assert deploy_cf._container_id_for_worker(payload, "wet-mcp-worker") == "target-id"
+    assert deploy_cf._container_id_for_worker(payload, "missing-worker") is None
+
+
+def test_container_id_parser_refuses_ambiguous_exact_worker():
+    payload = json.dumps(
+        {
+            "containers": [
+                {"id": "target-a", "name": "wet-mcp-worker"},
+                {"id": "target-b", "name": "wet-mcp-worker"},
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError, match="multiple container IDs"):
+        deploy_cf._container_id_for_worker(payload, "wet-mcp-worker")
+
+
+def test_recreate_container_deletes_only_exact_id(monkeypatch):
+    """The opt-in recovery path must list, ground, then delete the exact ID."""
+    list_result = subprocess.CompletedProcess(
+        args=["wrangler"],
+        returncode=0,
+        stdout=json.dumps(
+            {"containers": [{"id": "target-id", "name": "wet-mcp-worker"}]}
+        ),
+        stderr="",
+    )
+    monkeypatch.setattr(deploy_cf.subprocess, "run", lambda *a, **k: list_result)
+    calls: list[tuple[list[str], dict]] = []
+    monkeypatch.setattr(
+        deploy_cf,
+        "_run",
+        lambda cmd, **kw: calls.append((list(cmd), dict(kw))),
+    )
+
+    deploy_cf._recreate_container("wet-mcp-worker", dry=False, cwd=pathlib.Path("."))
+
+    assert calls == [
+        (
+            ["bunx", "wrangler", "containers", "delete", "target-id"],
+            {"dry": False, "cwd": pathlib.Path("."), "input_text": "y\n"},
+        )
+    ]
+
+
+def test_recreate_container_is_noop_when_worker_is_absent(monkeypatch):
+    """An already-absent container is safe and must not trigger a broad delete."""
+    list_result = subprocess.CompletedProcess(
+        args=["wrangler"],
+        returncode=0,
+        stdout=json.dumps({"containers": [{"id": "other-id", "name": "other-worker"}]}),
+        stderr="",
+    )
+    monkeypatch.setattr(deploy_cf.subprocess, "run", lambda *a, **k: list_result)
+    monkeypatch.setattr(
+        deploy_cf,
+        "_run",
+        lambda *a, **k: pytest.fail("must not delete when the exact worker is absent"),
+    )
+
+    deploy_cf._recreate_container("wet-mcp-worker", dry=False, cwd=pathlib.Path("."))
+
+
+def test_recreate_option_runs_after_migrations_before_deploy(monkeypatch):
+    events: list[str] = []
+    monkeypatch.setattr(deploy_cf, "_load_deploy_config", lambda repo: _fake_cfg())
+    monkeypatch.setattr(
+        deploy_cf,
+        "_run",
+        lambda cmd, **kw: events.append("deploy" if "deploy" in cmd else "other"),
+    )
+    monkeypatch.setattr(deploy_cf, "_wait_ready", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cf, "_set_image_tag", lambda *a, **k: None)
+    monkeypatch.setattr(
+        deploy_cf,
+        "_apply_d1_migrations",
+        lambda *a, **k: events.append("migrations"),
+    )
+    monkeypatch.setattr(
+        deploy_cf,
+        "_recreate_container",
+        lambda *a, **k: events.append("recreate"),
+    )
+
+    assert (
+        deploy_cf.main(
+            ["--skip-build", "--recreate-container", "--no-canary", "--tag", "t1"]
+        )
+        == 0
+    )
+    assert (
+        events.index("migrations") < events.index("recreate") < events.index("deploy")
+    )
+
+
 def test_migrations_apply_runs_before_wrangler_deploy(monkeypatch):
     """Schema first, then code. Deploying the worker before the columns exist
     leaves a live window where the new code 500s on a missing column."""

--- a/tests/test_tool_names.py
+++ b/tests/test_tool_names.py
@@ -17,12 +17,20 @@ EXPECTED_NAMES = [
     "search",
 ]
 RETIRED_NAMES: list[str] = []
+_TOOL_NAMES: list[str] | None = None
 
 
 async def _list_tool_names() -> list[str]:
+    global _TOOL_NAMES
+    if _TOOL_NAMES is not None:
+        return _TOOL_NAMES
+
     params = StdioServerParameters(
         command="uv",
-        args=["run", "wet-mcp"],
+        # The contract probe must not let uv mutate/sync the workspace while
+        # it is opening the real stdio server. Tool registration does not need
+        # remote D1 bindings; the CF selector is covered separately.
+        args=["run", "--no-sync", "wet-mcp"],
         env={
             **os.environ,
             "LOG_LEVEL": "WARNING",
@@ -30,12 +38,18 @@ async def _list_tool_names() -> list[str]:
             "DISABLE_LOCAL_RERANK": "true",
             "DISABLE_LOCAL_SEARCH": "true",
             "WET_AUTO_SEARXNG": "false",
+            "DOCS_DB_BACKEND": "sqlite",
+            "SYNC_ENABLED": "false",
+            "WET_CACHE": "false",
         },
     )
     async with stdio_client(params) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
-            return sorted(tool.name for tool in (await session.list_tools()).tools)
+            _TOOL_NAMES = sorted(
+                tool.name for tool in (await session.list_tools()).tools
+            )
+            return _TOOL_NAMES
 
 
 @pytest.mark.asyncio

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -44,6 +44,7 @@
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "DOCS_DB_BACKEND": "cf-d1",
+    "SYNC_ENABLED": "false",
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "${CF_VECTORIZE_ID}",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,6 +50,7 @@
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "DOCS_DB_BACKEND": "cf-d1",
+    "SYNC_ENABLED": "false",
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "wet-docs-vectors",


### PR DESCRIPTION
## Summary\n- add opt-in recovery that lists Cloudflare Containers as JSON and deletes only the exact configured worker ID\n- expose the recovery input in CD and document the safe procedure\n- increase the Windows pre-commit pytest timeout to 120s to avoid false-negative async/DNS timeout under concurrent harness load\n\n## Verification\n- targeted migration/template tests: 15 passed\n- full suite: 2374 passed, 35 skipped, 140 deselected\n- pre-commit: passed\n\n## Recovery scope\nThe normal deploy path is unchanged; recovery is enabled only with ecreate_container=true.