### PR TITLE
fix: isolate search quality harness from legacy drive credentials

### DIFF
--- a/tests/search_quality/run_baseline.py
+++ b/tests/search_quality/run_baseline.py
@@ -154,18 +154,29 @@ def _payload(result: Any) -> dict[str, Any]:
     return data
 
 
+def _server_env(temp_path: Path) -> dict[str, str]:
+    """Build an isolated server environment for the search-quality protocol run."""
+    env = {
+        **os.environ,
+        "LOG_LEVEL": os.environ.get("LOG_LEVEL", "WARNING"),
+        "CACHE_DIR": str(temp_path / "cache"),
+        "DOCS_DB_PATH": str(temp_path / "docs.db"),
+        "DOWNLOAD_DIR": str(temp_path / "downloads"),
+        # Search quality exercises the web-search path, not legacy Drive sync.
+        # Blank both values so a stale one-sided local credential cannot prevent
+        # server startup after the Drive-to-Cloudflare cutover.
+        "GOOGLE_DRIVE_CLIENT_ID": "",
+        "GOOGLE_DRIVE_CLIENT_SECRET": "",
+    }
+    return env
+
+
 async def run(queries: list[dict[str, Any]]) -> dict[str, Any]:
     records: list[dict[str, Any]] = []
     runner_error: str | None = None
     with tempfile.TemporaryDirectory(prefix="wet-search-quality-") as temp_dir:
         temp_path = Path(temp_dir)
-        env = {
-            **os.environ,
-            "LOG_LEVEL": os.environ.get("LOG_LEVEL", "WARNING"),
-            "CACHE_DIR": str(temp_path / "cache"),
-            "DOCS_DB_PATH": str(temp_path / "docs.db"),
-            "DOWNLOAD_DIR": str(temp_path / "downloads"),
-        }
+        env = _server_env(temp_path)
         params = StdioServerParameters(command="uv", args=["run", "wet-mcp"], env=env)
         try:
             async with stdio_client(params) as (read_stream, write_stream):

--- a/tests/search_quality/test_run_baseline.py
+++ b/tests/search_quality/test_run_baseline.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from run_baseline import _payload, dedupe, filter_unusable, load_queries, score_one
+from run_baseline import (
+    _payload,
+    _server_env,
+    dedupe,
+    filter_unusable,
+    load_queries,
+    score_one,
+)
 
 
 def test_fixed_queries_have_scoring_metadata_and_topic_clusters():
@@ -76,3 +83,10 @@ def test_payload_extracts_json_from_mcp_untrusted_content_wrapper():
     assert _payload(result) == {
         "results": [{"url": "https://example.test", "title": "Result"}]
     }
+
+
+def test_server_env_disables_legacy_drive_pair_for_search_baseline(tmp_path):
+    env = _server_env(tmp_path)
+
+    assert env["GOOGLE_DRIVE_CLIENT_ID"] == ""
+    assert env["GOOGLE_DRIVE_CLIENT_SECRET"] == ""


### PR DESCRIPTION
Isolate the search-quality protocol runner from stale one-sided Google Drive credentials after the Cloudflare cutover. Add regression coverage. Verification: Ruff passed; targeted search-quality tests 5 passed; commit hooks passed.