### PR TITLE
fix: separate Renovate range and lock ownership

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   "labels": [
     "dependencies"
   ],
-  "rangeStrategy": "bump",
+  "rangeStrategy": "widen",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -24,6 +24,14 @@
     "commitMessageAction": "lock file maintenance"
   },
   "packageRules": [
+    {
+      "matchCategories": [
+        "golang"
+      ],
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
+    },
     {
       "description": "Group minor updates for review (prod scope by default)",
       "matchUpdateTypes": [
@@ -84,8 +92,8 @@
     },
     {
       "description": "Pin PSR to v10 — block Renovate downgrades",
-      "matchPackagePatterns": [
-        "^python-semantic-release/"
+      "matchPackageNames": [
+        "/^python-semantic-release//"
       ],
       "matchManagers": [
         "github-actions"
@@ -131,10 +139,5 @@
   "commitMessageAction": "update",
   "commitMessageTopic": "{{depName}}",
   "semanticCommitType": "fix",
-  "semanticCommitScope": "deps",
-  "golang": {
-    "postUpdateOptions": [
-      "gomodTidy"
-    ]
-  }
+  "semanticCommitScope": "deps"
 }

--- a/tests/test_renovate_config.py
+++ b/tests/test_renovate_config.py
@@ -1,0 +1,48 @@
+"""Regression tests for Renovate's dependency update responsibilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "renovate.json"
+
+
+def _load_config() -> dict[str, Any]:
+    return json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def test_library_ranges_and_lock_refreshes_have_separate_owners() -> None:
+    config = _load_config()
+    package_rules = config["packageRules"]
+
+    assert config["rangeStrategy"] == "widen"
+    assert config["lockFileMaintenance"]["enabled"] is True
+    assert config["lockFileMaintenance"]["schedule"]
+    assert all("rangeStrategy" not in rule for rule in package_rules)
+
+    rules_by_slug = {
+        rule["groupSlug"]: rule for rule in package_rules if "groupSlug" in rule
+    }
+    for group_slug in ("non-major-dev", "all-patch", "gha-digests"):
+        assert rules_by_slug[group_slug]["minimumReleaseAge"] == "7 days"
+
+
+def test_config_does_not_require_known_renovate_migrations() -> None:
+    config = _load_config()
+    package_rules = config["packageRules"]
+
+    assert "golang" not in config
+    assert {
+        "matchCategories": ["golang"],
+        "postUpdateOptions": ["gomodTidy"],
+    } in package_rules
+    assert all("matchPackagePatterns" not in rule for rule in package_rules)
+
+    psr_rule = next(
+        rule
+        for rule in package_rules
+        if rule.get("description") == "Pin PSR to v10 — block Renovate downgrades"
+    )
+    assert psr_rule["matchPackageNames"] == ["/^python-semantic-release//"]


### PR DESCRIPTION
Fixes the configuration-level cause of artifact churn in grouped dependency PRs.`n`n- widen declared ranges without making patch PRs own lock refreshes`n- keep scheduled lock-file maintenance as the sole refresh owner`n- migrate deprecated Renovate keys and validate the official schema`n- add regression tests for ownership and cooldown invariants`n`nVerification: focused pytest 2 passed; official Renovate config validator passed; full pre-commit passed at commit time.`n`nFollow-up in this campaign: rebase PR #1659 and verify renovate/artifacts plus stability semantics on the regenerated branch.