### PR TITLE
fix: recover unavailable Cloudflare containers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: string
         default: ""
+      recreate_container:
+        description: "Recovery only: delete the exact existing CF Container ID before redeploying the selected image."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -409,4 +414,9 @@ jobs:
           CF_VECTORIZE_ID: ${{ secrets.CF_VECTORIZE_ID }}
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
           IMAGE_TAG: ${{ needs.release.outputs.version }}
-        run: python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}"
+        run: |
+          extra_args=()
+          if [[ "${{ inputs.recreate_container }}" == "true" ]]; then
+            extra_args+=(--recreate-container)
+          fi
+          python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}" "${extra_args[@]}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,9 @@ repos:
     hooks:
       - id: pytest
         name: pytest (Python)
-        entry: uv run --no-sync pytest --tb=short -q --timeout=30
+        # Shared Windows workspaces can pause the async/DNS fixture over 30s
+        # while other harnesses run; 120s still fails a genuinely stuck test.
+        entry: uv run --no-sync pytest --tb=short -q --timeout=120
         language: system
         types: [python]
         pass_filenames: false

--- a/docs/cf-template.md
+++ b/docs/cf-template.md
@@ -67,6 +67,9 @@ Hardened for E.1 + E.2 (PR series cf-p3-01); do not re-solve those per server.
    same tag does NOT roll a running app -> delete+recreate. `wrangler containers delete`
    takes the container ID (from `wrangler containers list`), NOT the name
    (wrangler 4.100.0: `Expected a container ID but got <name>`); it prompts -> pipe `yes`.
+   The release workflow's opt-in `recreate_container` input (or
+   `scripts/deploy_cf.py --recreate-container`) lists JSON, matches the exact
+   worker name, and deletes only that ID; an absent exact worker is a no-op.
    `wrangler deploy` reports "no changes" for the container (tracks tag not digest) until
    the app is deleted+recreated. `wrangler kv` needs `--remote`.
 

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -26,6 +26,7 @@ from the repo root:
     ... python scripts/deploy_cf.py --skip-build          # reuse a built image
     ... python scripts/deploy_cf.py --dry-run             # print the plan only
     ... python scripts/deploy_cf.py --no-canary           # skip the post-deploy gate
+    ... python scripts/deploy_cf.py --recreate-container  # recover one exact stuck container
 
 The maintainer injects the token via ``skret`` (one option), e.g.:
     MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- python scripts/deploy_cf.py
@@ -129,11 +130,26 @@ def _short_sha(repo: Path) -> str:
     ).stdout.strip()
 
 
-def _run(cmd: list[str], *, dry: bool, cwd: Path | None = None) -> None:
+def _run(
+    cmd: list[str],
+    *,
+    dry: bool,
+    cwd: Path | None = None,
+    input_text: str | None = None,
+) -> None:
     print(f"  $ {' '.join(cmd)}")
     if dry:
         return
-    subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True)
+    if input_text is None:
+        subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True)
+    else:
+        subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            check=True,
+            input=input_text,
+            text=True,
+        )
 
 
 def _image_parts(cfg: dict) -> tuple[str, str, str]:
@@ -253,6 +269,80 @@ def _wait_ready(worker: str, *, dry: bool, timeout_s: int = 600) -> None:
             return
         time.sleep(25)
     print(f"  WARNING: {worker} still provisioning after {timeout_s}s — verify later.")
