### PR TITLE
fix: route Jina reranking through Cloudflare gateway

### DIFF
--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -14,6 +14,7 @@ for better precision. Pipeline: retrieve top-30 -> rerank -> return top-N.
 from __future__ import annotations
 
 from typing import Any, Protocol
+from urllib.parse import urlsplit, urlunsplit
 
 from loguru import logger
 
@@ -58,6 +59,7 @@ class CloudReranker:
     """Cloud reranking via mcp_core.llm (litellm passthrough)."""
 
     DEFAULT_MODEL = "rerank-v4.0-pro"
+    _CLOUDFLARE_AI_GATEWAY_HOST = "gateway.ai.cloudflare.com"
 
     def __init__(self, model: str | None = None, api_key: str | None = None):
         self.model = model or self.DEFAULT_MODEL
@@ -73,6 +75,59 @@ class CloudReranker:
             return f"jina_ai/{self.model}"
         return f"cohere/{self.model}"
 
+    @classmethod
+    def _is_cloudflare_jina_route(cls, model: str, api_base: str | None) -> bool:
+        """Return whether a Jina model targets the Cloudflare AI Gateway."""
+        if not api_base or not model.lower().startswith("jina_ai/"):
+            return False
+        return (
+            urlsplit(api_base).hostname or ""
+        ).lower() == cls._CLOUDFLARE_AI_GATEWAY_HOST
+
+    @staticmethod
+    def _cloudflare_rerank_api_base(api_base: str) -> str:
+        """Append only ``/rerank`` to a Cloudflare Gateway route."""
+        parts = urlsplit(api_base)
+        path = parts.path.rstrip("/")
+        if not path.lower().endswith("/rerank"):
+            path = f"{path}/rerank" if path else "/rerank"
+        return urlunsplit(
+            (parts.scheme, parts.netloc, path, parts.query, parts.fragment)
+        )
+
+    def _resolve_call_parameters(self) -> tuple[str, str | None, str | None]:
+        """Resolve model, endpoint, and key for the current rerank request.
+
+        LiteLLM's Jina transformer normalizes the path to ``/v1/rerank``;
+        Cohere leaves the explicit Cloudflare Gateway ``/rerank`` route intact.
+        """
+        from wet_mcp.credential_state import (
+            api_base_for_task,
+            api_key_for_model,
+            credentials_for_current_request,
+        )
+
+        litellm_model = self._litellm_model()
+        api_base = api_base_for_task("RERANK_API_BASE")
+        if litellm_model.lower().startswith("jina_ai/") and not api_base:
+            api_base = api_base_for_task("JINA_AI_API_BASE")
+
+        if self._is_cloudflare_jina_route(litellm_model, api_base):
+            assert api_base is not None
+            jina_model = litellm_model.split("/", 1)[1]
+            api_key = self.api_key or api_key_for_model(litellm_model)
+            if api_key is None:
+                api_key = (
+                    credentials_for_current_request().get("JINA_AI_API_KEY") or None
+                )
+            return (
+                f"cohere/{jina_model}",
+                self._cloudflare_rerank_api_base(api_base),
+                api_key,
+            )
+
+        return litellm_model, api_base, self.api_key or api_key_for_model(litellm_model)
+
     def _call_rerank(
         self, query: str, documents: list[str], top_n: int
     ) -> list[tuple[int, float]]:
@@ -80,9 +135,7 @@ class CloudReranker:
         # Lazy import: litellm costs ~1-2s on first import.
         from mcp_core.llm import rerank as core_rerank
 
-        from wet_mcp.credential_state import api_base_for_task, api_key_for_model
-
-        litellm_model = self._litellm_model()
+        litellm_model, api_base, api_key = self._resolve_call_parameters()
         # Resolve the provider key AND custom endpoint from the request-scoped
         # per-sub bucket (HTTP multi-user) or the process env (single-user);
         # explicit api_key wins. Avoids os.environ cross-user bleed. SSRF-vetted
@@ -92,8 +145,8 @@ class CloudReranker:
             query=query,
             documents=documents,
             top_n=top_n,
