### PR TITLE
fix: preserve usable web search results

### DIFF
--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -849,7 +849,7 @@ async def _rerank_results(
     from wet_mcp.reranker import resolve_rerank_backend_for_request
 
     reranker = resolve_rerank_backend_for_request()
-    if not reranker or len(results) <= top_n:
+    if not reranker or len(results) < top_n:
         return results[:top_n]
 
     try:
@@ -1267,19 +1267,33 @@ async def search(  # noqa: PLR0913
 
                     # Rerank by semantic relevance (same as research/docs)
                     try:
-                        results_list = data.get("results", [])
+                        raw_results = data.get("results", [])
+                        results_list = [
+                            r
+                            for r in raw_results
+                            if any(
+                                isinstance(value, str) and value.strip()
+                                for value in (r.get("content"), r.get("snippet"))
+                            )
+                        ]
+                        if len(results_list) != len(raw_results):
+                            data["results"] = results_list[:max_results]
+                            data["total"] = len(data["results"])
+                            modified = True
                         if results_list:
-                            # Map snippet -> content for reranker (fallback to title)
+                            # Normalize the usable body for reranking and output.
                             for r in results_list:
-                                if "content" not in r:
-                                    r["content"] = r.get("snippet", r.get("title", ""))
+                                content = r.get("content")
+                                snippet = r.get("snippet")
+                                if not isinstance(content, str) or not content.strip():
+                                    r["content"] = snippet
+                                if not isinstance(snippet, str) or not snippet.strip():
+                                    r["snippet"] = r["content"]
                             reranked = await _rerank_results(
                                 query, results_list, top_n=max_results
                             )
                             if reranked:
-                                data["results"] = [
-                                    r for r in reranked if r.get("score", 1.0) > 0.2
-                                ]
+                                data["results"] = reranked
                                 data["total"] = len(data["results"])
                                 modified = True
                     except Exception as e:

--- a/tests/test_multiuser_llm_gate_and_backend.py
+++ b/tests/test_multiuser_llm_gate_and_backend.py
@@ -25,6 +25,8 @@ CRITICAL multi-user invariant: per-sub creds NEVER touch the process-global
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from wet_mcp.credential_state import (
@@ -442,6 +444,135 @@ class TestLiveDispatchWiring:
         assert captured["api_key"] == "co_a"
         # top result is index 1 (doc-b) per the fake scores.
         assert ranked[0]["content"] == "doc-b"
+
+    async def test_rerank_applies_semantic_order_when_candidates_equal_top_n(
+        self, monkeypatch
+    ):
+        """Candidate-count equality must not bypass an available cloud reranker."""
+        from wet_mcp import server
+
+        store_for_sub(
+            "user_a",
+            {"RERANK_MODELS": "cohere/rerank-v3.5", "COHERE_API_KEY": "co_a"},
+        )
+        captured: dict = {}
+
+        def fake_rerank(**kwargs):
+            captured.update(kwargs)
+
+            class _R:
+                results = [
+                    {"index": 1, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.1},
+                ]
+
+            return _R()
+
+        monkeypatch.setattr("mcp_core.llm.rerank", fake_rerank)
+        set_current_sub("user_a")
+        results = [
+            {"content": "keyword-first"},
+            {"content": "semantic-first"},
+        ]
+
+        ranked = await server._rerank_results("semantic query", results, top_n=2)
+
+        assert [result["content"] for result in ranked] == [
+            "semantic-first",
+            "keyword-first",
+        ]
+        assert captured["top_n"] == 2
+
+    async def test_web_search_reranks_only_structurally_usable_results(
+        self, monkeypatch
+    ):
+        """Web search fills top_n from usable results regardless of score scale."""
+        from wet_mcp import server
+
+        store_for_sub(
+            "user_a",
+            {"RERANK_MODELS": "cohere/rerank-v3.5", "COHERE_API_KEY": "co_a"},
+        )
+
+        def fake_rerank(**kwargs):
+            relevance_by_document = {
+                "\t": 0.99,
+                "Best semantic result.": 0.19,
+                "Second-best semantic result.": 0.05,
+                "A less relevant candidate.": 0.01,
+            }
+            ranked = sorted(
+                enumerate(kwargs["documents"]),
+                key=lambda item: relevance_by_document[item[1]],
+                reverse=True,
+            )[: kwargs["top_n"]]
+
+            class _R:
+                results = [
+                    {
+                        "index": index,
+                        "relevance_score": relevance_by_document[document],
+                    }
+                    for index, document in ranked
+                ]
+
+            return _R()
+
+        async def fake_search_chain(**_kwargs):
+            return json.dumps(
+                {
+                    "results": [
+                        {
+                            "title": "semantic-second-low-score",
+                            "url": "https://example.com/second",
+                            "snippet": "Second-best semantic result.",
+                        },
+                        {
+                            "title": "empty-structural-result",
+                            "url": "https://account.apple.com/",
+                            "snippet": "",
+                            "content": "\t",
+                        },
+                        {
+                            "title": "not-selected",
+                            "url": "https://example.com/other",
+                            "snippet": "A less relevant candidate.",
+                        },
+                        {
+                            "title": "semantic-best-low-score",
+                            "url": "https://example.com/best",
+                            "snippet": "Best semantic result.",
+                        },
+                    ],
+                    "total": 4,
+                }
+            )
+
+        async def fake_ensure_searxng():
+            return "http://searxng.test"
+
+        monkeypatch.setattr("mcp_core.llm.rerank", fake_rerank)
+        monkeypatch.setattr(server, "_require_credentials", lambda: None)
+        monkeypatch.setattr(server, "is_uvx_tool_venv", lambda: False)
+        monkeypatch.setattr(server, "_web_cache", None)
+        monkeypatch.setattr(server, "ensure_searxng", fake_ensure_searxng)
+        monkeypatch.setattr(
+            server.search_backends, "chain_backend_names", lambda: ["searxng"]
+        )
+        monkeypatch.setattr(
+            server.search_backends, "run_search_chain", fake_search_chain
+        )
+        set_current_sub("user_a")
+
+        response = await server.search("search", query="semantic query", max_results=2)
+        results = response.structuredContent["results"]
+
+        assert [result["title"] for result in results] == [
+            "semantic-best-low-score",
+            "semantic-second-low-score",
+        ]
+        assert [result["score"] for result in results] == [0.19, 0.05]
+        assert response.structuredContent["total"] == 2
 
     async def test_single_user_embed_unchanged(self, monkeypatch):
         """sub=None still uses the startup singleton (no behaviour change)."""

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -87,7 +87,12 @@ async def test_external_tool_marks_both_channels():
 
 
 async def test_search_marks_both_channels():
-    chain = json.dumps({"results": [{"url": "https://e", "title": "T"}], "total": 1})
+    chain = json.dumps(
+        {
+            "results": [{"url": "https://e", "title": "T", "snippet": "usable result"}],
+            "total": 1,
+        }
+    )
     with (
         patch(
             "wet_mcp.server.ensure_searxng",


### PR DESCRIPTION
Closes #1656

- rerank candidates when count equals top_n
- remove structurally empty search entries before reranking
- preserve low but valid provider scores instead of a fixed global cutoff
- cover the exact regression and structured-output contract

Verification:
- full pre-commit hook passed
- exact search/structured-output regression: 3 passed