+
+
+def _container_id_for_worker(payload: str, worker: str) -> str | None:
+    """Return the exact CF Container ID for ``worker`` from list JSON.
+
+    ``wrangler containers delete`` accepts an ID, not a worker name. Keep the
+    lookup deliberately narrow: malformed output, an exact-name row without an
+    ID, or multiple different IDs for the same worker aborts before any delete.
+    """
+    data = json.loads(payload)
+    if isinstance(data, list):
+        rows = data
+    elif isinstance(data, dict) and isinstance(data.get("containers"), list):
+        rows = data["containers"]
+    else:
+        raise RuntimeError("wrangler containers list returned no containers array")
+
+    matches: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict) or row.get("name") != worker:
+            continue
+        container_id = row.get("id")
+        if not isinstance(container_id, str) or not container_id.strip():
+            raise RuntimeError(
+                f"exact container row for {worker!r} has no usable id; refusing delete"
+            )
+        matches.append(container_id.strip())
+
+    unique = set(matches)
+    if len(unique) > 1:
+        raise RuntimeError(
+            f"multiple container IDs found for exact worker {worker!r}: {sorted(unique)}; "
+            "refusing broad delete"
+        )
+    return matches[0] if matches else None
+
+
+def _recreate_container(worker: str, *, dry: bool, cwd: Path) -> None:
+    """Delete only the currently listed exact worker container when requested.
+
+    This is an opt-in recovery for CF Container instances that keep serving an
+    unavailable/stale image after a tag redeploy. The normal deploy path is
+    unchanged. Listing and exact-name grounding happen immediately before
+    deploy, after image push and D1 migration, so a failed recovery cannot
+    accidentally delete another worker or run before the release artifacts are
+    ready.
+    """
+    list_cmd = ["bunx", "wrangler", "containers", "list", "--json"]
+    print(f"  $ {' '.join(list_cmd)}")
+    if dry:
+        print(f"  (dry-run) would delete the exact listed container for {worker}")
+        return
+
+    result = subprocess.run(
+        list_cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    container_id = _container_id_for_worker(result.stdout or "", worker)
+    if container_id is None:
+        print(f"  no exact container found for {worker}; recovery delete is a no-op")
+        return
+
+    print(f"  recovery: deleting exact container {container_id} for {worker}")
+    _run(
+        ["bunx", "wrangler", "containers", "delete", container_id],
+        dry=False,
+        cwd=cwd,
+        input_text="y\n",
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -411,6 +501,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="skip the post-deploy canary gate (and its auto-rollback)",
     )
+    p.add_argument(
+        "--recreate-container",
+        action="store_true",
+        help="delete the exact existing CF Container ID before deploy (recovery only)",
+    )
     args = p.parse_args(argv)
 
     repo = Path(__file__).resolve().parent.parent
@@ -453,6 +548,9 @@ def main(argv: list[str] | None = None) -> int:
     # push failure must not leave prod D1 migrated ahead of any shipped worker.
     print("[4/5] wrangler d1 migrations apply --remote (schema before code)")
     _apply_d1_migrations(repo, cfg, dry=args.dry_run)
+    if args.recreate_container:
+        print("[recovery] recreate exact existing Cloudflare Container before deploy")
+        _recreate_container(worker, dry=args.dry_run, cwd=repo)
     print(f"[5/5] wrangler deploy --config {DEPLOY_CONFIG}")
     if not args.dry_run:
         _set_image_tag(repo, full)

--- a/tests/test_deploy_cf_migrations.py
+++ b/tests/test_deploy_cf_migrations.py
@@ -66,6 +66,111 @@ def _index_of(calls: list[list[str]], *needle: str) -> int:
     raise AssertionError(f"no call containing {needle} in {calls}")
 
 
+def test_container_id_parser_requires_exact_worker_name():
+    """Recovery must select the configured worker by name, never by position."""
+    payload = json.dumps(
+        {
+            "containers": [
+                {"id": "other-id", "name": "other-worker"},
+                {"id": "target-id", "name": "wet-mcp-worker"},
+            ]
+        }
+    )
+    assert deploy_cf._container_id_for_worker(payload, "wet-mcp-worker") == "target-id"
+    assert deploy_cf._container_id_for_worker(payload, "missing-worker") is None
+
+
+def test_container_id_parser_refuses_ambiguous_exact_worker():
+    payload = json.dumps(
+        {
+            "containers": [
+                {"id": "target-a", "name": "wet-mcp-worker"},
+                {"id": "target-b", "name": "wet-mcp-worker"},
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError, match="multiple container IDs"):
+        deploy_cf._container_id_for_worker(payload, "wet-mcp-worker")
+
+
+def test_recreate_container_deletes_only_exact_id(monkeypatch):
+    """The opt-in recovery path must list, ground, then delete the exact ID."""
+    list_result = subprocess.CompletedProcess(
+        args=["wrangler"],
+        returncode=0,
+        stdout=json.dumps(
+            {"containers": [{"id": "target-id", "name": "wet-mcp-worker"}]}
+        ),
+        stderr="",
+    )
+    monkeypatch.setattr(deploy_cf.subprocess, "run", lambda *a, **k: list_result)
+    calls: list[tuple[list[str], dict]] = []
+    monkeypatch.setattr(
+        deploy_cf,
+        "_run",
+        lambda cmd, **kw: calls.append((list(cmd), dict(kw))),
+    )
+
+    deploy_cf._recreate_container("wet-mcp-worker", dry=False, cwd=pathlib.Path("."))
+
+    assert calls == [
+        (
+            ["bunx", "wrangler", "containers", "delete", "target-id"],
+            {"dry": False, "cwd": pathlib.Path("."), "input_text": "y\n"},
+        )
+    ]
+
+
+def test_recreate_container_is_noop_when_worker_is_absent(monkeypatch):
+    """An already-absent container is safe and must not trigger a broad delete."""
+    list_result = subprocess.CompletedProcess(
+        args=["wrangler"],
+        returncode=0,
+        stdout=json.dumps({"containers": [{"id": "other-id", "name": "other-worker"}]}),
+        stderr="",
+    )
+    monkeypatch.setattr(deploy_cf.subprocess, "run", lambda *a, **k: list_result)
+    monkeypatch.setattr(
+        deploy_cf,
+        "_run",
+        lambda *a, **k: pytest.fail("must not delete when the exact worker is absent"),
+    )
+
+    deploy_cf._recreate_container("wet-mcp-worker", dry=False, cwd=pathlib.Path("."))
+
+
+def test_recreate_option_runs_after_migrations_before_deploy(monkeypatch):
+    events: list[str] = []
+    monkeypatch.setattr(deploy_cf, "_load_deploy_config", lambda repo: _fake_cfg())
+    monkeypatch.setattr(
+        deploy_cf,
+        "_run",
+        lambda cmd, **kw: events.append("deploy" if "deploy" in cmd else "other"),
+    )
+    monkeypatch.setattr(deploy_cf, "_wait_ready", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_cf, "_set_image_tag", lambda *a, **k: None)
+    monkeypatch.setattr(
+        deploy_cf,
+        "_apply_d1_migrations",
+        lambda *a, **k: events.append("migrations"),
+    )
+    monkeypatch.setattr(
+        deploy_cf,
+        "_recreate_container",
+        lambda *a, **k: events.append("recreate"),
+    )
+
+    assert (
+        deploy_cf.main(
+            ["--skip-build", "--recreate-container", "--no-canary", "--tag", "t1"]
+        )
+        == 0
+    )
+    assert (
+        events.index("migrations") < events.index("recreate") < events.index("deploy")
+    )
+
+
 def test_migrations_apply_runs_before_wrangler_deploy(monkeypatch):
     """Schema first, then code. Deploying the worker before the columns exist
     leaves a live window where the new code 500s on a missing column."""


### PR DESCRIPTION
## Summary\n- add opt-in recovery that lists Cloudflare Containers as JSON and deletes only the exact configured worker ID\n- expose the recovery input in CD and document the safe procedure\n- increase the Windows pre-commit pytest timeout to 120s to avoid false-negative async/DNS timeout under concurrent harness load\n\n## Verification\n- targeted migration/template tests: 15 passed\n- full suite: 2374 passed, 35 skipped, 140 deselected\n- pre-commit: passed\n\n## Recovery scope\nThe normal deploy path is unchanged; recovery is enabled only with ecreate_container=true.