### PR TITLE
fix: migrate wet-mcp to fastretrieval

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "EMBEDDING_MODELS": {
       "type": "string",
       "title": "Embedding model chain (optional)",
-      "description": "CSV 'provider/model,provider/model' (order = litellm fallback); provider inferred from prefix. Empty = local ONNX (qwen3-embed). Example: jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
+      "description": "CSV 'provider/model,provider/model' (order = litellm fallback); provider inferred from prefix. Empty = local ONNX through fastretrieval. Example: jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
       "required": false
     },
     "RERANK_MODELS": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ mise run dev       # uv run wet-mcp
 
 - KHONG co prefix ung dung (day la open-source MCP server)
 - LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]). Per-task model chains, CSV `provider/model,provider/model`, order = litellm fallback:
-  - `EMBEDDING_MODELS` -- chain embedding. Rong = local ONNX (qwen3-embed).
+  - `EMBEDDING_MODELS` -- chain embedding. Rong = local ONNX (fastretrieval).
   - `RERANK_MODELS` -- chain rerank. Rong = local ONNX cross-encoder.
   - `LLM_MODELS` -- chain LLM. Rong = tat feature LLM.
 - Provider duoc suy ra tu prefix model. API key theo convention litellm `<PROVIDER>_API_KEY`. 7 provider servers goi y:
@@ -73,7 +73,9 @@ mise run dev       # uv run wet-mcp
   | `anthropic/` | `ANTHROPIC_API_KEY` | console.anthropic.com |
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
-- Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
+ - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
+ - Local model cache: `FASTRETRIEVAL_CACHE_PATH` (preferred); the old
+   `QWEN3_EMBED_CACHE_PATH` name is still honored when the new name is absent.
 - X/Twitter search (`search` action `x`): `XAI_API_KEY` (from skret `/wet-mcp/prod`), `X_SEARCH_MODEL` (default `grok-4.3` ~$0.032/query; `grok-4.5` ~$0.12/query). Transport = `litellm.aresponses` (OpenAI Responses API shape), NOT `mcp_core.llm.acompletion`: xAI's `x_search` server-side tool is only accepted on `/v1/responses` — the chat-completions endpoint rejects `tools=[{"type":"x_search"}]` with `unknown variant 'x_search'`. litellm forwards the server tool and returns the same `AnnotationURLCitation` shape as the raw openai SDK, so no direct provider-SDK dep is added. Citations gotcha: `response.citations` is absent on this path — parse them from the `output_text` block's `annotations`. See `sources/x_search.py`.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
@@ -116,7 +118,7 @@ Forcing cloud embed/rerank (so the container never downloads local ONNX models):
 
 A non-empty `*_MODELS` chain whose provider key is set -> cloud backend (inferred,
 not via the deprecated `*_BACKEND`). Empty chain -> local ONNX. With cloud forced,
-`qwen3-embed` is never instantiated, keeping the container slim. Storage: set
+  `fastretrieval` is never instantiated, keeping the container slim. Storage: set
 `MCP_STORAGE_BACKEND=cf-kv` + `MCP_KV_BASE_URL=http://kv.internal`,
 `DOCS_DB_BACKEND=cf-d1` + `MCP_D1_BASE_URL`/`MCP_VECTORIZE_BASE_URL`/`MCP_VECTORIZE_IDX`,
 `SEARCH_BACKEND=tavily` + `TAVILY_API_KEY`, and `CREDENTIAL_SECRET`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ mise run dev       # uv run wet-mcp
 
 - KHONG co prefix ung dung (day la open-source MCP server)
 - LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]). Per-task model chains, CSV `provider/model,provider/model`, order = litellm fallback:
-  - `EMBEDDING_MODELS` -- chain embedding. Rong = local ONNX (qwen3-embed).
+  - `EMBEDDING_MODELS` -- chain embedding. Rong = local ONNX (fastretrieval).
   - `RERANK_MODELS` -- chain rerank. Rong = local ONNX cross-encoder.
   - `LLM_MODELS` -- chain LLM. Rong = tat feature LLM.
 - Provider duoc suy ra tu prefix model. API key theo convention litellm `<PROVIDER>_API_KEY`. 7 provider servers goi y:
@@ -73,7 +73,9 @@ mise run dev       # uv run wet-mcp
   | `anthropic/` | `ANTHROPIC_API_KEY` | console.anthropic.com |
 
   For any other litellm provider (used via env passthrough), see https://docs.litellm.ai/docs/providers/<provider> for its `<PROVIDER>_API_KEY` name.
-- Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
+ - Custom endpoint (SSRF-guarded): `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
+ - Local model cache: `FASTRETRIEVAL_CACHE_PATH` (preferred); the old
+   `QWEN3_EMBED_CACHE_PATH` name is still honored when the new name is absent.
 - X/Twitter search (`search` action `x`): `XAI_API_KEY` (from skret `/wet-mcp/prod`), `X_SEARCH_MODEL` (default `grok-4.3` ~$0.032/query; `grok-4.5` ~$0.12/query). Transport = `litellm.aresponses` (OpenAI Responses API shape), NOT `mcp_core.llm.acompletion`: xAI's `x_search` server-side tool is only accepted on `/v1/responses` — the chat-completions endpoint rejects `tools=[{"type":"x_search"}]` with `unknown variant 'x_search'`. litellm forwards the server tool and returns the same `AnnotationURLCitation` shape as the raw openai SDK, so no direct provider-SDK dep is added. Citations gotcha: `response.citations` is absent on this path — parse them from the `output_text` block's `annotations`. See `sources/x_search.py`.
 - Deprecated (honored mot release voi warning): singular `EMBEDDING_MODEL`/`RERANK_MODEL` + `EMBEDDING_BACKEND`/`RERANK_BACKEND` (backend gio suy ra tu chain rong hay khong). Priority-router cu "Jina > Gemini > OpenAI > Cohere" da bo.
 - SearXNG: `WET_AUTO_SEARXNG` (default true), `SEARXNG_URL` (external mode)
@@ -116,7 +118,7 @@ Forcing cloud embed/rerank (so the container never downloads local ONNX models):
 
 A non-empty `*_MODELS` chain whose provider key is set -> cloud backend (inferred,
 not via the deprecated `*_BACKEND`). Empty chain -> local ONNX. With cloud forced,
-`qwen3-embed` is never instantiated, keeping the container slim. Storage: set
+  `fastretrieval` is never instantiated, keeping the container slim. Storage: set
 `MCP_STORAGE_BACKEND=cf-kv` + `MCP_KV_BASE_URL=http://kv.internal`,
 `DOCS_DB_BACKEND=cf-d1` + `MCP_D1_BASE_URL`/`MCP_VECTORIZE_BASE_URL`/`MCP_VECTORIZE_IDX`,
 `SEARCH_BACKEND=tavily` + `TAVILY_API_KEY`, and `CREDENTIAL_SECRET`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,14 +72,14 @@ vf.write_text('VERSION_STRING = \"0.0.0\"\nVERSION_TAG = \"v0.0.0\"\nDOCKER_TAG 
 print(f'Created {vf}')"; \
     else echo "SLIM: skipping local SearXNG (external SEARXNG_URL used)"; fi
 
-# SLIM builds also drop the local qwen3 ONNX embed/rerank deps (CF uses cloud
-# Jina via EMBEDDING_MODELS; DISABLE_LOCAL_EMBED/RERANK). qwen3_embed is
+# SLIM builds also drop the local fastretrieval ONNX embed/rerank deps (CF uses
+# cloud Jina via EMBEDDING_MODELS; DISABLE_LOCAL_EMBED/RERANK). fastretrieval is
 # lazy-imported, so the slim image runs fine as long as the cloud chain is set.
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$SLIM" = "1" ]; then \
-    uv pip uninstall qwen3-embed onnxruntime || true; \
-    echo "SLIM: pruned qwen3-embed + onnxruntime"; \
-    else echo "full build: keeping local qwen3 embed/rerank"; fi
+    uv pip uninstall fastretrieval onnxruntime || true; \
+    echo "SLIM: pruned fastretrieval + onnxruntime"; \
+    else echo "full build: keeping local fastretrieval embed/rerank"; fi
 
 # Install Playwright chromium browser (skipped in SLIM CF builds — the browser
 # leg is offloaded to remote backends: CF Browser Rendering + OCI browserless,

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mcp-name: io.github.n24q02m/wet-mcp
 | [jules-task-archiver](https://github.com/n24q02m/jules-task-archiver) | Chrome Extension for bulk operations on Jules tasks via batchexecute API -- a... | Tooling |
 | [mcp-core](https://github.com/n24q02m/mcp-core) | Shared foundation for building MCP servers -- Streamable HTTP transport, OAut... | MCP |
 | [mnemo-mcp](https://github.com/n24q02m/mnemo-mcp) | Persistent AI memory with hybrid search and embedded sync. Open, free, unlimi... | MCP |
-| [qwen3-embed](https://github.com/n24q02m/qwen3-embed) | Lightweight Qwen3 text embedding and reranking via ONNX Runtime and GGUF | Library |
+| [fastretrieval](https://github.com/n24q02m/fastretrieval) | Multi-model embedding and reranking runtime via ONNX and GGUF | Library |
 | [skret](https://github.com/n24q02m/skret) | Secrets without the server. | CLI |
 | [tacet](https://github.com/n24q02m/tacet) | A self-distilling neuro-symbolic cascade that amortises LLM cost across knowl... | Tooling |
 | [web-core](https://github.com/n24q02m/web-core) | Shared web infrastructure package for search, scraping, HTTP security, and st... | Library |
@@ -91,7 +91,7 @@ mcp-name: io.github.n24q02m/wet-mcp
 - **Local File Conversion** -- Convert PDF, DOCX, XLSX, CSV, HTML, EPUB, PPTX to Markdown
 - **Media** -- List + download images / videos / audio files. `analyze` was removed in v2.0.0 -- use `imagine-mcp.understand` for vision/audio inference
 - **Anti-bot** -- Stealth strategies bypass Cloudflare, Medium, LinkedIn, Twitter
-- **Zero Config** -- Built-in local Qwen3 embedding + reranking, no API keys needed. Optional cloud providers (Jina AI, Gemini, OpenAI, Cohere, xAI, Anthropic) selected per task via the `EMBEDDING_MODELS` / `RERANK_MODELS` / `LLM_MODELS` model chains for higher-quality vectors and LLM features
+- **Zero Config** -- Built-in local reference embedding + reranking through fastretrieval, no API keys needed. Optional cloud providers (Jina AI, Gemini, OpenAI, Cohere, xAI, Anthropic) selected per task via the `EMBEDDING_MODELS` / `RERANK_MODELS` / `LLM_MODELS` model chains for higher-quality vectors and LLM features
 - **Sync** -- Cross-machine sync of indexed docs via Google Drive (OAuth Device Code, no browser redirect)
 
 ## Quick install
@@ -128,8 +128,8 @@ and the paste-to-agent snippets at
 ## Configuration
 
 wet runs zero-config out of the box: web search uses an embedded local SearXNG,
-and embedding/reranking fall back to the bundled local Qwen3 ONNX models when no
-cloud keys are set. For higher-quality results, point each task at a cloud model
+and embedding/reranking fall back to the bundled local ONNX models through
+fastretrieval when no cloud keys are set. For higher-quality results, point each task at a cloud model
 chain. All settings are plain environment variables (no app prefix) -- in the
 HTTP self-host mode they are entered through the browser setup form instead.
 
@@ -139,8 +139,8 @@ features (LLM):
 
 | Env var | Task | Empty default |
 |---|---|---|
-| `EMBEDDING_MODELS` | Embeddings for docs search | Local Qwen3-Embedding ONNX |
-| `RERANK_MODELS` | Result reranking | Local Qwen3-Reranker ONNX |
+| `EMBEDDING_MODELS` | Embeddings for docs search | Local fastretrieval ONNX |
+| `RERANK_MODELS` | Result reranking | Local fastretrieval cross-encoder |
 | `LLM_MODELS` | `extract(action="agent")` synthesis | LLM features disabled |
 
 **Provider keys** -- the provider is inferred from each model's prefix; supply the
@@ -158,6 +158,9 @@ matching key (litellm `<PROVIDER>_API_KEY` convention):
 
 Any other litellm provider works via env passthrough -- see
 [litellm provider docs](https://docs.litellm.ai/docs/providers) for its key name.
+
+`FASTRETRIEVAL_CACHE_PATH` controls the local model cache. The old
+`QWEN3_EMBED_CACHE_PATH` name is still honored when the new name is absent.
 
 **Search backends** -- `SEARCH_BACKENDS` (CSV, runtime fallback chain) over
 `searxng` (default, local) plus optional cloud providers `tavily` / `brave` /

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,7 +136,7 @@ key-priority router. Each chain is a CSV of `provider/model` entries
 
 ```text
 LLM_MODELS        -> LLM chain (e.g. extract agent). Empty -> LLM features off.
-EMBEDDING_MODELS  -> embedding chain. Empty -> local ONNX (qwen3-embed).
+EMBEDDING_MODELS  -> embedding chain. Empty -> local ONNX (fastretrieval).
 RERANK_MODELS     -> rerank chain. Empty -> local ONNX cross-encoder.
 LLM_API_BASE      -> custom OpenAI-compatible endpoint (SSRF-guarded)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # Vector search for docs
     "sqlite-vec",
     # Local ONNX embedding + reranking (auto-fallback when no cloud API)
-    "qwen3-embed>=1.13.0",
+    "fastretrieval>=1.0.1",
     "pillow>=12.3.0",
     "diskcache>=5.6.3",
     "cryptography>=50.0.0",

--- a/server.json
+++ b/server.json
@@ -22,7 +22,7 @@
       },
       "environmentVariables": [
         {
-          "description": "Provider API keys (format: PROVIDER_API_KEY:key,...). Select models per task with EMBEDDING_MODELS / RERANK_MODELS / LLM_MODELS (CSV provider/model, order = litellm fallback); provider is inferred from the model prefix. Empty embedding/rerank chain falls back to the built-in local Qwen3 model.",
+          "description": "Provider API keys (format: PROVIDER_API_KEY:key,...). Select models per task with EMBEDDING_MODELS / RERANK_MODELS / LLM_MODELS (CSV provider/model, order = litellm fallback); provider is inferred from the model prefix. Empty embedding/rerank chain falls back to fastretrieval's built-in local reference model.",
           "isRequired": false,
           "isSecret": true,
           "name": "API_KEYS"
@@ -44,7 +44,7 @@
       },
       "environmentVariables": [
         {
-          "description": "Provider API keys (format: PROVIDER_API_KEY:key,...). Select models per task with EMBEDDING_MODELS / RERANK_MODELS / LLM_MODELS (CSV provider/model, order = litellm fallback); provider is inferred from the model prefix. Empty embedding/rerank chain falls back to the built-in local Qwen3 model.",
+          "description": "Provider API keys (format: PROVIDER_API_KEY:key,...). Select models per task with EMBEDDING_MODELS / RERANK_MODELS / LLM_MODELS (CSV provider/model, order = litellm fallback); provider is inferred from the model prefix. Empty embedding/rerank chain falls back to fastretrieval's built-in local reference model.",
           "isRequired": false,
           "isSecret": true,
           "name": "API_KEYS"

--- a/src/wet_mcp/config.py
+++ b/src/wet_mcp/config.py
@@ -38,13 +38,13 @@ def _has_gguf_support() -> bool:
 def local_onnx_installed() -> bool:
     """Whether both local ONNX extras exist in this image.
 
-    The slim container build uninstalls ``qwen3-embed`` and ``onnxruntime``
+    The slim container build uninstalls ``fastretrieval`` and ``onnxruntime``
     (see ``Dockerfile``), so on that image the local embed/rerank leg is simply
     absent. Resolving that leg from ``DISABLE_LOCAL_EMBED`` /
     ``DISABLE_LOCAL_RERANK`` alone made a slim deployment correct only for as
     long as somebody remembered to set those vars; miss one and the first index
-    attempt died inside the lazy ``from qwen3_embed import ...``, recorded in
-    D1 as ``ModuleNotFoundError: No module named 'qwen3_embed'`` with zero
+    attempt died inside the lazy ``from fastretrieval import ...``, recorded in
+    D1 as ``ModuleNotFoundError: No module named 'fastretrieval'`` with zero
     chunks (#1630) -- a hard failure where a keyword-only degrade was available.
 
     The image is the ground truth, the flag is only a promise about it, so ask
@@ -58,7 +58,9 @@ def local_onnx_installed() -> bool:
         except (ImportError, ValueError):
             return False
 
-    return all(_package_present(package) for package in ("qwen3_embed", "onnxruntime"))
+    return all(
+        _package_present(package) for package in ("fastretrieval", "onnxruntime")
+    )
 
 
 def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
@@ -226,7 +228,7 @@ class Settings(BaseSettings):
     # honored one release with a warning. Backend now inferred.
 
     # Per-capability disable-local toggles (cross-cutting; see mcp_core.chains).
-    # Turn OFF the heavy local qwen3 ONNX fallback (~570MB download) WITHOUT
+    # Turn OFF the heavy local fastretrieval ONNX fallback (~570MB download) WITHOUT
     # pinning a specific cloud model. Toggle on + no cloud chain => the feature
     # is gracefully UNAVAILABLE (clear status), never silently forced to a
     # provider. Independent per task: a user may disable local embed but keep
@@ -248,7 +250,7 @@ class Settings(BaseSettings):
 
     # BYO local model override. When set, the LOCAL embedding/rerank backend
     # loads this model id instead of the bundled Qwen3 default. A non-built-in
-    # id is registered with qwen3-embed at startup using the companion vars
+    # id is registered with fastretrieval at startup using the companion vars
     # below.
     local_embedding_model: str = ""  # env LOCAL_EMBEDDING_MODEL
     local_rerank_model: str = ""  # env LOCAL_RERANK_MODEL
@@ -601,7 +603,7 @@ class Settings(BaseSettings):
         - 'cloud'       -- a non-empty EMBEDDING_MODELS chain (with keys).
         - 'local'       -- empty chain AND the local leg is enabled and present.
         - 'unavailable' -- empty chain AND no usable local leg, i.e.
-          DISABLE_LOCAL_EMBED is set OR the slim image has no ``qwen3-embed``
+          DISABLE_LOCAL_EMBED is set OR the slim image has no ``fastretrieval``
           installed. Embedding is then gracefully unavailable -- NOT forced.
 
         The deprecated EMBEDDING_BACKEND env var is honored for one release.
@@ -628,7 +630,7 @@ class Settings(BaseSettings):
 
         The ONNX default is the YesNo variant (~598 MB at inference vs ~12 GB
         for the full-vocab build); it is mathematically equivalent and, since
-        qwen3-embed 1.11.2b3, produces batch-invariant scores (issue #725).
+        fastretrieval's local runtime produces batch-invariant scores.
 
         LOCAL_RERANK_MODEL overrides the bundled default (BYO model).
         """
@@ -645,7 +647,7 @@ class Settings(BaseSettings):
         '' when rerank_enabled is False. Otherwise 3-way via the shared
         mcp-core primitive (same semantics as resolve_embedding_backend, keyed
         on RERANK_MODELS + DISABLE_LOCAL_RERANK + whether the slim image kept
-        ``qwen3-embed``); the deprecated RERANK_BACKEND env var is honored for
+        ``fastretrieval``); the deprecated RERANK_BACKEND env var is honored for
         one release.
         """
         if not self.rerank_enabled:

--- a/src/wet_mcp/embedder.py
+++ b/src/wet_mcp/embedder.py
@@ -1,8 +1,8 @@
-"""Dual-backend embedding: Cloud (litellm passthrough via mcp_core.llm) + qwen3-embed (local ONNX).
+"""Dual-backend embedding: Cloud (litellm passthrough via mcp_core.llm) + fastretrieval (local ONNX).
 
 Backend is inferred from the EMBEDDING_MODELS chain:
 - Non-empty chain (with a configured provider key) -> Cloud via mcp_core.llm.
-- Empty chain -> Local ONNX via qwen3-embed.
+- Empty chain -> Local ONNX via fastretrieval.
 
 Embeddings are truncated to the configured dims in server._embed().
 """
@@ -389,19 +389,19 @@ class CloudEmbeddingBackend:
 
 
 # ---------------------------------------------------------------------------
-# qwen3-embed Backend (local ONNX)
+# fastretrieval Backend (local ONNX)
 # ---------------------------------------------------------------------------
 
 
-class Qwen3EmbedBackend:
-    """Local ONNX embedding via qwen3-embed (Qwen3-Embedding-0.6B).
+class LocalEmbeddingBackend:
+    """Local ONNX embedding via fastretrieval's configured model.
 
     Uses last-token pooling with instruction-aware queries.
     Model is downloaded on first use (~0.57GB).
     Batch size is forced to 1 (static ONNX graph).
     """
 
-    # Default model for qwen3-embed
+    # Default model supplied by fastretrieval
     DEFAULT_MODEL = "n24q02m/Qwen3-Embedding-0.6B-ONNX"
 
     def __init__(self, model_name: str | None = None):
@@ -415,7 +415,7 @@ class Qwen3EmbedBackend:
         if not already cached. Logs a warning so users know why startup is slow.
         """
         if self._model is None:
-            from qwen3_embed import TextEmbedding
+            from fastretrieval import TextEmbedding
 
             logger.warning(
                 f"Loading local embedding model: {self._model_name} "
@@ -475,7 +475,7 @@ class Qwen3EmbedBackend:
         return result[0].tolist()
 
     async def check_available(self) -> int:
-        """Check if qwen3-embed is available."""
+        """Check if fastretrieval is available."""
         try:
             model = self._get_model()
 
@@ -505,7 +505,7 @@ _backend: EmbeddingBackend | None = None
 # stateless and key-free, so a single instance is safely shared across subs
 # (no per-sub data flows through it). Lazily created so single-user / stdio
 # deployments that never hit the multi-user resolver don't download the model.
-_shared_local_backend: Qwen3EmbedBackend | None = None
+_shared_local_backend: LocalEmbeddingBackend | None = None
 
 
 def get_backend() -> EmbeddingBackend | None:
@@ -519,11 +519,11 @@ def clear_backend() -> None:
     _backend = None
 
 
-def _shared_local_embed_backend() -> Qwen3EmbedBackend:
+def _shared_local_embed_backend() -> LocalEmbeddingBackend:
     """Return the process-shared local ONNX embedding backend (lazy)."""
     global _shared_local_backend
     if _shared_local_backend is None:
-        _shared_local_backend = Qwen3EmbedBackend()
+        _shared_local_backend = LocalEmbeddingBackend()
     return _shared_local_backend
 
 
@@ -547,7 +547,7 @@ def resolve_embed_backend_for_request() -> EmbeddingBackend | None:
     is spelled ``'unavailable'``, and it asks the same predicate
     (:meth:`Settings.local_embed_available`) so the two cannot drift. Both
     inputs matter: ``DISABLE_LOCAL_EMBED`` is what a slim deployment sets, and
-    whether ``qwen3-embed`` is installed is what is actually true of the image.
+    whether ``fastretrieval`` is installed is what is actually true of the image.
     Consulting only the flag meant a slim image whose operator forgot it handed
     back a backend that raises ``ModuleNotFoundError`` on first use, failing the
     entire index instead of storing keyword-searchable chunks without vectors.
@@ -585,7 +585,7 @@ def no_local_embed_clause() -> str:
 
     Three states, three different actions, so they must not share one string.
     Saying "DISABLE_LOCAL_EMBED is set" on an image that never shipped
-    ``qwen3-embed`` sends the reader after a var they never set -- and having
+    ``fastretrieval`` sends the reader after a var they never set -- and having
     checked it and found it empty, they conclude the message is wrong. The
     absent-image wording says instead that this is a property of the build, so
     the answer is "give this deployment a cloud chain", not "unset a flag".
@@ -596,7 +596,7 @@ def no_local_embed_clause() -> str:
         return "this deployment runs with DISABLE_LOCAL_EMBED set"
     if not local_onnx_installed():
         return (
-            "this image has no local ONNX leg installed (no qwen3-embed or "
+            "this image has no local ONNX leg installed (no fastretrieval or "
             "onnxruntime, which the slim Cloudflare container build removes "
             "on purpose)"
         )
@@ -659,7 +659,7 @@ def init_backend(
             raise ValueError("model is required for cloud backend")
         _backend = CloudEmbeddingBackend(model, api_base=api_base, api_key=api_key)
     elif backend_type == "local":
-        _backend = Qwen3EmbedBackend(model)
+        _backend = LocalEmbeddingBackend(model)
     else:
         raise ValueError(f"Unknown backend type: {backend_type}")
 

--- a/src/wet_mcp/relay_schema.py
+++ b/src/wet_mcp/relay_schema.py
@@ -217,12 +217,12 @@ RELAY_SCHEMA: dict[str, Any] = {
         {
             "label": "Embedding",
             "priority": "configurable",
-            "description": "Vector embeddings for docs search. Empty = local Qwen3-Embedding ONNX.",
+            "description": "Vector embeddings for docs search. Empty = local fastretrieval ONNX.",
         },
         {
             "label": "Reranking",
             "priority": "configurable",
-            "description": "Re-ranks search results for accuracy. Empty = local Qwen3-Reranker ONNX.",
+            "description": "Re-ranks search results for accuracy. Empty = local fastretrieval cross-encoder.",
         },
         {
             "label": "LLM",

--- a/src/wet_mcp/reranker.py
+++ b/src/wet_mcp/reranker.py
@@ -1,10 +1,10 @@
-"""Dual-backend reranking: Cloud (litellm passthrough) + qwen3-embed (local ONNX).
+"""Dual-backend reranking: Cloud (litellm passthrough) + fastretrieval (local ONNX).
 
 Supports two backends:
 - **cloud**: Cloud reranking via mcp_core.llm (litellm passthrough — Jina,
   Cohere, or any litellm rerank 'provider/model'). Requires the matching
   provider API key env var (JINA_AI_API_KEY, COHERE_API_KEY / CO_API_KEY).
-- **local**: Local ONNX cross-encoder via qwen3-embed (Qwen3-Reranker-0.6B).
+- **local**: Local ONNX cross-encoder via fastretrieval's configured model.
   No API keys needed, ~0.57GB model download on first use.
 
 Reranker takes search results and re-scores them with a cross-encoder
@@ -206,12 +206,12 @@ class CloudReranker:
 
 
 # ---------------------------------------------------------------------------
-# qwen3-embed Backend (local ONNX)
+# fastretrieval Backend (local ONNX)
 # ---------------------------------------------------------------------------
 
 
-class Qwen3Reranker:
-    """Local ONNX cross-encoder reranking via qwen3-embed (Qwen3-Reranker-0.6B).
+class LocalReranker:
+    """Local ONNX cross-encoder reranking via fastretrieval's configured model.
 
     Uses causal LM yes/no logit scoring with chat template.
     Scores are P(yes) in [0, 1].
@@ -219,7 +219,7 @@ class Qwen3Reranker:
     """
 
     # YesNo variant: ~598 MB at inference vs ~12 GB for the full-vocab build,
-    # mathematically equivalent, batch-invariant since qwen3-embed 1.11.2b3 (#725).
+    # The reference YesNo variant is small and keeps scores batch-invariant.
     DEFAULT_MODEL = "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
 
     def __init__(self, model_name: str | None = None):
@@ -233,7 +233,7 @@ class Qwen3Reranker:
         if not already cached. Logs a warning so users know why startup is slow.
         """
         if self._model is None:
-            from qwen3_embed import TextCrossEncoder
+            from fastretrieval import TextCrossEncoder
 
             logger.warning(
                 f"Loading local reranker model: {self._model_name} "
@@ -269,7 +269,7 @@ class Qwen3Reranker:
             return []
 
     def check_available(self) -> bool:
-        """Check if qwen3-embed reranker is available."""
+        """Check if fastretrieval reranker is available."""
         try:
             model = self._get_model()
             scores = list(model.rerank("test", ["test document"]))
@@ -288,7 +288,7 @@ _backend: RerankerBackend | None = None
 # Shared local ONNX reranker for the HTTP multi-user path. Local inference is
 # stateless and key-free, so one instance is safely shared across subs. Lazy
 # so single-user / stdio deployments never download the model unnecessarily.
-_shared_local_backend: Qwen3Reranker | None = None
+_shared_local_backend: LocalReranker | None = None
 
 
 def get_reranker() -> RerankerBackend | None:
@@ -302,11 +302,11 @@ def clear_reranker() -> None:
     _backend = None
 
 
-def _shared_local_reranker() -> Qwen3Reranker:
+def _shared_local_reranker() -> LocalReranker:
     """Return the process-shared local ONNX reranker backend (lazy)."""
     global _shared_local_backend
     if _shared_local_backend is None:
-        _shared_local_backend = Qwen3Reranker()
+        _shared_local_backend = LocalReranker()
     return _shared_local_backend
 
 
@@ -328,8 +328,8 @@ def resolve_rerank_backend_for_request() -> RerankerBackend | None:
     spells it ``'unavailable'`` at startup, via the shared
     :meth:`Settings.local_rerank_available` predicate -- so it covers both
     ``DISABLE_LOCAL_RERANK`` and an image the slim build stripped
-    ``qwen3-embed`` out of. It matters more here than the traceback suggests:
-    :meth:`Qwen3Reranker.rerank` swallows its own load failure and returns
+    ``fastretrieval`` out of. It matters more here than the traceback suggests:
+    :meth:`LocalReranker.rerank` swallows its own load failure and returns
     ``[]``, so a local reranker on an image built without the ONNX extras
     degrades every search to unranked order behind one log line, quietly,
     forever. Returning ``None`` says the same thing out loud.
@@ -385,7 +385,7 @@ def init_reranker(
     if backend_type == "cloud":
         _backend = CloudReranker(model=model, api_key=api_key)
     elif backend_type == "local":
-        _backend = Qwen3Reranker(model)
+        _backend = LocalReranker(model)
     else:
         raise ValueError(f"Unknown reranker backend type: {backend_type}")
 

--- a/src/wet_mcp/server.py
+++ b/src/wet_mcp/server.py
@@ -516,18 +516,33 @@ async def _lifespan_shutdown(warmup_task: asyncio.Task | None) -> None:
     stop_searxng()
 
 
-def _maybe_register_custom_embed(local_model: str) -> None:
-    """Register a BYO local embedding model with qwen3-embed if needed.
+def _supported_model_ids(model_class: Any) -> set[str]:
+    """Read supported model ids from fastretrieval's public registry."""
+    ids: set[str] = set()
+    for item in model_class.list_supported_models():
+        model_id = (
+            item.get("model")
+            if isinstance(item, dict)
+            else getattr(item, "model", item)
+        )
+        if isinstance(model_id, str):
+            ids.add(model_id.lower())
+    return ids
 
-    Only fires when the user opted in via LOCAL_EMBEDDING_MODEL. Built-in
-    ``n24q02m/Qwen3-*`` ids are already known to qwen3-embed and are left
-    untouched. A custom id is registered via ``qwen3_embed.CustomModelSpec``
-    using the companion env vars so the local backend can load it. Requires
-    LOCAL_EMBEDDING_DIM (>0).
+
+def _maybe_register_custom_embed(local_model: str) -> None:
+    """Register a BYO local embedding model when it is not in the registry.
+
+    Built-in ids are resolved from fastretrieval's registry instead of a model
+    family prefix. External ids require explicit dimension, pooling, and
+    normalization settings from the user.
     """
     if not settings.local_embedding_model:
         return
-    if local_model.startswith("n24q02m/Qwen3-"):
+
+    from fastretrieval import CustomModelSpec, TextEmbedding
+
+    if local_model.lower() in _supported_model_ids(TextEmbedding):
         return
     if settings.local_embedding_dim <= 0:
         logger.error(
@@ -536,8 +551,6 @@ def _maybe_register_custom_embed(local_model: str) -> None:
             local_model,
         )
         return
-
-    from qwen3_embed import CustomModelSpec
 
     try:
         CustomModelSpec(
@@ -560,20 +573,14 @@ def _maybe_register_custom_embed(local_model: str) -> None:
 
 
 def _maybe_register_custom_rerank(local_model: str) -> None:
-    """Register a BYO local reranker with qwen3-embed if needed.
-
-    Only fires when the user opted in via LOCAL_RERANK_MODEL. Built-in
-    ``n24q02m/Qwen3-Reranker-*`` ids are already known to qwen3-embed and are
-    left untouched. A custom id is registered via ``qwen3_embed.CustomRerankerSpec``
-    using LOCAL_RERANK_MODEL_FILE so the local cross-encoder can load it. A
-    cross-encoder needs no dim/pooling.
-    """
+    """Register a BYO local reranker when it is not in the registry."""
     if not settings.local_rerank_model:
         return
-    if local_model.startswith("n24q02m/Qwen3-Reranker-"):
-        return
 
-    from qwen3_embed import CustomRerankerSpec
+    from fastretrieval import CustomRerankerSpec, TextCrossEncoder
+
+    if local_model.lower() in _supported_model_ids(TextCrossEncoder):
+        return
 
     try:
         CustomRerankerSpec(
@@ -700,11 +707,11 @@ async def _init_reranker_backend(mode: str) -> None:
         if not settings.local_rerank_available():
             # Same landmine as the embedding path above: an installed-but-
             # unusable singleton reads as "reranking is configured" everywhere
-            # downstream, and Qwen3Reranker.rerank swallows its own load
+            # downstream, and the local reranker swallows its own load
             # failure, so every search silently returns unranked order.
             logger.error(
                 "Reranker: local backend requested but unavailable "
-                "(DISABLE_LOCAL_RERANK set, or no qwen3-embed installed in "
+                "(DISABLE_LOCAL_RERANK set, or no fastretrieval installed in "
                 "this image); none initialised"
             )
             return
@@ -748,11 +755,11 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
 
     Args:
         text: Text to embed.
-        is_query: If True, use query_embed for instruction-aware asymmetric
-            retrieval (Qwen3). Document embeddings stay raw.
+        is_query: If True, use the model's query embedding path for asymmetric
+            retrieval. Document embeddings stay raw.
     """
     from wet_mcp.embedder import (
-        Qwen3EmbedBackend,
+        LocalEmbeddingBackend,
         _is_retryable,
         resolve_embed_backend_for_request,
     )
@@ -761,7 +768,7 @@ async def _embed(text: str, is_query: bool = False) -> list[float] | None:
     if not backend:
         return None
     try:
-        if is_query and isinstance(backend, Qwen3EmbedBackend):
+        if is_query and isinstance(backend, LocalEmbeddingBackend):
             return await backend.embed_single_query(text, _embedding_dims)
         return await backend.embed_single(text, _embedding_dims)
     except Exception as e:

--- a/src/wet_mcp/setup_tool.py
+++ b/src/wet_mcp/setup_tool.py
@@ -7,7 +7,6 @@ structured dicts for MCP tool responses.
 import asyncio
 import os
 import shutil
-import tempfile
 from pathlib import Path
 
 from loguru import logger
@@ -15,17 +14,31 @@ from loguru import logger
 from wet_mcp.config import settings
 
 
+def _resolve_cache_dir() -> Path:
+    """Resolve the fastretrieval cache path with an intentional old alias."""
+    new = os.getenv("FASTRETRIEVAL_CACHE_PATH")
+    if new:
+        return Path(new)
+
+    old = os.getenv("QWEN3_EMBED_CACHE_PATH")
+    if old:
+        logger.warning(
+            "QWEN3_EMBED_CACHE_PATH is deprecated; use "
+            "FASTRETRIEVAL_CACHE_PATH instead. Still honoring it."
+        )
+        return Path(old)
+
+    xdg_cache_home = os.getenv("XDG_CACHE_HOME")
+    base_path = Path(xdg_cache_home) if xdg_cache_home else Path.home() / ".cache"
+    return base_path / "fastretrieval"
+
+
 def clear_model_cache(model_name: str) -> str | None:
     """Remove corrupted HuggingFace cache for a model so it re-downloads.
 
     Returns the path that was cleared, or None if no cache existed.
     """
-    cache_dir = Path(
-        os.getenv(
-            "QWEN3_EMBED_CACHE_PATH",
-            os.path.join(tempfile.gettempdir(), "qwen3_embed_cache"),
-        )
-    )
+    cache_dir = _resolve_cache_dir()
     safe_name = model_name.replace("/", "--")
     model_cache = cache_dir / f"models--{safe_name}"
     if model_cache.exists():
@@ -76,7 +89,7 @@ async def _validate_cloud_models(settings_obj) -> dict:
 
 def _download_local_embedding(settings_obj) -> dict:
     """Download and validate local embedding model."""
-    from qwen3_embed import TextEmbedding
+    from fastretrieval import TextEmbedding
 
     local_model = settings_obj.resolve_local_embedding_model()
     try:
@@ -125,7 +138,7 @@ def _download_local_reranker(settings_obj) -> dict:
             "message": "Reranking disabled",
         }
 
-    from qwen3_embed import TextCrossEncoder
+    from fastretrieval import TextCrossEncoder
 
     local_model = settings_obj.resolve_local_rerank_model()
     try:

--- a/tests/run_benchmark.py
+++ b/tests/run_benchmark.py
@@ -273,13 +273,13 @@ async def main():
             print(f"Embedding: local ONNX (dims={ndims})")
 
             async def _embed(text, is_query=False):
-                from wet_mcp.embedder import Qwen3EmbedBackend
+                from wet_mcp.embedder import LocalEmbeddingBackend
 
                 b = get_backend()
                 if not b:
                     return None
                 t = text
-                if is_query and isinstance(b, Qwen3EmbedBackend):
+                if is_query and isinstance(b, LocalEmbeddingBackend):
                     t = f"Instruct: Retrieve relevant technical documentation\nQuery: {text}"
                 vec = await b.embed_single(t, 768)
                 return vec[:768] if len(vec) > 768 else vec

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -175,7 +175,7 @@ class TestSetupSyncNoClientId:
 class TestSetupToolCoverageGaps:
     """Cover setup_tool.py edge cases for local embedding/reranker."""
 
-    @patch("qwen3_embed.TextEmbedding")
+    @patch("fastretrieval.TextEmbedding")
     def test_local_embedding_empty_result(self, mock_te):
         """embed returns empty list -- returns warning dict."""
         from wet_mcp.setup_tool import _download_local_embedding
@@ -191,7 +191,7 @@ class TestSetupToolCoverageGaps:
         assert result["status"] == "warning"
 
     @patch("wet_mcp.setup_tool.clear_model_cache")
-    @patch("qwen3_embed.TextEmbedding")
+    @patch("fastretrieval.TextEmbedding")
     def test_local_embedding_empty_after_retry(self, mock_te, mock_clear):
         """embed returns empty after cache clear retry."""
         from wet_mcp.setup_tool import _download_local_embedding
@@ -229,7 +229,7 @@ class TestSetupToolCoverageGaps:
         assert result["cloud_ready"] is True
         assert result["reranker"] is None
 
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_local_reranker_empty_result(self, mock_tce):
         """local reranker returns empty scores."""
         from wet_mcp.setup_tool import _download_local_reranker
@@ -246,7 +246,7 @@ class TestSetupToolCoverageGaps:
         assert result["status"] == "warning"
 
     @patch("wet_mcp.setup_tool.clear_model_cache")
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_local_reranker_empty_after_retry(self, mock_tce, mock_clear):
         """reranker retry returns empty scores."""
         from wet_mcp.setup_tool import _download_local_reranker
@@ -265,7 +265,7 @@ class TestSetupToolCoverageGaps:
         mock_clear.assert_called_once_with("org/rerank")
         assert result["status"] == "warning"
 
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_local_reranker_non_cache_error_reraises(self, mock_tce):
         """non-cache reranker error is re-raised."""
         from wet_mcp.setup_tool import _download_local_reranker
@@ -274,7 +274,7 @@ class TestSetupToolCoverageGaps:
         mock_settings.rerank_enabled = True
         mock_settings.resolve_local_rerank_model.return_value = "org/rerank"
 
-        mock_tce.side_effect = ImportError("qwen3_embed broken")
+        mock_tce.side_effect = ImportError("fastretrieval broken")
 
         with pytest.raises(ImportError, match="broken"):
             _download_local_reranker(mock_settings)

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -1036,30 +1036,30 @@ class TestCloudEmbeddingBackendWithApiBaseAndKey:
             assert dims == 2
 
 
-class TestQwen3EmbedBackendLoadError:
+class TestLocalEmbeddingBackendLoadError:
     """Cover lines 262-272: _get_model import error and lazy loading."""
 
     async def test_get_model_import_error(self):
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        backend = Qwen3EmbedBackend()
-        with patch.dict("sys.modules", {"qwen3_embed": None}):
+        backend = LocalEmbeddingBackend()
+        with patch.dict("sys.modules", {"fastretrieval": None}):
             with patch(
                 "builtins.__import__",
-                side_effect=ImportError("No module named 'qwen3_embed'"),
+                side_effect=ImportError("No module named 'fastretrieval'"),
             ):
                 with pytest.raises(ImportError):
                     backend._get_model()
 
     async def test_get_model_caches(self):
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        backend = Qwen3EmbedBackend("test-model")
+        backend = LocalEmbeddingBackend("test-model")
         mock_text_embedding = MagicMock()
         mock_module = MagicMock()
         mock_module.TextEmbedding = mock_text_embedding
 
-        with patch.dict("sys.modules", {"qwen3_embed": mock_module}):
+        with patch.dict("sys.modules", {"fastretrieval": mock_module}):
             model1 = backend._get_model()
             model2 = backend._get_model()
             assert model1 is model2
@@ -1067,13 +1067,13 @@ class TestQwen3EmbedBackendLoadError:
             mock_text_embedding.assert_called_once()
 
 
-class TestQwen3EmbedCheckAvailableEmptyResult:
+class TestLocalEmbedCheckAvailableEmptyResult:
     """Cover line 324: check_available returns 0 when result is empty."""
 
     async def test_check_available_empty_result(self):
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.embed.return_value = iter([])
 
@@ -1082,15 +1082,15 @@ class TestQwen3EmbedCheckAvailableEmptyResult:
             assert dims == 0
 
 
-class TestQwen3EmbedSingleQuery:
+class TestLocalEmbedSingleQuery:
     """Cover lines 306-311: embed_single_query with dimensions."""
 
     async def test_embed_single_query_with_dims(self):
         import numpy as np
 
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.query_embed.return_value = iter([np.array([0.1, 0.2, 0.3])])
 
@@ -1102,9 +1102,9 @@ class TestQwen3EmbedSingleQuery:
     async def test_embed_single_query_no_dims(self):
         import numpy as np
 
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.query_embed.return_value = iter([np.array([0.4, 0.5])])
 
@@ -1289,28 +1289,28 @@ class TestCloudRerankerWithApiKey:
             assert reranker.api_key == "sk-test"
 
 
-class TestQwen3RerankerLoadModel:
+class TestLocalRerankerLoadModel:
     """Cover lines 164-174: _get_model lazy loading and caching."""
 
     async def test_get_model_loads_and_caches(self):
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
-        reranker = Qwen3Reranker("test-model")
+        reranker = LocalReranker("test-model")
         mock_cross_encoder = MagicMock()
         mock_module = MagicMock()
         mock_module.TextCrossEncoder = mock_cross_encoder
 
-        with patch.dict("sys.modules", {"qwen3_embed": mock_module}):
+        with patch.dict("sys.modules", {"fastretrieval": mock_module}):
             model1 = reranker._get_model()
             model2 = reranker._get_model()
             assert model1 is model2
             mock_cross_encoder.assert_called_once()
 
     async def test_get_model_import_error(self):
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
-        reranker = Qwen3Reranker()
-        with patch.dict("sys.modules", {"qwen3_embed": None}):
+        reranker = LocalReranker()
+        with patch.dict("sys.modules", {"fastretrieval": None}):
             with patch(
                 "builtins.__import__",
                 side_effect=ImportError("No module"),

--- a/tests/test_disable_local_per_request_resolution.py
+++ b/tests/test_disable_local_per_request_resolution.py
@@ -5,10 +5,10 @@ Two backend-selection paths exist and they disagreed. The startup path
 chain is empty and ``DISABLE_LOCAL_EMBED`` is set. The per-request path
 (``embedder.resolve_embed_backend_for_request``) fell through to the local ONNX
 backend unconditionally, so on a deployment built WITHOUT the local extras --
-the http-slim image, which ``Dockerfile`` uninstalls ``qwen3-embed`` and
+the http-slim image, which ``Dockerfile`` uninstalls ``fastretrieval`` and
 ``onnxruntime`` from -- every indexing request for a sub with no cloud chain
-died on ``ModuleNotFoundError: No module named 'qwen3_embed'`` raised from the
-lazy import inside ``Qwen3EmbedBackend._get_model``. Live D1 recorded exactly
+died on ``ModuleNotFoundError: No module named 'fastretrieval'`` raised from the
+lazy import inside ``LocalEmbeddingBackend._get_model``. Live D1 recorded exactly
 that in ``index_state='failed'`` (#1614) while ``config status`` reported the
 startup singleton and claimed embedding was available.
 
@@ -17,7 +17,7 @@ chain + local disabled == gracefully UNAVAILABLE. Not the local backend, and
 not the startup singleton either -- that one carries the OPERATOR's key, and
 spending it on an arbitrary sub is what the resolver's docstring rules out.
 
-``qwen3_embed`` is installed in the dev venv, so these tests intercept the
+``fastretrieval`` is installed in the dev venv, so these tests intercept the
 import instead of relying on its absence: that both reproduces the slim image
 and makes "the local leg was never reached" assertable. A test that only
 checked the return value would stay green if the import happened first.
@@ -60,7 +60,7 @@ def _isolate(monkeypatch, tmp_path):
 
 @pytest.fixture
 def slim_image(monkeypatch):
-    """Make ``qwen3_embed`` unimportable, as the http-slim build leaves it.
+    """Make ``fastretrieval`` unimportable, as the http-slim build leaves it.
 
     Returns the list of import names the code under test asked for, so a test
     can assert the local leg was never even entered.
@@ -69,7 +69,7 @@ def slim_image(monkeypatch):
     attempted: list[str] = []
 
     def _guarded(name, *args, **kwargs):
-        if name == "qwen3_embed" or name.startswith("qwen3_embed."):
+        if name == "fastretrieval" or name.startswith("fastretrieval."):
             attempted.append(name)
             raise ModuleNotFoundError(f"No module named '{name}'")
         return real_import(name, *args, **kwargs)
@@ -107,7 +107,7 @@ class TestEmbedResolverHonoursDisableLocalEmbed:
 
         assert resolve_embed_backend_for_request() is None
 
-    async def test_no_chain_and_local_disabled_never_imports_qwen3_embed(
+    async def test_no_chain_and_local_disabled_never_imports_fastretrieval(
         self, local_embed_disabled, slim_image
     ):
         """End-to-end through the live dispatch helper, on a slim image.
@@ -115,7 +115,7 @@ class TestEmbedResolverHonoursDisableLocalEmbed:
         ``server._embed`` is what the search path calls. With the local leg
         still reachable this raises ModuleNotFoundError out of the lazy import;
         the fix has to make the resolver say "none" BEFORE anything touches
-        ``qwen3_embed``, which is why the import list is asserted too.
+        ``fastretrieval``, which is why the import list is asserted too.
         """
         from wet_mcp import server
 
@@ -163,13 +163,13 @@ class TestEmbedResolverHonoursDisableLocalEmbed:
     def test_no_chain_with_local_enabled_still_returns_shared_local(self):
         """No regression: the local fallback is untouched when local is on."""
         from wet_mcp import embedder
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
         store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
         set_current_sub("user_a")
 
         backend = embedder.resolve_embed_backend_for_request()
-        assert isinstance(backend, Qwen3EmbedBackend)
+        assert isinstance(backend, LocalEmbeddingBackend)
         # It is the process-shared instance, not a fresh one per request.
         assert backend is embedder.resolve_embed_backend_for_request()
 
@@ -201,9 +201,9 @@ class TestEmbedResolverHonoursDisableLocalEmbed:
     ):
         """Stdio / single-user is out of scope for the per-sub flag branch."""
         from wet_mcp import embedder
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        sentinel = Qwen3EmbedBackend()
+        sentinel = LocalEmbeddingBackend()
         monkeypatch.setattr(embedder, "_backend", sentinel)
         set_current_sub(None)
 
@@ -224,12 +224,12 @@ class TestRerankResolverHonoursDisableLocalRerank:
 
         assert resolve_rerank_backend_for_request() is None
 
-    async def test_no_chain_and_local_disabled_never_imports_qwen3_embed(
+    async def test_no_chain_and_local_disabled_never_imports_fastretrieval(
         self, local_rerank_disabled, slim_image
     ):
         """``_rerank_results`` must return the unranked order, importing nothing.
 
-        ``Qwen3Reranker.rerank`` swallows its own exceptions, so the broken
+        ``LocalReranker.rerank`` swallows its own exceptions, so the broken
         local leg shows up here as a silent ``logger.warning`` per search
         rather than a traceback -- the import list is the only assertion that
         can tell "reranking was skipped" from "reranking failed quietly".
@@ -262,13 +262,13 @@ class TestRerankResolverHonoursDisableLocalRerank:
 
     def test_no_chain_with_local_enabled_still_returns_shared_local(self):
         from wet_mcp import reranker
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
         store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
         set_current_sub("user_a")
 
         backend = reranker.resolve_rerank_backend_for_request()
-        assert isinstance(backend, Qwen3Reranker)
+        assert isinstance(backend, LocalReranker)
         assert backend is reranker.resolve_rerank_backend_for_request()
 
     def test_cloud_chain_wins_over_the_flag_and_carries_the_subs_key(
@@ -294,9 +294,9 @@ class TestRerankResolverHonoursDisableLocalRerank:
         self, local_rerank_disabled, monkeypatch
     ):
         from wet_mcp import reranker
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
-        sentinel = Qwen3Reranker()
+        sentinel = LocalReranker()
         monkeypatch.setattr(reranker, "_backend", sentinel)
         set_current_sub(None)
 

--- a/tests/test_embed_rerank_cloud.py
+++ b/tests/test_embed_rerank_cloud.py
@@ -29,13 +29,13 @@ def test_key_gating_filters_chain_without_key(monkeypatch):
 def test_cloud_config_no_local_model_download(monkeypatch):
     monkeypatch.setenv("EMBEDDING_MODELS", "jina_ai/jina-embeddings-v5-text-small")
     monkeypatch.setenv("JINA_AI_API_KEY", "k")
-    fake_qwen = unittest.mock.MagicMock()
-    monkeypatch.setitem(sys.modules, "qwen3_embed", fake_qwen)
+    fake_fastretrieval = unittest.mock.MagicMock()
+    monkeypatch.setitem(sys.modules, "fastretrieval", fake_fastretrieval)
     from wet_mcp.config import Settings
 
     s = Settings()
     assert s.resolve_embedding_backend() == "cloud"
-    fake_qwen.assert_not_called()
+    fake_fastretrieval.assert_not_called()
 
 
 def test_local_onnx_presence_treats_broken_module_specs_as_unavailable(monkeypatch):

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,7 +1,7 @@
 """Tests for src/wet_mcp/embedder.py -- Dual-backend embedding.
 
 Covers CloudEmbeddingBackend (litellm passthrough via mcp_core.llm),
-batch splitting, retry logic, Qwen3EmbedBackend (local ONNX), factory functions,
+batch splitting, retry logic, LocalEmbeddingBackend (local ONNX), factory functions,
 and provider detection helpers.
 """
 
@@ -12,7 +12,7 @@ import pytest
 
 from wet_mcp.embedder import (
     CloudEmbeddingBackend,
-    Qwen3EmbedBackend,
+    LocalEmbeddingBackend,
     _detect_embedding_provider,
     _is_retryable,
     _is_unsupported_param,
@@ -562,16 +562,16 @@ class TestRetryLogic:
 
 
 # -----------------------------------------------------------------------
-# Qwen3EmbedBackend
+# LocalEmbeddingBackend
 # -----------------------------------------------------------------------
 
 
-class TestQwen3EmbedBackend:
+class TestLocalEmbeddingBackend:
     async def test_embed_texts_success(self):
         """Local ONNX embedding returns correct vectors."""
         import numpy as np
 
-        backend = Qwen3EmbedBackend("test-model")
+        backend = LocalEmbeddingBackend("test-model")
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
             [
@@ -589,14 +589,14 @@ class TestQwen3EmbedBackend:
 
     async def test_embed_texts_empty(self):
         """Empty input returns empty list."""
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         assert await backend.embed_texts([]) == []
 
     async def test_embed_texts_with_mrl_truncation(self):
         """Dimensions parameter is passed to model.embed(dim=) for MRL."""
         import numpy as np
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         # Model handles truncation internally when dim= is passed
         mock_model.embed.return_value = iter(
@@ -616,7 +616,7 @@ class TestQwen3EmbedBackend:
         """embed_single delegates to embed_texts."""
         import numpy as np
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.embed.return_value = iter([np.array([0.1, 0.2])])
 
@@ -629,7 +629,7 @@ class TestQwen3EmbedBackend:
         """Returns dimensions when model loads successfully."""
         import numpy as np
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.embed.return_value = iter([np.array([0.0] * 1024)])
 
@@ -640,7 +640,7 @@ class TestQwen3EmbedBackend:
 
     async def test_check_available_failure(self):
         """Returns 0 when model fails to load."""
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
 
         with patch.object(
             backend, "_get_model", side_effect=Exception("ONNX load error")
@@ -651,7 +651,7 @@ class TestQwen3EmbedBackend:
 
     async def test_check_available_embed_exception(self):
         """Returns 0 when model.embed fails."""
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.embed.side_effect = Exception("Runtime error")
 
@@ -662,7 +662,7 @@ class TestQwen3EmbedBackend:
 
     async def test_check_available_empty_result(self):
         """Returns 0 when model.embed returns empty list."""
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.embed.return_value = []
 
@@ -675,7 +675,7 @@ class TestQwen3EmbedBackend:
         """embed_single_query calls model.query_embed."""
         import numpy as np
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.query_embed.return_value = iter([np.array([0.1, 0.2])])
 
@@ -689,7 +689,7 @@ class TestQwen3EmbedBackend:
         """embed_single_query passes dim parameter to model.query_embed."""
         import numpy as np
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.query_embed.return_value = iter([np.array([0.1, 0.2])])
 
@@ -701,8 +701,8 @@ class TestQwen3EmbedBackend:
 
     async def test_get_model_caching(self):
         """_get_model instantiates TextEmbedding once and caches it."""
-        backend = Qwen3EmbedBackend()
-        with patch("qwen3_embed.TextEmbedding") as mock_cls:
+        backend = LocalEmbeddingBackend()
+        with patch("fastretrieval.TextEmbedding") as mock_cls:
             mock_model = MagicMock()
             mock_cls.return_value = mock_model
 
@@ -730,9 +730,9 @@ class TestBackendFactory:
         assert get_backend() is backend
 
     async def test_init_local_backend(self):
-        """init_backend('local') creates Qwen3EmbedBackend."""
+        """init_backend('local') creates LocalEmbeddingBackend."""
         backend = init_backend("local")
-        assert isinstance(backend, Qwen3EmbedBackend)
+        assert isinstance(backend, LocalEmbeddingBackend)
         assert get_backend() is backend
 
     async def test_init_cloud_requires_model(self):
@@ -830,16 +830,16 @@ class TestCheckAvailableApiKeyValidation:
 
 
 # -----------------------------------------------------------------------
-# Qwen3 model loading edge cases
+# Local model loading edge cases
 # -----------------------------------------------------------------------
 
 
-class TestQwen3GetModelWarning:
+class TestLocalGetModelWarning:
     """_get_model() logs download warning and check_available edge cases."""
 
     async def test_check_available_import_error(self):
-        """Returns 0 when qwen3-embed is not installed."""
-        backend = Qwen3EmbedBackend()
+        """Returns 0 when fastretrieval is not installed."""
+        backend = LocalEmbeddingBackend()
         with patch.object(backend, "_get_model", side_effect=ImportError("No module")):
             assert await backend.check_available() == 0
 
@@ -847,7 +847,7 @@ class TestQwen3GetModelWarning:
         """Returns dims when local model works."""
         import numpy as np
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         mock_model = MagicMock()
         mock_model.embed.return_value = iter([np.array([0.1, 0.2, 0.3])])
         with patch.object(backend, "_get_model", return_value=mock_model):
@@ -865,7 +865,7 @@ class TestSharedLocalBackend:
         wet_mcp.embedder._shared_local_backend = None
 
         try:
-            with patch("wet_mcp.embedder.Qwen3EmbedBackend") as mock_cls:
+            with patch("wet_mcp.embedder.LocalEmbeddingBackend") as mock_cls:
                 instance = MagicMock()
                 mock_cls.return_value = instance
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,11 +50,34 @@ class TestClearModelCache:
 
         assert result is None
 
+    def test_new_cache_env_wins_over_old_alias(self, tmp_path):
+        from wet_mcp.setup_tool import clear_model_cache
+
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_model = old_dir / "models--org--model"
+        new_model = new_dir / "models--org--model"
+        old_model.mkdir(parents=True)
+        new_model.mkdir(parents=True)
+
+        with patch.dict(
+            "os.environ",
+            {
+                "FASTRETRIEVAL_CACHE_PATH": str(new_dir),
+                "QWEN3_EMBED_CACHE_PATH": str(old_dir),
+            },
+        ):
+            result = clear_model_cache("org/model")
+
+        assert result == str(new_model)
+        assert not new_model.exists()
+        assert old_model.exists()
+
 
 class TestDownloadLocalEmbedding:
     """_download_local_embedding validates and downloads local models."""
 
-    @patch("qwen3_embed.TextEmbedding")
+    @patch("fastretrieval.TextEmbedding")
     def test_embedding_success(self, mock_te):
         from wet_mcp.setup_tool import _download_local_embedding
 
@@ -72,7 +95,7 @@ class TestDownloadLocalEmbedding:
         assert result["dims"] == 2
 
     @patch("wet_mcp.setup_tool.clear_model_cache")
-    @patch("qwen3_embed.TextEmbedding")
+    @patch("fastretrieval.TextEmbedding")
     def test_corrupted_cache_clears_and_retries(self, mock_te, mock_clear):
         from wet_mcp.setup_tool import _download_local_embedding
 
@@ -91,21 +114,21 @@ class TestDownloadLocalEmbedding:
         assert result["status"] == "ok"
         assert result.get("retried") is True
 
-    @patch("qwen3_embed.TextEmbedding")
+    @patch("fastretrieval.TextEmbedding")
     def test_non_cache_error_reraises(self, mock_te):
         from wet_mcp.setup_tool import _download_local_embedding
 
         mock_settings = MagicMock()
         mock_settings.resolve_local_embedding_model.return_value = "org/model"
 
-        mock_te.side_effect = ImportError("qwen3_embed not installed")
+        mock_te.side_effect = ImportError("fastretrieval not installed")
 
         import pytest
 
         with pytest.raises(ImportError, match="not installed"):
             _download_local_embedding(mock_settings)
 
-    @patch("qwen3_embed.TextEmbedding")
+    @patch("fastretrieval.TextEmbedding")
     def test_embedding_empty_result(self, mock_te):
         from wet_mcp.setup_tool import _download_local_embedding
 
@@ -120,7 +143,7 @@ class TestDownloadLocalEmbedding:
         assert result["status"] == "warning"
 
     @patch("wet_mcp.setup_tool.clear_model_cache")
-    @patch("qwen3_embed.TextEmbedding")
+    @patch("fastretrieval.TextEmbedding")
     def test_embedding_empty_after_retry(self, mock_te, mock_clear):
         from wet_mcp.setup_tool import _download_local_embedding
 
@@ -149,7 +172,7 @@ class TestDownloadLocalReranker:
         result = _download_local_reranker(mock_settings)
         assert result["status"] == "skipped"
 
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_reranker_success(self, mock_tce):
         from wet_mcp.setup_tool import _download_local_reranker
 
@@ -165,7 +188,7 @@ class TestDownloadLocalReranker:
         assert result["status"] == "ok"
 
     @patch("wet_mcp.setup_tool.clear_model_cache")
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_corrupted_reranker_cache_retries(self, mock_tce, mock_clear):
         from wet_mcp.setup_tool import _download_local_reranker
 
@@ -183,7 +206,7 @@ class TestDownloadLocalReranker:
         assert result["status"] == "ok"
         assert result.get("retried") is True
 
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_reranker_empty_result(self, mock_tce):
         from wet_mcp.setup_tool import _download_local_reranker
 
@@ -199,7 +222,7 @@ class TestDownloadLocalReranker:
         assert result["status"] == "warning"
 
     @patch("wet_mcp.setup_tool.clear_model_cache")
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_reranker_empty_after_retry(self, mock_tce, mock_clear):
         from wet_mcp.setup_tool import _download_local_reranker
 
@@ -215,7 +238,7 @@ class TestDownloadLocalReranker:
         result = _download_local_reranker(mock_settings)
         assert result["status"] == "warning"
 
-    @patch("qwen3_embed.TextCrossEncoder")
+    @patch("fastretrieval.TextCrossEncoder")
     def test_reranker_non_cache_error_reraises(self, mock_tce):
         from wet_mcp.setup_tool import _download_local_reranker
 

--- a/tests/test_multiuser_llm_gate_and_backend.py
+++ b/tests/test_multiuser_llm_gate_and_backend.py
@@ -140,11 +140,11 @@ class TestPerRequestEmbedBackend:
         """sub=None -> the module-level startup singleton, unchanged."""
         from wet_mcp import embedder
         from wet_mcp.embedder import (
-            Qwen3EmbedBackend,
+            LocalEmbeddingBackend,
             resolve_embed_backend_for_request,
         )
 
-        sentinel = Qwen3EmbedBackend()
+        sentinel = LocalEmbeddingBackend()
         monkeypatch.setattr(embedder, "_backend", sentinel)
         assert resolve_embed_backend_for_request() is sentinel
 
@@ -197,11 +197,11 @@ class TestPerRequestEmbedBackend:
         """Resolving a per-sub cloud backend must NOT mutate the module singleton."""
         from wet_mcp import embedder
         from wet_mcp.embedder import (
-            Qwen3EmbedBackend,
+            LocalEmbeddingBackend,
             resolve_embed_backend_for_request,
         )
 
-        startup = Qwen3EmbedBackend()
+        startup = LocalEmbeddingBackend()
         monkeypatch.setattr(embedder, "_backend", startup)
 
         store_for_sub(
@@ -247,11 +247,11 @@ class TestPerRequestRerankBackend:
     def test_single_user_returns_startup_singleton(self, monkeypatch):
         from wet_mcp import reranker
         from wet_mcp.reranker import (
-            Qwen3Reranker,
+            LocalReranker,
             resolve_rerank_backend_for_request,
         )
 
-        sentinel = Qwen3Reranker()
+        sentinel = LocalReranker()
         monkeypatch.setattr(reranker, "_backend", sentinel)
         assert resolve_rerank_backend_for_request() is sentinel
 
@@ -305,11 +305,11 @@ class TestPerRequestRerankBackend:
     def test_multi_user_does_not_rebind_singleton(self, monkeypatch):
         from wet_mcp import reranker
         from wet_mcp.reranker import (
-            Qwen3Reranker,
+            LocalReranker,
             resolve_rerank_backend_for_request,
         )
 
-        startup = Qwen3Reranker()
+        startup = LocalReranker()
         monkeypatch.setattr(reranker, "_backend", startup)
 
         store_for_sub(

--- a/tests/test_no_stale_package_name.py
+++ b/tests/test_no_stale_package_name.py
@@ -1,0 +1,40 @@
+"""Không còn tham chiếu đến tên gói cũ, kể cả trong chuỗi và Dockerfile."""
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST_FILE = Path(__file__).resolve().relative_to(ROOT).as_posix()
+
+# CHANGELOG ghi lại lịch sử; tên gói cũ ở đó là đúng và phải giữ nguyên.
+ALLOWED = {"CHANGELOG.md"}
+# Tên biến cũ được đọc có chủ ý để không làm vỡ cấu hình người dùng cũ.
+ALLOWED_LINES = ("QWEN3_EMBED_CACHE_PATH",)
+
+
+def _tracked_hits(pattern: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "grep", "-n", pattern],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [
+        line
+        for line in result.stdout.splitlines()
+        if line
+        and not line.startswith(f"{TEST_FILE}:")
+        and not any(line.startswith(f"{name}:") for name in ALLOWED)
+        and not any(token in line for token in ALLOWED_LINES)
+    ]
+
+
+def test_no_module_reference_remains():
+    hits = _tracked_hits("qwen3_embed")
+    assert not hits, "stale module name:\n" + "\n".join(hits)
+
+
+def test_no_distribution_reference_remains():
+    hits = _tracked_hits("qwen3-embed")
+    assert not hits, "stale distribution name:\n" + "\n".join(hits)

--- a/tests/test_real_comprehensive.py
+++ b/tests/test_real_comprehensive.py
@@ -386,20 +386,20 @@ class TestLiteLLMSDK:
 
 
 class TestLocalONNX:
-    """Test local Qwen3 ONNX embedding and reranking."""
+    """Test local ONNX embedding and reranking."""
 
     async def test_local_embedding(self):
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        backend = Qwen3EmbedBackend()
+        backend = LocalEmbeddingBackend()
         vectors = await backend.embed_texts(["Hello world", "Python programming"])
         assert len(vectors) == 2
         assert len(vectors[0]) > 0  # Should have dimensions
 
     async def test_local_reranking(self):
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
-        reranker = Qwen3Reranker()
+        reranker = LocalReranker()
         results = reranker.rerank(
             query="What is Python?",
             documents=[

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,6 +1,6 @@
 """Tests for src/wet_mcp/reranker.py — Dual-backend reranking.
 
-Covers CloudReranker (litellm passthrough via mcp_core.llm), Qwen3Reranker,
+Covers CloudReranker (litellm passthrough via mcp_core.llm), LocalReranker,
 factory functions, and graceful fallback behavior.
 """
 
@@ -12,7 +12,7 @@ import pytest
 
 from wet_mcp.reranker import (
     CloudReranker,
-    Qwen3Reranker,
+    LocalReranker,
     get_reranker,
     init_reranker,
 )
@@ -302,14 +302,14 @@ class TestCloudflareGatewayJinaRoute:
 
 
 # -----------------------------------------------------------------------
-# Qwen3Reranker
+# LocalReranker
 # -----------------------------------------------------------------------
 
 
-class TestQwen3Reranker:
+class TestLocalReranker:
     def test_rerank_success(self):
         """Local cross-encoder reranking returns sorted results."""
-        reranker = Qwen3Reranker("test-model")
+        reranker = LocalReranker("test-model")
 
         mock_model = MagicMock()
         # Simulate P(yes) scores for 3 documents
@@ -331,13 +331,13 @@ class TestQwen3Reranker:
 
     def test_rerank_empty_documents(self):
         """Empty documents return empty results."""
-        reranker = Qwen3Reranker()
+        reranker = LocalReranker()
         results = reranker.rerank("query", [])
         assert results == []
 
     def test_rerank_passes_pairs(self):
         """Reranker receives (query, document) pairs."""
-        reranker = Qwen3Reranker()
+        reranker = LocalReranker()
 
         mock_model = MagicMock()
         mock_model.rerank.return_value = iter([0.5, 0.8])
@@ -351,7 +351,7 @@ class TestQwen3Reranker:
 
     def test_rerank_error_returns_empty(self):
         """Model errors return empty results (graceful fallback)."""
-        reranker = Qwen3Reranker()
+        reranker = LocalReranker()
 
         with patch.object(reranker, "_get_model", side_effect=Exception("ONNX error")):
             results = reranker.rerank("query", ["doc1"])
@@ -360,7 +360,7 @@ class TestQwen3Reranker:
 
     def test_check_available_success(self):
         """Returns True when model loads successfully."""
-        reranker = Qwen3Reranker()
+        reranker = LocalReranker()
 
         mock_model = MagicMock()
         mock_model.rerank.return_value = iter([0.5])
@@ -370,7 +370,7 @@ class TestQwen3Reranker:
 
     def test_check_available_failure(self):
         """Returns False when model fails to load."""
-        reranker = Qwen3Reranker()
+        reranker = LocalReranker()
 
         with patch.object(reranker, "_get_model", side_effect=Exception("Load error")):
             assert reranker.check_available() is False
@@ -416,18 +416,18 @@ class TestCloudRerankerApiKeyValidation:
             assert reranker.check_available() is True
 
 
-class TestQwen3RerankerGetModelWarning:
+class TestLocalRerankerGetModelWarning:
     """_get_model() and check_available edge cases."""
 
     def test_check_available_import_error(self):
-        """Returns False when qwen3-embed is not installed."""
-        reranker = Qwen3Reranker()
+        """Returns False when fastretrieval is not installed."""
+        reranker = LocalReranker()
         with patch.object(reranker, "_get_model", side_effect=ImportError("No module")):
             assert reranker.check_available() is False
 
     def test_check_available_success(self):
         """Returns True when local reranker works."""
-        reranker = Qwen3Reranker()
+        reranker = LocalReranker()
         mock_model = MagicMock()
         mock_model.rerank.return_value = iter([0.8])
         with patch.object(reranker, "_get_model", return_value=mock_model):
@@ -442,9 +442,9 @@ class TestRerankerFactory:
         assert get_reranker() is reranker
 
     def test_init_local_reranker(self):
-        """init_reranker('local') creates Qwen3Reranker."""
+        """init_reranker('local') creates LocalReranker."""
         reranker = init_reranker("local")
-        assert isinstance(reranker, Qwen3Reranker)
+        assert isinstance(reranker, LocalReranker)
         assert get_reranker() is reranker
 
     def test_init_unknown_backend(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,44 +32,37 @@ def _no_real_searxng_spawn():
 
 def test_maybe_register_custom_embed_no_optin_noop(monkeypatch):
     """No registration when LOCAL_EMBEDDING_MODEL is unset (default local)."""
-    import qwen3_embed
-
     from wet_mcp.config import settings
 
     monkeypatch.setattr(settings, "local_embedding_model", "")
-    called = []
-    monkeypatch.setattr(
-        qwen3_embed.TextEmbedding,
-        "add_custom_model",
-        classmethod(lambda cls, desc, **kw: called.append((desc, kw))),
-    )
     _maybe_register_custom_embed("local-model")
-    assert called == []
 
 
 def test_maybe_register_custom_embed_builtin_noop(monkeypatch):
-    """Built-in Qwen3 ids are left untouched (no registration call)."""
-    import qwen3_embed
+    """Any id in the live registry is left untouched."""
+    import fastretrieval
 
     from wet_mcp.config import settings
 
+    monkeypatch.setattr(settings, "local_embedding_model", "acme/tiny-e5")
     monkeypatch.setattr(
-        settings, "local_embedding_model", "n24q02m/Qwen3-Embedding-0.6B-ONNX"
+        fastretrieval.TextEmbedding,
+        "list_supported_models",
+        classmethod(lambda cls: [{"model": "acme/tiny-e5"}]),
     )
     called = []
     monkeypatch.setattr(
-        qwen3_embed.TextEmbedding,
-        "add_custom_model",
-        classmethod(lambda cls, desc, **kw: called.append((desc, kw))),
+        fastretrieval.CustomModelSpec,
+        "register",
+        lambda self: called.append(self),
     )
-    _maybe_register_custom_embed("n24q02m/Qwen3-Embedding-0.6B-ONNX")
+    _maybe_register_custom_embed("acme/tiny-e5")
     assert called == []
 
 
-def test_maybe_register_custom_embed_calls_add_custom_model(monkeypatch):
-    """A BYO id with dim/pooling registers via TextEmbedding.add_custom_model."""
-    import qwen3_embed
-    from qwen3_embed.common.model_description import PoolingType
+def test_maybe_register_custom_embed_registers_public_spec(monkeypatch):
+    """A BYO id with explicit metadata registers through the public spec API."""
+    import fastretrieval
 
     from wet_mcp.config import settings
 
@@ -79,37 +72,46 @@ def test_maybe_register_custom_embed_calls_add_custom_model(monkeypatch):
 
     captured = {}
 
-    def _fake(cls, desc, *, pooling, normalization):
-        captured["model"] = desc.model
-        captured["pooling"] = pooling
-        captured["normalization"] = normalization
-
     monkeypatch.setattr(
-        qwen3_embed.TextEmbedding,
-        "add_custom_model",
-        classmethod(_fake),
+        fastretrieval.TextEmbedding,
+        "list_supported_models",
+        classmethod(lambda cls: []),
+    )
+    monkeypatch.setattr(
+        fastretrieval.CustomModelSpec,
+        "register",
+        lambda self: captured.update(
+            model=self.model_id,
+            pooling=self.pooling,
+            normalization=self.normalization,
+        ),
     )
 
     _maybe_register_custom_embed("Org/custom-embed")
 
     assert captured["model"] == "Org/custom-embed"
-    assert captured["pooling"] == PoolingType.CLS
+    assert captured["pooling"] == "CLS"
     assert captured["normalization"] is True
 
 
 def test_maybe_register_custom_embed_missing_dim(monkeypatch):
     """A BYO id without LOCAL_EMBEDDING_DIM skips registration (no call)."""
-    import qwen3_embed
+    import fastretrieval
 
     from wet_mcp.config import settings
 
     monkeypatch.setattr(settings, "local_embedding_model", "Org/custom-embed")
     monkeypatch.setattr(settings, "local_embedding_dim", 0)
+    monkeypatch.setattr(
+        fastretrieval.TextEmbedding,
+        "list_supported_models",
+        classmethod(lambda cls: []),
+    )
     called = []
     monkeypatch.setattr(
-        qwen3_embed.TextEmbedding,
-        "add_custom_model",
-        classmethod(lambda cls, desc, **kw: called.append(desc)),
+        fastretrieval.CustomModelSpec,
+        "register",
+        lambda self: called.append(self),
     )
     _maybe_register_custom_embed("Org/custom-embed")
     assert called == []
@@ -117,43 +119,37 @@ def test_maybe_register_custom_embed_missing_dim(monkeypatch):
 
 def test_maybe_register_custom_rerank_no_optin_noop(monkeypatch):
     """No registration when LOCAL_RERANK_MODEL is unset (default local)."""
-    import qwen3_embed
-
     from wet_mcp.config import settings
 
     monkeypatch.setattr(settings, "local_rerank_model", "")
-    called = []
-    monkeypatch.setattr(
-        qwen3_embed.TextCrossEncoder,
-        "add_custom_model",
-        classmethod(lambda cls, desc, **kw: called.append(desc)),
-    )
     _maybe_register_custom_rerank("local-reranker")
-    assert called == []
 
 
 def test_maybe_register_custom_rerank_builtin_noop(monkeypatch):
-    """Built-in Qwen3 reranker ids are left untouched (no registration call)."""
-    import qwen3_embed
+    """Any reranker id in the live registry is left untouched."""
+    import fastretrieval
 
     from wet_mcp.config import settings
 
+    monkeypatch.setattr(settings, "local_rerank_model", "acme/tiny-reranker")
     monkeypatch.setattr(
-        settings, "local_rerank_model", "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
+        fastretrieval.TextCrossEncoder,
+        "list_supported_models",
+        classmethod(lambda cls: [{"model": "acme/tiny-reranker"}]),
     )
     called = []
     monkeypatch.setattr(
-        qwen3_embed.TextCrossEncoder,
-        "add_custom_model",
-        classmethod(lambda cls, desc, **kw: called.append(desc)),
+        fastretrieval.CustomRerankerSpec,
+        "register",
+        lambda self: called.append(self),
     )
-    _maybe_register_custom_rerank("n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo")
+    _maybe_register_custom_rerank("acme/tiny-reranker")
     assert called == []
 
 
-def test_maybe_register_custom_rerank_calls_add_custom_model(monkeypatch):
-    """A BYO reranker id registers via TextCrossEncoder.add_custom_model."""
-    import qwen3_embed
+def test_maybe_register_custom_rerank_registers_public_spec(monkeypatch):
+    """A BYO reranker id registers through the public spec API."""
+    import fastretrieval
 
     from wet_mcp.config import settings
 
@@ -164,15 +160,19 @@ def test_maybe_register_custom_rerank_calls_add_custom_model(monkeypatch):
 
     captured = {}
 
-    def _fake(cls, desc):
-        captured["model"] = desc.model
-        captured["model_file"] = desc.model_file
-        captured["hf"] = desc.sources.hf
-
     monkeypatch.setattr(
-        qwen3_embed.TextCrossEncoder,
-        "add_custom_model",
-        classmethod(_fake),
+        fastretrieval.TextCrossEncoder,
+        "list_supported_models",
+        classmethod(lambda cls: []),
+    )
+    monkeypatch.setattr(
+        fastretrieval.CustomRerankerSpec,
+        "register",
+        lambda self: captured.update(
+            model=self.model_id,
+            model_file=self.model_file,
+            hf=self.hf,
+        ),
     )
 
     _maybe_register_custom_rerank("Org/custom-reranker")

--- a/tests/test_server_comprehensive.py
+++ b/tests/test_server_comprehensive.py
@@ -1219,11 +1219,11 @@ async def test_embed_no_backend():
 
 @pytest.mark.asyncio
 async def test_embed_query_mode():
-    """Test _embed with is_query=True for Qwen3 (lines 327-330)."""
+    """Test _embed with is_query=True for the local backend (lines 327-330)."""
     with patch("wet_mcp.embedder.get_backend") as mock_get:
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        mock_backend = MagicMock(spec=Qwen3EmbedBackend)
+        mock_backend = MagicMock(spec=LocalEmbeddingBackend)
         mock_backend.embed_single_query.return_value = [0.5, 0.6]
         mock_get.return_value = mock_backend
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -417,12 +417,12 @@ async def test_init_reranker_local_exception(_mock_settings):
 # ---------------------------------------------------------------------------
 
 
-async def test_embed_query_qwen3_backend():
-    """Lines 327-330: query embedding with Qwen3EmbedBackend."""
+async def test_embed_query_local_backend():
+    """Lines 327-330: query embedding with LocalEmbeddingBackend."""
     with patch("wet_mcp.embedder.get_backend") as mock_get:
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
-        mock_backend = MagicMock(spec=Qwen3EmbedBackend)
+        mock_backend = MagicMock(spec=LocalEmbeddingBackend)
         mock_backend.embed_single_query.return_value = [0.5, 0.6]
         mock_get.return_value = mock_backend
 

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -13,7 +13,7 @@ class TestRunWarmup:
         with (
             patch("wet_mcp.setup.run_auto_setup"),
             patch("wet_mcp.setup_tool.settings") as mock_settings,
-            patch("qwen3_embed.TextEmbedding") as mock_embed,
+            patch("fastretrieval.TextEmbedding") as mock_embed,
         ):
             mock_settings.setup_providers.return_value = "local"
             mock_settings.rerank_enabled = False
@@ -65,7 +65,7 @@ class TestRunWarmup:
             patch("wet_mcp.setup.run_auto_setup"),
             patch("wet_mcp.setup_tool.settings") as mock_settings,
             patch("wet_mcp.embedder.init_backend") as mock_init_backend,
-            patch("qwen3_embed.TextEmbedding") as mock_embed,
+            patch("fastretrieval.TextEmbedding") as mock_embed,
         ):
             mock_settings.setup_providers.return_value = "sdk"
             mock_settings.embedding_chain.return_value = ["gemini/embed"]
@@ -93,7 +93,7 @@ class TestRunWarmup:
                 side_effect=Exception("setup failed"),
             ),
             patch("wet_mcp.setup_tool.settings") as mock_settings,
-            patch("qwen3_embed.TextEmbedding") as mock_embed,
+            patch("fastretrieval.TextEmbedding") as mock_embed,
         ):
             mock_settings.setup_providers.return_value = "local"
             mock_settings.rerank_enabled = False
@@ -113,8 +113,8 @@ class TestRunWarmup:
         with (
             patch("wet_mcp.setup.run_auto_setup"),
             patch("wet_mcp.setup_tool.settings") as mock_settings,
-            patch("qwen3_embed.TextEmbedding") as mock_embed,
-            patch("qwen3_embed.TextCrossEncoder") as mock_reranker,
+            patch("fastretrieval.TextEmbedding") as mock_embed,
+            patch("fastretrieval.TextCrossEncoder") as mock_reranker,
         ):
             mock_settings.setup_providers.return_value = "local"
             mock_settings.rerank_enabled = True
@@ -138,7 +138,7 @@ class TestRunWarmup:
             patch("wet_mcp.setup.run_auto_setup"),
             patch("wet_mcp.setup_tool.settings") as mock_settings,
             patch("wet_mcp.setup_tool.clear_model_cache") as mock_clear,
-            patch("qwen3_embed.TextEmbedding") as mock_embed,
+            patch("fastretrieval.TextEmbedding") as mock_embed,
         ):
             mock_settings.setup_providers.return_value = "local"
             mock_settings.rerank_enabled = False

--- a/tests/test_slim_image_missing_local_extras.py
+++ b/tests/test_slim_image_missing_local_extras.py
@@ -1,16 +1,16 @@
 """The local ONNX leg must be resolved from the IMAGE, not only from a flag.
 
-The http-slim build uninstalls ``qwen3-embed`` and ``onnxruntime`` (see
+The http-slim build uninstalls ``fastretrieval`` and ``onnxruntime`` (see
 ``Dockerfile``), so on that image the local embed/rerank leg does not exist --
 whatever the configuration says. Every resolver in the codebase decided the
 question from ``DISABLE_LOCAL_EMBED`` / ``DISABLE_LOCAL_RERANK`` alone, which
 makes a slim deployment correct only for as long as somebody remembers to set
 those vars. Forget one, or run the slim image outside the Cloudflare worker
 that supplies them, and the first index attempt dies inside the lazy import in
-``Qwen3EmbedBackend._get_model``. Live prod D1 recorded exactly that (#1630)::
+``LocalEmbeddingBackend._get_model``. Live prod D1 recorded exactly that (#1630)::
 
     fastapi:python  pending  0 chunks  failed
-        ModuleNotFoundError: No module named 'qwen3_embed'
+        ModuleNotFoundError: No module named 'fastretrieval'
 
 -- a hard failure with zero chunks, where the same request had a perfectly good
 keyword-only degrade available to it.
@@ -20,7 +20,7 @@ string a caller is told, the durable record the background indexer leaves in
 ``versions.index_error``, and the startup path that used to install a backend
 it had already proved could not load.
 
-Both ``qwen3_embed`` and ``onnxruntime`` ARE installed in the dev venv, so the
+Both ``fastretrieval`` and ``onnxruntime`` ARE installed in the dev venv, so the
 slim container cannot be reproduced by simply not having them. The
 ``slim_image`` fixture simulates both packages on two channels at once:
 ``find_spec`` answers "absent" (what the fix is supposed to consult) and
@@ -95,7 +95,7 @@ def slim_image(monkeypatch):
     real_import = builtins.__import__
     real_find_spec = importlib.util.find_spec
     attempted: list[str] = []
-    missing = ("qwen3_embed", "onnxruntime")
+    missing = ("fastretrieval", "onnxruntime")
 
     def _guarded_import(name, *args, **kwargs):
         if any(
@@ -167,7 +167,7 @@ class TestEmbedResolutionOnASlimImage:
 
         reason = embedding_unavailable_reason()
         assert reason is not None
-        assert "qwen3-embed" in reason
+        assert "fastretrieval" in reason
         assert "onnxruntime" in reason
         # Named as a property of the build, so the reader looks for a cloud
         # chain rather than a flag to unset.
@@ -188,18 +188,18 @@ class TestEmbedResolutionOnASlimImage:
         reason = embedding_unavailable_reason()
         assert reason is not None
         assert "DISABLE_LOCAL_EMBED" in reason
-        assert "qwen3-embed" not in reason
+        assert "fastretrieval" not in reason
 
     def test_installed_local_extras_are_still_used(self):
         """No regression: a full image with the flag off keeps its local leg."""
         from wet_mcp import embedder
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
         store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
         set_current_sub("user_a")
 
         backend = embedder.resolve_embed_backend_for_request()
-        assert isinstance(backend, Qwen3EmbedBackend)
+        assert isinstance(backend, LocalEmbeddingBackend)
         assert backend is embedder.resolve_embed_backend_for_request()
 
 
@@ -214,7 +214,7 @@ class TestRerankResolutionOnASlimImage:
         assert slim_image == [], f"local ONNX leg was entered: {slim_image}"
 
     async def test_rerank_returns_unranked_order_touching_nothing(self, slim_image):
-        """``Qwen3Reranker.rerank`` swallows its own load failure and returns
+        """``LocalReranker.rerank`` swallows its own load failure and returns
         ``[]``, so the broken leg is invisible in the result. The import list is
         the only thing that can tell "skipped" from "failed quietly"."""
         store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
@@ -228,12 +228,12 @@ class TestRerankResolutionOnASlimImage:
 
     def test_installed_local_extras_are_still_used(self):
         from wet_mcp import reranker
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
         store_for_sub("user_a", {"GITHUB_TOKEN": "ghp_x"})
         set_current_sub("user_a")
 
-        assert isinstance(reranker.resolve_rerank_backend_for_request(), Qwen3Reranker)
+        assert isinstance(reranker.resolve_rerank_backend_for_request(), LocalReranker)
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +288,7 @@ class TestBackgroundIndexerOnASlimImage:
         """The exact prod row, inverted.
 
         Before: ``state=failed``, ``error='ModuleNotFoundError: No module named
-        'qwen3_embed''``, ``chunk_count=0`` -- the library unservable forever.
+        'fastretrieval''``, ``chunk_count=0`` -- the library unservable forever.
         After: the chunks land keyword-searchable and the version says, where
         ``config(action="status")`` and D1 both show it, that it holds no
         vectors and why. Storing them silently would trade a loud failure for a
@@ -321,7 +321,7 @@ class TestBackgroundIndexerOnASlimImage:
 
         error = state["error"] or ""
         assert "ModuleNotFoundError" not in error
-        assert "qwen3-embed" in error
+        assert "fastretrieval" in error
         assert "keyword" in error.lower(), (
             "the record must say the version holds no vectors, not just that "
             f"something was off: {error!r}"
@@ -422,12 +422,12 @@ class TestStartupNeverInstallsABackendItCannotLoad:
         self, real_backend_factories, monkeypatch
     ):
         from wet_mcp import embedder
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
         self._enable_local_startup(monkeypatch)
         self._set_local_credential_state(monkeypatch)
         monkeypatch.setattr(
-            Qwen3EmbedBackend, "check_available", AsyncMock(return_value=0)
+            LocalEmbeddingBackend, "check_available", AsyncMock(return_value=0)
         )
 
         await server._init_embedding_backend("local")
@@ -438,12 +438,12 @@ class TestStartupNeverInstallsABackendItCannotLoad:
         self, real_backend_factories, monkeypatch
     ):
         from wet_mcp import embedder
-        from wet_mcp.embedder import Qwen3EmbedBackend
+        from wet_mcp.embedder import LocalEmbeddingBackend
 
         self._enable_local_startup(monkeypatch)
         self._set_local_credential_state(monkeypatch)
         monkeypatch.setattr(
-            Qwen3EmbedBackend,
+            LocalEmbeddingBackend,
             "check_available",
             AsyncMock(side_effect=RuntimeError("embedding unavailable")),
         )
@@ -471,11 +471,11 @@ class TestStartupNeverInstallsABackendItCannotLoad:
         self, real_backend_factories, monkeypatch
     ):
         from wet_mcp import reranker
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
         self._enable_local_startup(monkeypatch)
         self._set_local_credential_state(monkeypatch)
-        monkeypatch.setattr(Qwen3Reranker, "check_available", Mock(return_value=False))
+        monkeypatch.setattr(LocalReranker, "check_available", Mock(return_value=False))
 
         await server._init_reranker_backend("local")
 
@@ -485,12 +485,12 @@ class TestStartupNeverInstallsABackendItCannotLoad:
         self, real_backend_factories, monkeypatch
     ):
         from wet_mcp import reranker
-        from wet_mcp.reranker import Qwen3Reranker
+        from wet_mcp.reranker import LocalReranker
 
         self._enable_local_startup(monkeypatch)
         self._set_local_credential_state(monkeypatch)
         monkeypatch.setattr(
-            Qwen3Reranker,
+            LocalReranker,
             "check_available",
             Mock(side_effect=RuntimeError("reranker unavailable")),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -3426,7 +3426,7 @@ wheels = [
 
 [[package]]
 name = "wet-mcp"
-version = "3.7.2"
+version = "3.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },

--- a/uv.lock
+++ b/uv.lock
@@ -762,6 +762,24 @@ server = [
 ]
 
 [[package]]
+name = "fastretrieval"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/35/2a91b42d6b9784ee620d4c75bd2abadbcbd3cf304dcb0a41f5a3a22ee0ba/fastretrieval-1.0.1.tar.gz", hash = "sha256:a1d766e1c1471347ba830c4a7f280ed7b0ff86fbc48425ac457b7b9d8d0e5783", size = 330230, upload-time = "2026-08-14T16:58:25.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/94/28ba6e0d86b4b8bb0f2a687d5669bd3c6adb7c3346d6e80431fb66ba6c2d/fastretrieval-1.0.1-py3-none-any.whl", hash = "sha256:902851b02c6b1ffefc66aa63c7976a2226696d7ea2b43b9ec471029e97e58892", size = 144199, upload-time = "2026-08-14T16:58:24.195Z" },
+]
+
+[[package]]
 name = "fastuuid"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2652,24 +2670,6 @@ wheels = [
 ]
 
 [[package]]
-name = "qwen3-embed"
-version = "1.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub" },
-    { name = "loguru" },
-    { name = "numpy" },
-    { name = "onnxruntime" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/57/05fbd601679bbfd49c882bc21f4e17ec3e1e01946cd71a84bc49abe6d7d9/qwen3_embed-1.13.0.tar.gz", hash = "sha256:f5384c8348b521d7bed34b9cd1d120fd63892fc1c22c7598b996914097309d21", size = 234980, upload-time = "2026-08-08T04:06:32.853Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/fb/06af2973c1988cc1d2db58b226b5914149b71481c33b005440b1892eb1a6/qwen3_embed-1.13.0-py3-none-any.whl", hash = "sha256:d6bace0157032edf96bf6b36b3d8004817a65093ec1fd723682bbd62939b3d1b", size = 69825, upload-time = "2026-08-08T04:06:31.906Z" },
-]
-
-[[package]]
 name = "rank-bm25"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3411,6 +3411,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "diskcache" },
     { name = "fastmcp" },
+    { name = "fastretrieval" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "greenlet" },
@@ -3425,7 +3426,6 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "qwen3-embed" },
     { name = "sqlite-vec" },
     { name = "urllib3" },
     { name = "waitress", marker = "sys_platform == 'win32'" },
@@ -3453,6 +3453,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
+    { name = "fastretrieval", specifier = ">=1.0.1" },
     { name = "google-api-python-client", specifier = ">=2.198.0" },
     { name = "google-auth", specifier = ">=2.56.2" },
     { name = "greenlet", specifier = "<3.5.5" },
@@ -3468,7 +3469,6 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings" },
-    { name = "qwen3-embed", specifier = ">=1.13.0" },
     { name = "sqlite-vec" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "waitress", marker = "sys_platform == 'win32'", specifier = ">=3.0.2" },

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -34,7 +34,7 @@
     "BROWSERLESS_URL": "https://browserless.n24q02m.com",
     "DISABLE_LOCAL_BROWSER": "true",
     "DISABLE_LOCAL_EMBED": "true",
-    // Paired with the line above: the SLIM image uninstalls qwen3-embed, so the
+    // Paired with the line above: the SLIM image uninstalls fastretrieval, so the
     // local leg is absent for rerank too. See wrangler.jsonc for why the
     // deploy-level RERANK_MODELS does not cover the per-sub case.
     "DISABLE_LOCAL_RERANK": "true",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,10 +36,10 @@
     "DISABLE_LOCAL_SEARCH": "true",
     "DISABLE_LOCAL_BROWSER": "true",
     "DISABLE_LOCAL_EMBED": "true",
-    // The SLIM image this Worker runs uninstalls qwen3-embed outright, so the
+    // The SLIM image this Worker runs uninstalls fastretrieval outright, so the
     // local leg is gone for BOTH capabilities -- the rerank flag has to say so
     // too. Without it a sub whose own bucket carries no RERANK_MODELS resolves
-    // to the local cross-encoder, whose import failure Qwen3Reranker.rerank
+    // to the local cross-encoder, whose import failure the local reranker
     // swallows into an empty list: every search silently answers in unranked
     // order. The deploy-level RERANK_MODELS below does not cover that case; it
     // is process env, and per-sub chains resolve from the sub's bucket.


### PR DESCRIPTION
- **fix: migrate wet-mcp to fastretrieval**
- **fix: sync wet lock metadata after release merge**
