### PR TITLE
fix: wait for backend readiness before first request

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -70,6 +70,7 @@ _RERANK_CANDIDATE_MULTIPLIER = 3
 _web_cache: WebCache | None = None
 _docs_db: DocsDB | None = None
 _embedding_dims: int = 0
+_backend_init_task: asyncio.Task | None = None
 
 # Strong references to fire-and-forget background tasks. asyncio keeps only a
 # WEAK reference to a running task, so a task whose handle is discarded can be
@@ -111,6 +112,16 @@ def _launch_background_task(coro, label: str) -> asyncio.Task:
     _background_tasks.add(task)
     task.add_done_callback(functools.partial(_on_background_task_done, label=label))
     return task
+
+
+async def _wait_for_backend_init() -> None:
+    """Wait for startup backend initialization when it is still running."""
+    task = _backend_init_task
+    if task is None or task.done():
+        return
+    # A canceled request must not cancel the shared startup task. Shutdown
+    # owns cancellation of that task explicitly in _lifespan_shutdown.
+    await asyncio.shield(task)
 
 
 def _missing_docs_db_methods(backend) -> list[str]:
@@ -334,7 +345,7 @@ async def _lifespan(_server: FastMCP):
 
 async def _lifespan_startup() -> asyncio.Task | None:
     """Initialize all server components. Returns SearXNG warmup task."""
-    global _web_cache, _docs_db, _embedding_dims
+    global _backend_init_task, _web_cache, _docs_db, _embedding_dims
 
     logger.info("Starting WET MCP Server...")
 
@@ -417,7 +428,7 @@ async def _lifespan_startup() -> asyncio.Task | None:
         except Exception as e:
             logger.error(f"Background backend init failed: {e}")
 
-    _launch_background_task(_init_backends_task(), "init-backends")
+    _backend_init_task = _launch_background_task(_init_backends_task(), "init-backends")
 
     # 5. Initialize docs DB (sqlite or cf-d1) via the backend factory, then run
     #    Alembic migrations (auto-migrate-on-startup with backup-before-migrate
@@ -473,7 +484,7 @@ async def _lifespan_startup() -> asyncio.Task | None:
 
 async def _lifespan_shutdown(warmup_task: asyncio.Task | None) -> None:
     """Shut down all server components."""
-    global _web_cache, _docs_db
+    global _backend_init_task, _web_cache, _docs_db
 
     logger.info("Shutting down WET MCP Server...")
 
@@ -484,6 +495,16 @@ async def _lifespan_shutdown(warmup_task: asyncio.Task | None) -> None:
             await warmup_task
         except (asyncio.CancelledError, Exception):
             pass
+
+    # Backend initialization is tracked separately because embedding and
+    # reranking requests wait for it while startup is still in progress.
+    if _backend_init_task and not _backend_init_task.done():
+        _backend_init_task.cancel()
+        try:
+            await _backend_init_task
+        except (asyncio.CancelledError, Exception):
+            pass
+    _backend_init_task = None
 
     # Stop auto-sync (whichever backend is active)
     from wet_mcp.config import settings
@@ -751,6 +772,8 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
         is_query: If True, use query_embed for instruction-aware asymmetric
             retrieval (Qwen3). Document embeddings stay raw.
     """
+    await _wait_for_backend_init()
+
     from wet_mcp.embedder import (
         Qwen3EmbedBackend,
         _is_retryable,
@@ -784,6 +807,8 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
 
 async def _embed_batch(texts: list[str]) -> list[list[float]] | None:
     """Embed batch of texts if backend is available."""
+    await _wait_for_backend_init()
+
     from wet_mcp.embedder import _is_retryable, resolve_embed_backend_for_request
 
     backend = resolve_embed_backend_for_request()
@@ -819,6 +844,8 @@ async def _rerank_results(
 
     Falls back to original results if reranking fails or is unavailable.
     """
+    await _wait_for_backend_init()
+
     from wet_mcp.reranker import resolve_rerank_backend_for_request
 
     reranker = resolve_rerank_backend_for_request()
@@ -2060,6 +2087,8 @@ def _active_docs_backend() -> str:
 
 
 async def _handle_config_status() -> dict[str, Any]:
+    await _wait_for_backend_init()
+
     from wet_mcp.embedder import (
         embedding_unavailable_reason,
         resolve_embed_backend_for_request,
@@ -2839,6 +2868,8 @@ async def _background_index_and_search(
         # path can both read it back.
         keyword_only_reason: str | None = None
         if all_chunks:
+            await _wait_for_backend_init()
+
             from wet_mcp.embedder import (
                 embedding_unavailable_reason,
                 resolve_embed_backend_for_request,

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -17,6 +17,26 @@ from structured import payload, text
 
 from wet_mcp import server
 
+
+async def test_rerank_waits_for_background_backend_initialization(monkeypatch):
+    """A first request must not silently bypass a backend still starting."""
+    ready = asyncio.Event()
+
+    async def _pending_backend_init():
+        await ready.wait()
+
+    backend_init_task = asyncio.create_task(_pending_backend_init())
+    monkeypatch.setattr(server, "_backend_init_task", backend_init_task, raising=False)
+    results = [{"content": "doc-a"}, {"content": "doc-b"}]
+    rerank_task = asyncio.create_task(server._rerank_results("query", results, 1))
+
+    await asyncio.sleep(0)
+    assert not rerank_task.done()
+
+    ready.set()
+    assert await rerank_task == [{"content": "doc-a"}]
+
+
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause
The server launched embedding/reranking initialization as fire-and-forget work. A first request could resolve an unavailable backend before startup completed and silently bypass reranking/embedding.

## Fix
Track the backend initialization task, await it from backend-dependent request paths with cancellation shielding, and cancel/await it during shutdown.

## Verification
- Full local suite: 2381 passed, 35 skipped, 140 deselected
- Targeted server suite: 120 passed
- Regression test: backend readiness wait passes
- Ruff, ty, gitleaks, diff check, and pre-commit pass
- Exact 24-query protocol rerun follows after merge

The search-quality acceptance remains open pending exact post-merge metrics.