### PR TITLE
fix: preserve crawler SSRF transport protection

### DIFF
--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -683,7 +683,6 @@ async def download_media(
     output_path = Path(output_dir).expanduser().resolve()
     output_path.mkdir(parents=True, exist_ok=True)
 
-    transport = httpx.AsyncHTTPTransport(retries=3)
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -776,7 +775,7 @@ async def download_media(
                 }
 
     async with _safe_httpx_client(
-        timeout=settings.crawler_timeout, transport=transport, headers=headers
+        timeout=settings.crawler_timeout, headers=headers
     ) as client:
         tasks = [_download_one(url, client) for url in media_urls]
         results = await asyncio.gather(*tasks)

--- a/tests/test_crawler_download.py
+++ b/tests/test_crawler_download.py
@@ -56,6 +56,29 @@ async def test_download_media_success(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_download_media_uses_ssrf_safe_transport(tmp_path):
+    """Media downloads must keep web-core's SSRF-protected transport."""
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"safe content"
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_client
+    mock_client_instance.__aexit__.return_value = None
+    mock_client_factory = MagicMock(return_value=mock_client_instance)
+
+    with patch("wet_mcp.sources.crawler._safe_httpx_client", mock_client_factory):
+        await download_media(["http://example.com/file.txt"], str(tmp_path))
+
+    assert "transport" not in mock_client_factory.call_args.kwargs
+
+
+@pytest.mark.asyncio
 async def test_download_media_protocol_relative(tmp_path):
     """Test handling of protocol-relative URLs."""
     mock_content = b"image data"


### PR DESCRIPTION
## Summary
- preserve web-core SSRF/DNS-rebinding protection for media downloads
- remove the raw `httpx.AsyncHTTPTransport` override that bypassed the safe client transport
- add a regression test asserting `download_media` does not pass a custom transport

## Verification
- exact RED: `1 failed` with the unsafe `transport` kwarg
- exact GREEN: `tests/test_crawler_download.py` — `5 passed`
- `tests/test_crawler_comprehensive.py` — `34 passed`
- pre-commit hooks passed on commit `cb8763e`