-            api_base=api_base_for_task("RERANK_API_BASE"),
-            api_key=self.api_key or api_key_for_model(litellm_model),
+            api_base=api_base,
+            api_key=api_key,
         )
 
         # litellm RerankResponse.results defaults to None and rerank items

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -4,6 +4,7 @@ Covers CloudReranker (litellm passthrough via mcp_core.llm), Qwen3Reranker,
 factory functions, and graceful fallback behavior.
 """
 
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -183,6 +184,121 @@ class TestCloudRerankerModelMapping:
         assert (
             CloudReranker(model="rerank-v3.5")._litellm_model() == "cohere/rerank-v3.5"
         )
+
+
+class TestCloudflareGatewayJinaRoute:
+    """Cloudflare AI Gateway's custom Jina route needs Cohere dispatch."""
+
+    def test_gateway_jina_uses_cohere_and_explicit_single_user_jina_key(
+        self, monkeypatch
+    ):
+        gateway_base = (
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/custom-jina/v1"
+        )
+        monkeypatch.setenv("JINA_AI_API_BASE", gateway_base)
+        monkeypatch.delenv("RERANK_API_BASE", raising=False)
+        monkeypatch.setenv("JINA_AI_API_KEY", "jina-single-user-key")
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+
+        from wet_mcp.credential_state import set_current_sub
+
+        set_current_sub(None)
+        reranker = CloudReranker(model="jina_ai/jina-reranker-v3")
+
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.9)])
+            reranker.rerank("query", ["document"], top_n=1)
+
+        call_kwargs = mock_rerank.call_args[1]
+        assert call_kwargs["model"] == "cohere/jina-reranker-v3"
+        assert call_kwargs["api_base"] == f"{gateway_base}/rerank"
+        assert call_kwargs["api_key"] == "jina-single-user-key"
+        assert os.environ["JINA_AI_API_KEY"] == "jina-single-user-key"
+
+    def test_gateway_jina_prefers_rerank_base_without_double_suffix(self, monkeypatch):
+        rerank_base = (
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/custom-jina/v1/rerank"
+        )
+        monkeypatch.setenv("RERANK_API_BASE", rerank_base)
+        monkeypatch.setenv(
+            "JINA_AI_API_BASE",
+            "https://gateway.ai.cloudflare.com/v1/other/route/custom-jina/v1",
+        )
+
+        reranker = CloudReranker(model="jina_ai/jina-reranker-v3", api_key="jina-key")
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.9)])
+            reranker.rerank("query", ["document"], top_n=1)
+
+        call_kwargs = mock_rerank.call_args[1]
+        assert call_kwargs["model"] == "cohere/jina-reranker-v3"
+        assert call_kwargs["api_base"] == rerank_base
+        assert call_kwargs["api_key"] == "jina-key"
+
+    @pytest.mark.parametrize(
+        ("model", "api_base", "expected_model"),
+        [
+            (
+                "jina_ai/jina-reranker-v3",
+                "https://api.jina.ai/v1",
+                "jina_ai/jina-reranker-v3",
+            ),
+            (
+                "cohere/rerank-v3.5",
+                "https://gateway.ai.cloudflare.com/v1/account/gateway/cohere/v1",
+                "cohere/rerank-v3.5",
+            ),
+        ],
+    )
+    def test_adapter_only_targets_cloudflare_jina_route(
+        self, monkeypatch, model, api_base, expected_model
+    ):
+        monkeypatch.setenv("RERANK_API_BASE", api_base)
+        reranker = CloudReranker(model=model, api_key="provider-key")
+
+        with patch("mcp_core.llm.rerank") as mock_rerank:
+            mock_rerank.return_value = _rerank_response([(0, 0.9)])
+            reranker.rerank("query", ["document"], top_n=1)
+
+        call_kwargs = mock_rerank.call_args[1]
+        assert call_kwargs["model"] == expected_model
+        assert call_kwargs["api_base"] == api_base
+        assert call_kwargs["api_key"] == "provider-key"
+
+    def test_gateway_jina_uses_per_sub_key_and_never_mutates_process_env(
+        self, monkeypatch, tmp_path
+    ):
+        gateway_base = (
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/custom-jina/v1"
+        )
+        monkeypatch.setenv("WET_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret")
+        monkeypatch.setenv("JINA_AI_API_KEY", "operator-key")
+        monkeypatch.delenv("RERANK_API_BASE", raising=False)
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+
+        from wet_mcp.credential_state import set_current_sub, store_for_sub
+
+        store_for_sub(
+            "user_a",
+            {"JINA_AI_API_KEY": "user-a-key", "JINA_AI_API_BASE": gateway_base},
+        )
+        reranker = CloudReranker(model="jina_ai/jina-reranker-v3")
+
+        try:
+            set_current_sub("user_a")
+            with patch("mcp_core.llm.rerank") as mock_rerank:
+                mock_rerank.return_value = _rerank_response([(0, 0.9)])
+                reranker.rerank("query", ["document"], top_n=1)
+
+            call_kwargs = mock_rerank.call_args[1]
+            assert call_kwargs["model"] == "cohere/jina-reranker-v3"
+            assert call_kwargs["api_base"] == f"{gateway_base}/rerank"
+            assert call_kwargs["api_key"] == "user-a-key"
+            assert os.environ["JINA_AI_API_KEY"] == "operator-key"
+            assert "COHERE_API_KEY" not in os.environ
+        finally:
+            set_current_sub(None)
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route Jina reranking through the Cloudflare AI Gateway custom-Jina endpoint using the compatible Cohere adapter
- preserve per-user Jina endpoint/key resolution without mutating process-wide environment state
- cover explicit rerank-base precedence, direct-provider non-regression, and multi-user isolation

## Verification
- uv run pytest -q tests/test_reranker.py tests/test_embed_rerank_cloud.py tests/test_credential_state.py --timeout=120 — 99 passed
- uv run pytest --tb=short -q --timeout=120 — 2380 passed, 35 skipped, 140 deselected
- pre-commit: gitleaks, ruff, format, ty, pytest, whitespace/conflict/Unicode checks passed

Refs #1656