### PR TITLE
fix: enforce robots policy in crawler actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ mise run dev       # uv run wet-mcp
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
 - Browser render backends (headless leg of `extract`): `BROWSER_BACKENDS` (CSV escalation chain: `native` | `browserless` | `cf-browser-rendering`; empty = `native`), `BROWSERLESS_URL`/`BROWSERLESS_TOKEN` (self-host browserless), `CF_BROWSER_RENDERING_TOKEN`/`CF_ACCOUNT_ID` (Cloudflare Browser Rendering), `CAPSOLVER_API_KEY` (optional key-gated captcha tier)
+- Robots policy: `RESPECT_ROBOTS_TXT` (default `false`); set `true` to enforce `robots.txt` for the ScrapingAgent extract chain and Crawl4AI `crawl`, `sitemap`, and `list_media` actions
 - Disable-local toggles (skip heavy in-process fallbacks per capability): `DISABLE_LOCAL_BROWSER`, `DISABLE_LOCAL_SEARCH`, `DISABLE_LOCAL_EMBED`, `DISABLE_LOCAL_RERANK`
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ mise run dev       # uv run wet-mcp
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
 - Browser render backends (headless leg of `extract`): `BROWSER_BACKENDS` (CSV escalation chain: `native` | `browserless` | `cf-browser-rendering`; empty = `native`), `BROWSERLESS_URL`/`BROWSERLESS_TOKEN` (self-host browserless), `CF_BROWSER_RENDERING_TOKEN`/`CF_ACCOUNT_ID` (Cloudflare Browser Rendering), `CAPSOLVER_API_KEY` (optional key-gated captcha tier)
+- Robots policy: `RESPECT_ROBOTS_TXT` (default `false`); set `true` to enforce `robots.txt` for the ScrapingAgent extract chain and Crawl4AI `crawl`, `sitemap`, and `list_media` actions
 - Disable-local toggles (skip heavy in-process fallbacks per capability): `DISABLE_LOCAL_BROWSER`, `DISABLE_LOCAL_SEARCH`, `DISABLE_LOCAL_EMBED`, `DISABLE_LOCAL_RERANK`
 - Sync: `SYNC_ENABLED` (default true), `GOOGLE_DRIVE_CLIENT_ID` (required for sync), `SYNC_FOLDER` (default "wet-mcp"), `SYNC_INTERVAL` (default 300s)
 - Sync dung Google Drive API truc tiep (httpx). OAuth Device Code flow, token luu tai `~/.wet-mcp/tokens/google_drive.json`

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ Browser Rendering -- set `CF_ACCOUNT_ID` + `CF_BROWSER_RENDERING_TOKEN`). Empty
 chain falls back to `native`. Set `CAPSOLVER_API_KEY` to append an optional,
 key-gated CAPTCHA tier as the last escalation step.
 
+**Robots policy** -- set `RESPECT_ROBOTS_TXT=true` to enforce `robots.txt`
+across both the `extract` strategy chain and the Crawl4AI-backed `crawl`,
+`sitemap`, and `list_media` actions. The default is `false` to preserve existing
+deployment behaviour; configure this process-level policy explicitly when the
+operator requires robots enforcement.
+
 **Disable local fallbacks** -- opt out of the heavy in-process local fallbacks
 per capability (e.g. on a slim container that renders/searches/embeds via cloud
 backends only): `DISABLE_LOCAL_BROWSER`, `DISABLE_LOCAL_SEARCH`,

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -109,6 +109,8 @@ class Settings(BaseSettings):
     - EMBEDDING_DIMS: Embedding dimensions (0 = auto-detect, default 768)
     - RERANK_ENABLED: Enable reranking (default: true)
     - RERANK_TOP_N: Return top N results after reranking (default: 10)
+    - RESPECT_ROBOTS_TXT: Enforce robots.txt for extract and crawler actions
+        (default: false)
     - EMBEDDING_MODEL / EMBEDDING_BACKEND / RERANK_MODEL / RERANK_BACKEND:
         DEPRECATED (2026-06-11) -- singular model + backend env vars, folded
         into the plural *_MODELS chain (honored one release with a warning).
