### PR TITLE
fix: stabilize s3 auto-sync error test

### DIFF
--- a/tests/test_sync_backend_resolve.py
+++ b/tests/test_sync_backend_resolve.py
@@ -283,15 +283,27 @@ async def test_s3_auto_sync_loop_push_error_is_non_fatal(monkeypatch, tmp_path) 
 
     fake_backend = MagicMock()
     fake_backend.pull = AsyncMock(return_value=None)
-    fake_backend.push = AsyncMock(side_effect=RuntimeError("boom"))
+    second_push_attempted = _asyncio.Event()
+    push_attempts = 0
+
+    async def failing_push(*_args: object, **_kwargs: object) -> None:
+        nonlocal push_attempts
+        push_attempts += 1
+        if push_attempts >= 2:
+            second_push_attempted.set()
+        raise RuntimeError("boom")
+
+    fake_backend.push = AsyncMock(side_effect=failing_push)
 
     monkeypatch.setattr("wet_mcp.sync.get", lambda name: fake_backend)
 
     task = _asyncio.create_task(_s3_auto_sync_loop(db=MagicMock()))
-    await _asyncio.sleep(0.2)
-    assert fake_backend.push.await_count >= 2  # still ticking after error
-    task.cancel()
     try:
-        await task
-    except _asyncio.CancelledError:
-        pass
+        await _asyncio.wait_for(second_push_attempted.wait(), timeout=5.0)
+        assert fake_backend.push.await_count >= 2  # still ticking after error
+    finally:
+        task.cancel()
+        try:
+            await task
+        except _asyncio.CancelledError:
+            pass


### PR DESCRIPTION
## Root cause

The test used a fixed wall-clock sleep before asserting that the background loop had attempted a second push. Under Windows scheduler contention, the assertion could run with `await_count == 1`, while the second tick and error log appeared during teardown.

## Fix

- Signal an `asyncio.Event` from the failing backend on the second push attempt.
- Wait for that deterministic condition with a bounded timeout instead of sleeping for an assumed duration.
- Always cancel and await the background task in `finally`.
- Leave production sync behavior unchanged.

## Verification

- RED under Windows contention: `AssertionError: assert 1 >= 2`; second push error logged during teardown.
- Exact target: `1 passed in 42.43s`.
- Repeated target collection: `10 passed, 180 deselected in 44.92s`.
- Relevant sync suite: `151 passed, 7 warnings in 84.75s`.
- `ruff check .`: passed.
- `ruff format --check .`: `239 files already formatted`.
- `ty check`: passed.
- Full `pre-commit run --all-files`: passed.