@@ -154,6 +156,7 @@ class Settings(BaseSettings):
     # Crawler
     crawler_headless: bool = True
     crawler_timeout: int = 60
+    respect_robots_txt: bool = False  # env RESPECT_ROBOTS_TXT
 
     # Browser backend chain for the headless (JS-render) leg. BROWSER_BACKENDS
     # CSV (order = agent escalation/fallback): native (in-process chromium) |

--- a/src/wet_mcp/sources/crawler.py
+++ b/src/wet_mcp/sources/crawler.py
@@ -126,6 +126,14 @@ def _get_semaphore() -> asyncio.Semaphore:
     return _browser_semaphore
 
 
+def _crawler_run_config() -> CrawlerRunConfig:
+    """Build the shared Crawl4AI run policy for legacy crawler actions."""
+    return CrawlerRunConfig(
+        verbose=False,
+        check_robots_txt=settings.respect_robots_txt,
+    )
+
+
 def _cleanup_browser_data_dir() -> None:
     """Remove browser data directory to clear stale locks and state."""
     import shutil
@@ -274,8 +282,8 @@ def _build_scraping_agent(stealth: bool = True) -> ScrapingAgent:
     on arbitrary URLs; patchright pulls in heavier optional deps); ``captcha`` is
     appended separately as a key-gated tier (see _build_scraping_agent callers).
 
-    ``respect_robots`` stays False to preserve wet's historical behaviour;
-    callers wanting robots compliance can override via env in a follow-up.
+    ``respect_robots`` follows ``RESPECT_ROBOTS_TXT``. The setting defaults to
+    False to preserve wet's historical behaviour for existing deployments.
     """
     strategies: dict[str, Any] = {
         "basic_http": BasicHTTPStrategy(timeout=settings.crawler_timeout),
@@ -292,7 +300,10 @@ def _build_scraping_agent(stealth: bool = True) -> ScrapingAgent:
         strategies["captcha"] = CaptchaStrategy(
             capsolver_api_key=settings.capsolver_api_key
         )
-    return ScrapingAgent(strategies=strategies, respect_robots=False)
+    return ScrapingAgent(
+        strategies=strategies,
+        respect_robots=settings.respect_robots_txt,
+    )
 
 
 async def _get_scraping_agent(stealth: bool = True) -> ScrapingAgent:
@@ -504,7 +515,7 @@ async def crawl(
                 try:
                     result = await crawler.arun(  # ty: ignore[missing-argument]
                         url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
-                        config=CrawlerRunConfig(verbose=False),
+                        config=_crawler_run_config(),
                     )
 
                     if result.success:
@@ -594,8 +605,12 @@ async def sitemap(
                 try:
                     result = await crawler.arun(  # ty: ignore[missing-argument]
                         url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
-                        config=CrawlerRunConfig(verbose=False),
+                        config=_crawler_run_config(),
                     )
+
+                    if settings.respect_robots_txt and not result.success:
+                        site_urls.pop()
+                        continue
 
                     if result.success and current_depth < depth:
                         for link in result.links.get("internal", [])[:20]:
@@ -641,7 +656,7 @@ async def list_media(
     async with sem:
         result = await crawler.arun(  # ty: ignore[missing-argument]
             url,  # type: ignore[invalid-argument-type]  # ty: ignore[invalid-argument-type]
-            config=CrawlerRunConfig(verbose=False),
+            config=_crawler_run_config(),
         )
 
         if not result.success:

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -68,6 +68,7 @@ export interface Env {
   DISABLE_LOCAL_RERANK?: string
   DISABLE_LOCAL_SEARCH?: string
   DISABLE_LOCAL_BROWSER?: string
+  RESPECT_ROBOTS_TXT?: string
 }
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the container
@@ -87,11 +88,12 @@ const CONTAINER_ENV_KEYS = [
   'BROWSERLESS_URL', 'BROWSERLESS_TOKEN', 'CAPSOLVER_API_KEY',
   'DISABLE_LOCAL_EMBED', 'DISABLE_LOCAL_RERANK',
   'DISABLE_LOCAL_SEARCH', 'DISABLE_LOCAL_BROWSER',
+  'RESPECT_ROBOTS_TXT',
   // CF AI Gateway (llm-main) litellm routing
   'OPENROUTER_API_BASE', 'OPENROUTER_API_KEY', 'JINA_AI_API_BASE',
 ] as const
 
-function pickContainerEnv(env: Env): Record<string, string> {
+export function pickContainerEnv(env: Env): Record<string, string> {
   const out: Record<string, string> = {}
   for (const k of CONTAINER_ENV_KEYS) {
     const v = (env as unknown as Record<string, unknown>)[k]

--- a/tests/test_browser_backends.py
+++ b/tests/test_browser_backends.py
@@ -135,3 +135,19 @@ def test_captcha_tier_absent_when_no_key(monkeypatch):
     agent = _build_scraping_agent(stealth=True)
     assert "captcha" not in agent.strategies
     assert "basic_http" in agent.strategies
+
+
+def test_scraping_agent_uses_configured_robots_policy(monkeypatch):
+    _set_browser(monkeypatch, respect_robots_txt=True)
+
+    agent = _build_scraping_agent(stealth=True)
+
+    assert agent.respect_robots is True
+
+
+def test_scraping_agent_defaults_to_disabled_robots_policy(monkeypatch):
+    _set_browser(monkeypatch)
+
+    agent = _build_scraping_agent(stealth=True)
+
+    assert agent.respect_robots is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,6 +134,18 @@ class TestCleanEnvCoverage:
         assert missing == []
 
 
+def test_robots_policy_preserves_legacy_default():
+    """Existing deployments keep robots checks disabled unless opted in."""
+    assert Settings().respect_robots_txt is False
+
+
+def test_robots_policy_reads_environment(monkeypatch):
+    """RESPECT_ROBOTS_TXT is the explicit process-level policy switch."""
+    monkeypatch.setenv("RESPECT_ROBOTS_TXT", "true")
+
+    assert Settings().respect_robots_txt is True
+
+
 def test_setup_api_keys_valid():
     """Test setup_api_keys with valid input."""
     settings = Settings(api_keys=SecretStr("GOOGLE_API_KEY:abc,OPENAI_API_KEY:xyz"))

--- a/tests/test_crawler_comprehensive.py
+++ b/tests/test_crawler_comprehensive.py
@@ -182,6 +182,28 @@ async def test_crawl_success():
 
 
 @pytest.mark.asyncio
+async def test_crawl_robots_blocked_result_is_excluded(monkeypatch):
+    mock_crawler = MockAsyncWebCrawler()
+    mock_crawler.arun.return_value = MockCrawlerResult(
+        success=False,
+        error_message="robots.txt disallows the URL",
+    )
+    monkeypatch.setattr(crawler.settings, "respect_robots_txt", True)
+
+    with (
+        patch(
+            "wet_mcp.sources.crawler._get_crawler",
+            new=AsyncMock(return_value=mock_crawler),
+        ),
+        patch("wet_mcp.sources.crawler.is_safe_url", return_value=True),
+    ):
+        result_json = await crawler.crawl(["https://safe.com"], depth=0)
+
+    assert json.loads(result_json) == []
+    assert mock_crawler.arun.await_args.kwargs["config"].check_robots_txt is True
+
+
+@pytest.mark.asyncio
 async def test_crawl_unsafe_url():
     with patch("wet_mcp.sources.crawler.is_safe_url", return_value=False):
         with patch("wet_mcp.sources.crawler._get_crawler", new_callable=AsyncMock):
@@ -227,6 +249,50 @@ async def test_sitemap_success():
         assert "https://safe.com" in urls
         assert "https://safe.com/page2" in urls
         assert "https://safe.com/page3" in urls
+
+
+@pytest.mark.asyncio
+async def test_sitemap_robots_blocked_result_is_excluded_when_enabled(monkeypatch):
+    mock_crawler = MockAsyncWebCrawler()
+    mock_crawler.arun.return_value = MockCrawlerResult(
+        success=False,
+        error_message="robots.txt disallows the URL",
+    )
+    monkeypatch.setattr(crawler.settings, "respect_robots_txt", True)
+
+    with (
+        patch(
+            "wet_mcp.sources.crawler._get_crawler",
+            new=AsyncMock(return_value=mock_crawler),
+        ),
+        patch("wet_mcp.sources.crawler.is_safe_url", return_value=True),
+    ):
+        result_json = await crawler.sitemap(["https://safe.com"], depth=0)
+
+    assert json.loads(result_json) == []
+    assert mock_crawler.arun.await_args.kwargs["config"].check_robots_txt is True
+
+
+@pytest.mark.asyncio
+async def test_sitemap_failed_result_keeps_legacy_output_when_disabled(monkeypatch):
+    mock_crawler = MockAsyncWebCrawler()
+    mock_crawler.arun.return_value = MockCrawlerResult(
+        success=False,
+        error_message="robots.txt disallows the URL",
+    )
+    monkeypatch.setattr(crawler.settings, "respect_robots_txt", False)
+
+    with (
+        patch(
+            "wet_mcp.sources.crawler._get_crawler",
+            new=AsyncMock(return_value=mock_crawler),
+        ),
+        patch("wet_mcp.sources.crawler.is_safe_url", return_value=True),
+    ):
+        result_json = await crawler.sitemap(["https://safe.com"], depth=0)
+
+    assert json.loads(result_json) == [{"url": "https://safe.com", "depth": 0}]
+    assert mock_crawler.arun.await_args.kwargs["config"].check_robots_txt is False
 
 
 @pytest.mark.asyncio
@@ -278,6 +344,28 @@ async def test_list_media_success():
         assert len(data["videos"]) == 1
         assert "audio" in data
         assert len(data["audio"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_media_robots_blocked_result_returns_error(monkeypatch):
+    mock_crawler = MockAsyncWebCrawler()
+    mock_crawler.arun.return_value = MockCrawlerResult(
+        success=False,
+        error_message="robots.txt disallows the URL",
+    )
+    monkeypatch.setattr(crawler.settings, "respect_robots_txt", True)
+
+    with (
+        patch(
+            "wet_mcp.sources.crawler._get_crawler",
+            new=AsyncMock(return_value=mock_crawler),
+        ),
+        patch("wet_mcp.sources.crawler.is_safe_url", return_value=True),
+    ):
+        result_json = await crawler.list_media("https://safe.com")
+
+    assert json.loads(result_json) == {"error": "robots.txt disallows the URL"}
+    assert mock_crawler.arun.await_args.kwargs["config"].check_robots_txt is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_crawler_uses_scraping_agent.py
+++ b/tests/test_crawler_uses_scraping_agent.py
@@ -12,6 +12,38 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from web_core.scraper import RobotsCache, ScrapingAgent, ScrapingResult, StrategyCache
+
+
+class _FakeRobotsCache(RobotsCache):
+    def __init__(self, allowed: bool):
+        super().__init__(user_agent="test-agent")
+        self.allowed = allowed
+
+    async def is_allowed(self, url: str) -> bool:
+        return self.allowed
+
+
+def _build_actual_scraping_agent(*, respect_robots: bool):
+    strategy = MagicMock()
+    strategy.fetch = AsyncMock(
+        return_value=ScrapingResult(
+            content="x" * 120,
+            url="https://example.com/page",
+            strategy="fake",
+            status_code=200,
+        )
+    )
+    agent = ScrapingAgent(
+        strategies={"fake": strategy},
+        strategy_cache=StrategyCache(default_order=["fake"]),
+        robots_cache=_FakeRobotsCache(allowed=False),
+        max_retries=1,
+        min_content_length=1,
+        enable_selector_inference=False,
+        respect_robots=respect_robots,
+    )
+    return agent, strategy
 
 
 def _build_fake_agent(scrape_return: str | None = None, scrape_side_effect=None):
@@ -115,6 +147,53 @@ async def test_extract_agent_error_surfaces_in_result() -> None:
 
     pages = json.loads(result_json)
     assert "strategy chain exhausted" in pages[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_extract_actual_agent_blocks_before_strategy_when_robots_enabled() -> (
+    None
+):
+    """The real ScrapingAgent must enforce its RobotsCache before any strategy."""
+    from wet_mcp.sources.crawler import extract
+
+    agent, strategy = _build_actual_scraping_agent(respect_robots=True)
+
+    with (
+        patch(
+            "wet_mcp.sources.crawler._get_scraping_agent",
+            new_callable=AsyncMock,
+            return_value=agent,
+        ),
+        patch("wet_mcp.sources.crawler.is_safe_url", return_value=True),
+    ):
+        result_json = await extract(["https://example.com/page"])
+
+    pages = json.loads(result_json)
+    assert "robots.txt disallows" in pages[0]["error"]
+    strategy.fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_extract_actual_agent_reaches_strategy_when_robots_disabled() -> None:
+    """The legacy disabled mode still executes the configured strategy."""
+    from wet_mcp.sources.crawler import extract
+
+    agent, strategy = _build_actual_scraping_agent(respect_robots=False)
+
+    with (
+        patch(
+            "wet_mcp.sources.crawler._get_scraping_agent",
+            new_callable=AsyncMock,
+            return_value=agent,
+        ),
+        patch("wet_mcp.sources.crawler.is_safe_url", return_value=True),
+    ):
+        result_json = await extract(["https://example.com/page"])
+
+    pages = json.loads(result_json)
+    assert "error" not in pages[0]
+    assert pages[0]["url"] == "https://example.com/page"
+    strategy.fetch.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import worker, { OUTBOUND_BY_HOST } from '../src/worker'
+import worker, { OUTBOUND_BY_HOST, pickContainerEnv } from '../src/worker'
 
 function fakeEnv() {
   const kv = new Map<string, string>()
@@ -35,6 +35,14 @@ const vectorizeH = OUTBOUND_BY_HOST['vectorize.internal']!
 // Handlers also take an OutboundHandlerContext third arg (containerId/className);
 // unused by these handlers, only needed to satisfy the call signature in tests.
 const ctx = { containerId: 'test', className: 'WetContainer' } as never
+
+describe('container environment forwarding', () => {
+  it('forwards the explicit robots policy to the Python process', () => {
+    const env = { RESPECT_ROBOTS_TXT: 'true' }
+
+    expect(pickContainerEnv(env as never)).toEqual({ RESPECT_ROBOTS_TXT: 'true' })
+  })
+})
 
 describe('outbound handlers', () => {
   it('KV get 404 then put then get 200', async () => {


### PR DESCRIPTION
## Summary
- Add opt-in RESPECT_ROBOTS_TXT configuration with legacy default false.
- Apply the policy to web-core ScrapingAgent extract and legacy Crawl4AI crawl, sitemap, and list_media actions.
- Forward the setting through the Cloudflare Worker container environment.
- Add behavior tests for blocked URLs, legacy-disabled behavior, config, and Worker forwarding.
- Keep this separate from the existing SearXNG search-quality and X-search implementations.

## Verification
- uv run pytest tests/test_config.py tests/test_browser_backends.py tests/test_crawler_comprehensive.py tests/test_crawler_uses_scraping_agent.py -q
- uv run pytest tests/test_crawler_download.py -q
- bun run test:worker
- bunx tsc --noEmit
- Pre-commit hooks passed during commit.